### PR TITLE
replace hardcoded /bin/cp with cp for portability

### DIFF
--- a/data/scripts/cairo-dock-package-theme.sh
+++ b/data/scripts/cairo-dock-package-theme.sh
@@ -105,7 +105,7 @@ import_file_full()
 	if test ${f:0:1} = "/" -o ${f:0:1} = "~"; then
 		echo " to import"
 		if test ${f:0:35} != "~/.config/cairo-dock/current_theme/"; then
-			/bin/cp -v "$f" "$3"
+			cp -v "$f" "$3"
 		fi
 		local_file=${f##*/}
 		if test "$4" = "1"; then
@@ -156,7 +156,7 @@ _import_theme()
 				if test "x$theme_path" != "x"; then
 					echo "We copy $theme_path to "`pwd`"/extras/$3/$THEME_NAME"
 					mkdir -p "extras/$3"
-					/bin/cp -r "$theme_path" "extras/$3/$THEME_NAME"
+					cp -r "$theme_path" "extras/$3/$THEME_NAME"
 					set_value "$1" "$2" "$THEME_NAME"
 				fi
 			fi

--- a/misc/generate-theme-package.sh
+++ b/misc/generate-theme-package.sh
@@ -43,7 +43,7 @@ import_file()
 	if test ${file:0:1} = "/" -o ${file:0:1} = "~"; then
 		static local_file=${file##*/}
 		echo "  => $local_file"
-		/bin/cp "$file" "$3"
+		cp "$file" "$3"
 		set_value "Accessibility" "callback image" "$local_file"
 	fi
 }
@@ -75,7 +75,7 @@ _import_theme()
 				if test "x$theme_path" != "x"; then
 					echo "on importe $theme_path dans "`pwd`"/extras/$3/$THEME_NAME"
 					mkdir "extras/$3"
-					/bin/cp -r "$theme_path" "extras/$3/$THEME_NAME"
+					cp -r "$theme_path" "extras/$3/$THEME_NAME"
 					set_value "$1" "$2" "$THEME_NAME"
 				fi
 			fi

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -762,7 +762,7 @@ int main (int argc, char** argv)
 		}
 		else
 			cThemeName = "Default-Single";
-		gchar *cCommand = g_strdup_printf ("/bin/cp -r \"%s/%s\"/* \"%s\"", CAIRO_DOCK_SHARE_DATA_DIR"/themes", cThemeName, g_cCurrentThemePath);
+		gchar *cCommand = g_strdup_printf ("cp -r \"%s/%s\"/* \"%s\"", CAIRO_DOCK_SHARE_DATA_DIR"/themes", cThemeName, g_cCurrentThemePath);
 		cd_message (cCommand);
 		int r = system (cCommand);
 		if (r < 0)

--- a/src/gldit/cairo-dock-themes-manager.c
+++ b/src/gldit/cairo-dock-themes-manager.c
@@ -226,7 +226,7 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 			
 			//\___________________ On traite tous le reste.
 			/// TODO : traiter les .conf des applets comme celui du dock...
-			g_string_printf (sCommand, "find \"%s\" -mindepth 1 -maxdepth 1  ! -name '%s' ! -name \"%s\" -exec /bin/cp -r '{}' \"%s\" \\;", g_cCurrentThemePath, CAIRO_DOCK_CONF_FILE, CAIRO_DOCK_LAUNCHERS_DIR, cNewThemePathEscaped);
+			g_string_printf (sCommand, "find \"%s\" -mindepth 1 -maxdepth 1  ! -name '%s' ! -name \"%s\" -exec cp -r '{}' \"%s\" \\;", g_cCurrentThemePath, CAIRO_DOCK_CONF_FILE, CAIRO_DOCK_LAUNCHERS_DIR, cNewThemePathEscaped);
 			cd_message ("%s", sCommand->str);
 			r = system (sCommand->str);
 			if (r < 0)
@@ -507,7 +507,7 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	gchar *cNewLocalIconsPath = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_ICONS_DIR);
 	if (! g_file_test (cNewLocalIconsPath, G_FILE_TEST_IS_DIR))  // it's an old theme: move icons to a new dir 'icons'.
 	{
-		g_string_printf (sCommand, "find \"%s/%s\" -mindepth 1 ! -name '*.desktop' -exec /bin/cp '{}' '%s' \\;", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentIconsPath);
+		g_string_printf (sCommand, "find \"%s/%s\" -mindepth 1 ! -name '*.desktop' -exec cp '{}' '%s' \\;", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentIconsPath);
 	}
 	else
 	{
@@ -548,7 +548,7 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 
 	if (g_pMainDock == NULL || bLoadBehavior)
 	{
-		g_string_printf (sCommand, "find \"%s\"/* -prune ! -name '*.conf' ! -name %s -exec /bin/cp -r '{}' \"%s\" \\;", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentThemePath);  // Copy all files of the new theme except launchers and .conf files in the dir of the current theme. Overwrite files with same names
+		g_string_printf (sCommand, "find \"%s\"/* -prune ! -name '*.conf' ! -name %s -exec cp -r '{}' \"%s\" \\;", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentThemePath);  // Copy all files of the new theme except launchers and .conf files in the dir of the current theme. Overwrite files with same names
 		_launch_cmd (sCommand->str);
 	}
 	else


### PR DESCRIPTION
Allows cairo-dock to run on systems where /bin/cp is somewhere else.  
