### PR TITLE
add desktop session files compatible with gnome-session 3.28

### DIFF
--- a/data/desktop-manager/CMakeLists.txt
+++ b/data/desktop-manager/CMakeLists.txt
@@ -3,8 +3,10 @@ if (${GTK_MAJOR} LESS 3 OR (${GTK_MAJOR} EQUAL 3 AND ${GTK_MINOR} LESS 8)) # GTK
 	add_subdirectory(gnome-session-3.0)
 elseif(${GTK_MAJOR} EQUAL 3 AND ${GTK_MINOR} EQUAL 8)
 	add_subdirectory(gnome-session-3.8)
-else()
+elseif(${GTK_MAJOR} EQUAL 3 AND ${GTK_MINOR} LESS 22)
 	add_subdirectory(gnome-session-3.10)
+else()
+	add_subdirectory(gnome-session-3.28)
 endif()
 
 install (FILES cairo-dock-session

--- a/data/desktop-manager/gnome-session-3.28/CMakeLists.txt
+++ b/data/desktop-manager/gnome-session-3.28/CMakeLists.txt
@@ -1,0 +1,9 @@
+install (FILES
+	cairo-dock.desktop
+	cairo-dock-fallback.desktop
+	DESTINATION /usr/share/xsessions)
+
+install (FILES
+	cairo-dock.session
+	cairo-dock-fallback.session
+	DESTINATION /usr/share/gnome-session/sessions)

--- a/data/desktop-manager/gnome-session-3.28/cairo-dock-fallback.desktop
+++ b/data/desktop-manager/gnome-session-3.28/cairo-dock-fallback.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=GNOME/Cairo-Dock (Metacity)
+Comment=This session logs you into GNOME Flashback with Cairo-Dock and Compiz
+Exec=/usr/lib/gnome-session/run-systemd-session gnome-session-flashback.target
+TryExec=metacity
+Type=Application
+DesktopNames=GNOME-Flashback;GNOME;
+X-Ubuntu-Gettext-Domain=gnome-flashback

--- a/data/desktop-manager/gnome-session-3.28/cairo-dock-fallback.desktop
+++ b/data/desktop-manager/gnome-session-3.28/cairo-dock-fallback.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=GNOME/Cairo-Dock (Metacity)
 Comment=This session logs you into GNOME Flashback with Cairo-Dock and Compiz
-Exec=/usr/lib/gnome-session/run-systemd-session gnome-session-flashback.target
+Exec=gnome-session --session=cairo-dock-fallback
 TryExec=metacity
 Type=Application
 DesktopNames=GNOME-Flashback;GNOME;

--- a/data/desktop-manager/gnome-session-3.28/cairo-dock-fallback.session
+++ b/data/desktop-manager/gnome-session-3.28/cairo-dock-fallback.session
@@ -1,0 +1,3 @@
+[GNOME Session]
+Name=GNOME/Cairo-Dock (Metacity)
+RequiredComponents=metacity;gnome-flashback-init;gnome-flashback;cairo-dock;nautilus-classic;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Clipboard;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Mouse;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;

--- a/data/desktop-manager/gnome-session-3.28/cairo-dock.desktop
+++ b/data/desktop-manager/gnome-session-3.28/cairo-dock.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=GNOME/Cairo-Dock (Compiz)
 Comment=This session logs you into GNOME Flashback with Cairo-Dock and Compiz
-Exec=/usr/lib/gnome-session/run-systemd-session gnome-session-flashback.target
+Exec=gnome-session --session=cairo-dock
 TryExec=compiz
 Type=Application
 DesktopNames=GNOME-Flashback;GNOME;

--- a/data/desktop-manager/gnome-session-3.28/cairo-dock.desktop
+++ b/data/desktop-manager/gnome-session-3.28/cairo-dock.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=GNOME/Cairo-Dock (Compiz)
+Comment=This session logs you into GNOME Flashback with Cairo-Dock and Compiz
+Exec=/usr/lib/gnome-session/run-systemd-session gnome-session-flashback.target
+TryExec=compiz
+Type=Application
+DesktopNames=GNOME-Flashback;GNOME;
+X-Ubuntu-Gettext-Domain=gnome-flashback

--- a/data/desktop-manager/gnome-session-3.28/cairo-dock.session
+++ b/data/desktop-manager/gnome-session-3.28/cairo-dock.session
@@ -1,0 +1,3 @@
+[GNOME Session]
+Name=GNOME/Cairo-Dock (Compiz)
+RequiredComponents=compiz;gnome-flashback-init;gnome-flashback;cairo-dock;nautilus-classic;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Clipboard;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Mouse;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;


### PR DESCRIPTION
On newer Ubuntu version (with newer GNOME components), the old gnome-session files do not work well as unity-settings-daemon seems to be not fully usable.

In this branch, I've created session files that use the GNOME components, based on the gnome-flashback-session sessions (only replacing the gnome-panel with cairo-dock).

These require the gnome-flashback and gnome-session-flashback packages to be installed (on Ubuntu).

Tested on Ubuntu 18.04
