### PR TITLE
Support for EGL on Wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,25 @@ set (packages_required "glib-2.0 gthread-2.0 cairo librsvg-2.0 dbus-1 dbus-glib-
 STRING (REGEX REPLACE " " ";" packages_required_semicolon ${packages_required})  # replace blank space by semicolon => to have more details if a package is missing
 pkg_check_modules ("PACKAGE" REQUIRED "${packages_required_semicolon}")
 
+# check for Wayland
+set (with_wayland no)
+enable_if_not_defined (enable-wayland-support) # enabled by default
+if (enable-wayland-support)
+	set (wayland_required "wayland-client")  # for the .pc
+	pkg_check_modules ("WAYLAND" ${wayland_required}>=1.0.0)
+	if (WAYLAND_FOUND)
+		set (HAVE_WAYLAND 1)
+		set (with_wayland "yes (${WAYLAND_VERSION})")
+	else()
+		set (wayland_required)
+	endif()
+endif()
+
 # check for EGL
 set (with_egl no)  # although EGL can be used with X (replacing GLX), it requires drivers that support DRI2, so most of the time GLX works better; so it's disabled by default for now; later, it will be required for Wayland, and we'll have to decide whether we compile with both, or whether we load one of them as a plug-in at run-time. It may depend on EGL having been built to support a given graphic target.
+if (HAVE_WAYLAND)
+	enable_if_not_defined (enable-egl-support) # enabled by default if compiling for Wayland
+endif()
 if (enable-egl-support)
 	pkg_check_modules ("EGL" "egl")
 	if (EGL_FOUND)
@@ -140,20 +157,6 @@ if (enable-x11-support)
 		endif()
 	else()
 		set (xextend_required)
-	endif()
-endif()
-
-# check for Wayland
-set (with_wayland no)
-enable_if_not_defined (enable-wayland-support) # enabled by default
-if (enable-wayland-support)
-	set (wayland_required "wayland-client")  # for the .pc
-	pkg_check_modules ("WAYLAND" ${wayland_required}>=1.0.0)
-	if (WAYLAND_FOUND)
-		set (HAVE_WAYLAND 1)
-		set (with_wayland "yes (${WAYLAND_VERSION})")
-	else()
-		set (wayland_required)
 	endif()
 endif()
 

--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -336,6 +336,14 @@ void gldi_container_present (GldiContainer *pContainer)
 		s_backend.present (pContainer);
 }
 
+void gldi_container_set_input_shape(GldiContainer *pContainer, cairo_region_t *pShape)
+{
+	gtk_widget_input_shape_combine_region ((pContainer)->pWidget, pShape);
+	if (s_backend.set_input_shape)
+		s_backend.set_input_shape (pContainer, pShape);
+}
+	
+
 void gldi_container_manager_register_backend (GldiContainerManagerBackend *pBackend)
 {
 	gpointer *ptr = (gpointer*)&s_backend;

--- a/src/gldit/cairo-dock-dock-facility.c
+++ b/src/gldit/cairo-dock-dock-facility.c
@@ -455,7 +455,7 @@ static gboolean _move_resize_dock (CairoDock *pDock)
 	 * themselves (remove + insert of one icon). We need 2 configure otherwise
 	 * the size will be blocked to the value of the first 'configure'
 	 */
-	//g_print (" -> %dx%d, %d;%d\n", iNewWidth, iNewHeight, iNewPositionX, iNewPositionY);
+	// g_print (" -> %dx%d (%dx%d), %d;%d\n", iNewWidth, iNewHeight, pDock->container.iWidth, pDock->container.iHeight, iNewPositionX, iNewPositionY);
 
 	if (pDock->container.bIsHorizontal)
 	{
@@ -468,6 +468,7 @@ static gboolean _move_resize_dock (CairoDock *pDock)
 		 * disturbed and it will block the draw of the dock. It seems Compiz
 		 * sends too much 'configure' compare to Metacity. 
 		 */
+		if (g_bUseOpenGL) gldi_gl_container_resized (CAIRO_CONTAINER (pDock), iNewWidth, iNewHeight);
 	}
 	else
 	{
@@ -476,6 +477,7 @@ static gboolean _move_resize_dock (CairoDock *pDock)
 			iNewPositionX,
 			iNewHeight,
 			iNewWidth);
+		if (g_bUseOpenGL) gldi_gl_container_resized (CAIRO_CONTAINER (pDock), iNewHeight, iNewWidth);
 	}
 	pDock->iSidMoveResize = 0;
 	return FALSE;
@@ -1053,6 +1055,7 @@ void cairo_dock_show_subdock (Icon *pPointedIcon, CairoDock *pParentDock)
 			iNewPositionY,
 			iNewWidth,
 			iNewHeight);
+		if (g_bUseOpenGL) gldi_gl_container_resized (CAIRO_CONTAINER (pSubDock), iNewWidth, iNewHeight);
 	}
 	else
 	{
@@ -1061,6 +1064,7 @@ void cairo_dock_show_subdock (Icon *pPointedIcon, CairoDock *pParentDock)
 			iNewPositionX,
 			iNewHeight,
 			iNewWidth);
+		if (g_bUseOpenGL) gldi_gl_container_resized (CAIRO_CONTAINER (pSubDock), iNewHeight, iNewWidth);
 		/* in this case, the sub-dock is over the label, so this one is drawn
 		 * with a low transparency, so we trigger the redraw.
 		 */

--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -1150,6 +1150,8 @@ static gboolean _on_configure (GtkWidget* pWidget, GdkEventConfigure* pEvent, Ca
 		// update the GL context
 		if (g_bUseOpenGL)
 		{
+			if (bSizeUpdated) gldi_gl_container_resized (CAIRO_CONTAINER (pDock), pEvent->width, pEvent->height);
+			
 			if (! gldi_gl_container_make_current (CAIRO_CONTAINER (pDock)))
 				return FALSE;
 			

--- a/src/gldit/cairo-dock-opengl.c
+++ b/src/gldit/cairo-dock-opengl.c
@@ -362,6 +362,12 @@ void gldi_gl_container_init (GldiContainer *pContainer)
 		pContainer);
 }
 
+void gldi_gl_container_resized (GldiContainer *pContainer, int iWidth, int iHeight)
+{
+	if (g_bUseOpenGL && s_backend.container_resized)
+		s_backend.container_resized (pContainer, iWidth, iHeight);
+}
+
 void gldi_gl_container_finish (GldiContainer *pContainer)
 {
 	if (g_bUseOpenGL && s_backend.container_finish)

--- a/src/gldit/cairo-dock-opengl.h
+++ b/src/gldit/cairo-dock-opengl.h
@@ -57,6 +57,7 @@ struct _GldiGLManagerBackend {
 	void (*container_end_draw) (GldiContainer *pContainer);
 	void (*container_init) (GldiContainer *pContainer);
 	void (*container_finish) (GldiContainer *pContainer);
+	void (*container_resized) (GldiContainer *pContainer, int iWidth, int iHeight);
 };
 	
 
@@ -131,6 +132,12 @@ void gldi_gl_container_set_ortho_view_for_icon (Icon *pIcon);
 *@param pContainer the container, not yet realized.
 */
 void gldi_gl_container_init (GldiContainer *pContainer);
+
+/** Should be called when the window is resized so that the
+ *  associated EGL surface can be resized -- needed on Wayland,
+ * 	pContainer->iWidth and iHeight should be set to the desired
+ *  new size */
+void gldi_gl_container_resized (GldiContainer *pContainer, int iWidth, int iHeight);
 
 void gldi_gl_container_finish (GldiContainer *pContainer);
 

--- a/src/implementations/CMakeLists.txt
+++ b/src/implementations/CMakeLists.txt
@@ -14,6 +14,8 @@ SET(impl_SRCS
 	cairo-dock-X-utilities.c             cairo-dock-X-utilities.h
 	cairo-dock-glx.c                     cairo-dock-glx.h
 	cairo-dock-egl.c                     cairo-dock-egl.h
+	cairo-dock-egl-X.c
+	cairo-dock-egl-wayland.c
 	cairo-dock-wayland-manager.c         cairo-dock-wayland-manager.h
 )
 #if ("${HAVE_X11}")

--- a/src/implementations/cairo-dock-egl-X.c
+++ b/src/implementations/cairo-dock-egl-X.c
@@ -1,0 +1,36 @@
+#include "gldi-config.h"
+#ifdef HAVE_EGL
+
+#include <EGL/egl.h>
+
+#include "cairo-dock-egl.h"
+#include "cairo-dock-container.h"
+#include "cairo-dock-log.h"
+
+
+#ifdef HAVE_X11
+#include <gdk/gdkx.h>
+EGLDisplay* egl_get_display_x11(GdkDisplay* dsp)
+{
+	Display* dpy = gdk_x11_display_get_xdisplay(dsp);
+	if (!dpy) return NULL;
+	return eglGetDisplay (dpy);
+}
+
+void egl_init_surface_X11 (GldiContainer *pContainer, EGLDisplay* dpy, EGLConfig conf)
+{
+	// create an EGL surface for this window
+	EGLNativeWindowType native_window = 
+		GDK_WINDOW_XID (gldi_container_get_gdk_window (pContainer));
+	pContainer->eglSurface = eglCreateWindowSurface (dpy, conf, native_window, NULL);
+}
+
+#else
+EGLDisplay* egl_get_display_x11(GdkDisplay* dsp) { return NULL; }
+void egl_init_surface_X11 (G_GNUC_UNUSED GldiContainer *pContainer, G_GNUC_UNUSED EGLDisplay* dpy, G_GNUC_UNUSED EGLConfig conf)
+{
+	cd_error (_("Not using X11 EGL backend!\n"));
+}
+#endif
+
+#endif

--- a/src/implementations/cairo-dock-egl-wayland.c
+++ b/src/implementations/cairo-dock-egl-wayland.c
@@ -1,0 +1,55 @@
+#include "gldi-config.h"
+#ifdef HAVE_EGL
+
+#ifdef HAVE_WAYLAND
+#define WL_EGL_PLATFORM 1
+#include <gdk/gdkwayland.h>
+#include <wayland-egl-core.h>
+#endif
+
+#include <EGL/egl.h>
+#include "cairo-dock-egl.h"
+#include "cairo-dock-container.h"
+#include "cairo-dock-log.h"
+
+#ifdef HAVE_WAYLAND
+EGLDisplay* egl_get_display_wayland(GdkDisplay* dsp)
+{
+	struct wl_display* wdpy = gdk_wayland_display_get_wl_display(dsp);
+	if (!wdpy) return NULL;
+	return eglGetDisplay (wdpy);
+}
+
+void egl_init_surface_wayland (GldiContainer *pContainer, EGLDisplay* dpy, EGLConfig conf)
+{
+	// create an EGL surface for this window
+	struct wl_surface* wls = gdk_wayland_window_get_wl_surface (
+		gldi_container_get_gdk_window (pContainer));
+	struct wl_egl_window* wlw = wl_egl_window_create (wls,
+		pContainer->iWidth, pContainer->iHeight);
+	pContainer->eglwindow = wlw;
+	pContainer->eglSurface = eglCreateWindowSurface (dpy, conf, wlw, NULL);
+}
+
+void egl_window_resize_wayland (GldiContainer* pContainer, int iWidth, int iHeight)
+{
+	if (pContainer->eglwindow) wl_egl_window_resize (
+		pContainer->eglwindow, iWidth, iHeight, 0, 0);
+}
+
+#else
+EGLDisplay* egl_get_display_wayland(G_GNUC_UNUSED GdkDisplay* dsp) { return NULL; }
+
+void egl_init_surface_wayland (G_GNUC_UNUSED GldiContainer *pContainer, G_GNUC_UNUSED EGLDisplay* dpy, G_GNUC_UNUSED EGLConfig conf)
+{
+	cd_error (_("Not using Wayland EGL backend!\n"));
+}
+
+void egl_window_resize_wayland (G_GNUC_UNUSED GldiContainer* pContainer, G_GNUC_UNUSED int iWidth, G_GNUC_UNUSED int iHeight)
+{
+	cd_error (_("Not using Wayland EGL backend!\n"));
+}
+#endif
+
+#endif
+

--- a/src/implementations/cairo-dock-egl.h
+++ b/src/implementations/cairo-dock-egl.h
@@ -29,6 +29,21 @@ G_BEGIN_DECLS
 
 void gldi_register_egl_backend (void);
 
+#ifdef HAVE_EGL
+#include <gdk/gdk.h>
+#include <gtk/gtk.h>
+#include <EGL/egl.h>
+
+/* backend-specific code to get the proper EGLDisplay */
+EGLDisplay* egl_get_display_x11(GdkDisplay* dsp);
+EGLDisplay* egl_get_display_wayland(GdkDisplay* dsp);
+
+void egl_init_surface_X11 (GldiContainer *pContainer, EGLDisplay* dpy, EGLConfig conf);
+void egl_init_surface_wayland (GldiContainer *pContainer, EGLDisplay* dpy, EGLConfig conf);
+
+void egl_window_resize_wayland (GldiContainer* pContainer, int iWidth, int iHeight);
 
 G_END_DECLS
 #endif
+#endif
+


### PR DESCRIPTION
On current master, OpenGL does not seem to be working on Wayland. It always shows as errror:
```Can't initialise EGL display, OpenGL will not be available```
This patch adds the necessary support to create and manage EGL surfaces when running on Wayland.
