### PR TITLE
Allow 3 digits prefix for unique filename

### DIFF
--- a/src/gldit/cairo-dock-utils.c
+++ b/src/gldit/cairo-dock-utils.c
@@ -39,10 +39,12 @@ gchar *cairo_dock_generate_unique_filename (const gchar *cBaseName, const gchar 
 	} while (iPrefixNumber < 99 && g_file_test (sFileName->str, G_FILE_TEST_EXISTS));
 
 	g_string_free (sFileName, TRUE);
-	if (iPrefixNumber == 99)
+	if (iPrefixNumber < 100)
+		return g_strdup_printf ("%02d%s", iPrefixNumber, cBaseName);
+	if (iPrefixNumber == 1000)
 		return NULL;
 	else
-		return g_strdup_printf ("%02d%s", iPrefixNumber, cBaseName);
+		return g_strdup_printf ("%03d%s", iPrefixNumber, cBaseName);
 }
 
 

--- a/src/gldit/cairo-dock-utils.c
+++ b/src/gldit/cairo-dock-utils.c
@@ -35,8 +35,12 @@ gchar *cairo_dock_generate_unique_filename (const gchar *cBaseName, const gchar 
 	do
 	{
 		iPrefixNumber ++;
-		g_string_printf (sFileName, "%s/%02d%s", cCairoDockDataDir, iPrefixNumber, cBaseName);
-	} while (iPrefixNumber < 99 && g_file_test (sFileName->str, G_FILE_TEST_EXISTS));
+		if (iPrefixNumber < 100)
+			g_string_printf (sFileName, "%s/%02d%s", cCairoDockDataDir, iPrefixNumber, cBaseName);
+		else
+			g_string_printf (sFileName, "%s/%03d%s", cCairoDockDataDir, iPrefixNumber, cBaseName);
+
+	} while (iPrefixNumber < 1000 && g_file_test (sFileName->str, G_FILE_TEST_EXISTS));
 
 	g_string_free (sFileName, TRUE);
 	if (iPrefixNumber < 100)


### PR DESCRIPTION
Hi there,
i've got an issue with more custom launchers than 98. When creating the 99nth launcher , the following error is shown:
"Couldn't create create the icon. Check that you have writing permissions on ~/.config/cairo-dock and its sub-folders"

The issue is in the function cairo_dock_generate_unique_filename in cairo-dock-utils.c, with doesnt allow prefix numbers higher than 98. With theese changes i could create one more custom launcher (prefixed with 99), but the next launcher I want to create is buggy. Its shows up in the dock but the unique file isnt created, Every next launcher i create inherits all configs from the previous one, which gets overwritten when saving it.

Could someone look into this please? It would be really nice to create more custom launchers than 98.