### PR TITLE
[LP1943052] wayland-manager: allocate new wl_output information by checking id

### DIFF
--- a/src/gldit/cairo-dock-desktop-manager.h
+++ b/src/gldit/cairo-dock-desktop-manager.h
@@ -59,10 +59,21 @@ typedef enum {
 	NB_NOTIFICATIONS_DESKTOP
 	} CairoDesktopNotifications;
 
+typedef struct GldiWlOutput {
+	struct wl_output *output;
+	uint32_t id, ver;
+} GldiWlOutput;
+
+typedef struct GldiScreenInfo {
+	int x, y;
+	int width, height;
+	GldiWlOutput wloutput; // wl_registry object identifier (in wayland session)
+} GldiScreenInfo;
+
 // data
 struct _GldiDesktopGeometry {
 	int iNbScreens;
-	GtkAllocation *pScreens;  // liste of all screen devices.
+	GldiScreenInfo *pScreens;  // liste of all screen devices.
 	GtkAllocation Xscreen;  // logical screen, possibly made of several screen devices.
 	int iNbDesktops;
 	int iNbViewportX, iNbViewportY;

--- a/src/implementations/cairo-dock-X-utilities.c
+++ b/src/implementations/cairo-dock-X-utilities.c
@@ -89,7 +89,7 @@ static Atom s_aUtf8String;
 static Atom s_aString;
 static unsigned char error_code = Success;
 
-static GtkAllocation *_get_screens_geometry (int *pNbScreens);
+static GldiScreenInfo *_get_screens_geometry (int *pNbScreens);
 
 static gboolean cairo_dock_support_X_extension (void);
 
@@ -185,14 +185,14 @@ unsigned char cairo_dock_get_X_error_code (void)
 	return error_code;
 }
 
-static GtkAllocation *_get_screens_geometry (int *pNbScreens)
+static GldiScreenInfo *_get_screens_geometry (int *pNbScreens)
 {
-	GtkAllocation *pScreens = NULL;
-	GtkAllocation *pScreen;
+	GldiScreenInfo *pScreens = NULL;
+	GldiScreenInfo *pScreen;
 	int iNbScreens = 0;
 	/*Unit Tests
 	iNbScreens = 2;
-	pScreens = g_new0 (GtkAllocation, iNbScreens);
+	pScreens = g_new0 (GldiScreenInfo, iNbScreens);
 	pScreens[0].x = 0;
 	pScreens[0].y = 0;
 	pScreens[0].width = 1000;
@@ -213,7 +213,7 @@ static GtkAllocation *_get_screens_geometry (int *pNbScreens)
 		{
 			int n = res->ncrtc;
 			cd_debug (" number of screen(s): %d", n);
-			pScreens = g_new0 (GtkAllocation, n);
+			pScreens = g_new0 (GldiScreenInfo, n);
 			int i;
 			for (i = 0; i < n; i++)
 			{
@@ -256,7 +256,7 @@ static GtkAllocation *_get_screens_geometry (int *pNbScreens)
 		if (scr != NULL)
 		{
 			cd_debug (" number of screen(s): %d", n);
-			pScreens = g_new0 (GtkAllocation, n);
+			pScreens = g_new0 (GldiScreenInfo, n);
 			int i;
 			for (i = 0; i < n; i++)
 			{
@@ -286,7 +286,7 @@ static GtkAllocation *_get_screens_geometry (int *pNbScreens)
 		#endif
 		
 		iNbScreens = 1;
-		pScreens = g_new0 (GtkAllocation, iNbScreens);
+		pScreens = g_new0 (GldiScreenInfo, iNbScreens);
 		pScreen = &pScreens[0];
 		pScreen->x = 0;
 		pScreen->y = 0;
@@ -335,7 +335,7 @@ gboolean cairo_dock_update_screen_geometry (void)
 	}
 	
 	// get the size and position of each screen (they could have changed even though the X screen has not changed, for instance if you swap 2 screens).
-	GtkAllocation *pScreens = g_desktopGeometry.pScreens;
+	GldiScreenInfo *pScreens = g_desktopGeometry.pScreens;
 	int iNbScreens = g_desktopGeometry.iNbScreens;
 	g_desktopGeometry.pScreens = _get_screens_geometry (&g_desktopGeometry.iNbScreens);
 	
@@ -347,7 +347,7 @@ gboolean cairo_dock_update_screen_geometry (void)
 			int i;
 			for (i = 0; i < MIN (iNbScreens, g_desktopGeometry.iNbScreens); i ++)
 			{
-				if (memcmp (&pScreens[i], &g_desktopGeometry.pScreens[i], sizeof (GtkAllocation)) != 0)
+				if (memcmp (&pScreens[i], &g_desktopGeometry.pScreens[i], sizeof (GldiScreenInfo)) != 0)
 				{
 					bNewSize = TRUE;
 					break;


### PR DESCRIPTION
With KDE Plasma Wayland session, after calling wl_output_add_listener()
and waiting for wl_output information with wl_display_roundtrip(),
wl_output::mode info is returned before wl_output::geometry info.

Current cairo-dock-wayland-manager logic expects the opposite order, and
on KDE session this causes cairo-dock segfault.

To avoid this, when collecting wl_output information, we should also check
"id" member of global registry object associated with that wl_output info,
check if the "id" is already the duplicates of the old infos.

Then if the "id" is new one, then allocate the new buffer to register new
wl_output information beforehand, then call wl_display_roundtrip() to gain
wl_output::geometry or wl_output::output information.

Should fix https://bugs.launchpad.net/cairo-dock-core/+bug/1943052