### PR TITLE
Typo fix

### DIFF
--- a/data/cairo-dock.conf.in
+++ b/data/cairo-dock.conf.in
@@ -213,7 +213,7 @@ move down nb steps = 16
 #X-[Refresh rate;system-run]
 frame_cpu =
 
-#i-[5;40] Refresh rate when mouving cursor into the dock:
+#i-[5;40] Refresh rate when moving cursor into the dock:
 #{in Hz. This is to adjust behaviour relative to your CPU power.}
 refresh frequency = 35
 

--- a/data/themes/default-theme-panel/cairo-dock.conf
+++ b/data/themes/default-theme-panel/cairo-dock.conf
@@ -213,7 +213,7 @@ move down nb steps=11
 #X-[Refresh rate;system-run]
 frame_cpu=
 
-#i-[5;40] Refresh rate when mouving cursor into the dock:
+#i-[5;40] Refresh rate when moving cursor into the dock:
 #{in Hz. This is to adjust behaviour relative to your CPU power.}
 refresh frequency=35
 

--- a/data/themes/default-theme/cairo-dock.conf
+++ b/data/themes/default-theme/cairo-dock.conf
@@ -213,7 +213,7 @@ move down nb steps=16
 #X-[Refresh rate;system-run]
 frame_cpu=
 
-#i-[5;40] Refresh rate when mouving cursor into the dock:
+#i-[5;40] Refresh rate when moving cursor into the dock:
 #{in Hz. This is to adjust behaviour relative to your CPU power.}
 refresh frequency=35
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -2978,7 +2978,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/be.po
+++ b/po/be.po
@@ -3036,7 +3036,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "у Гц. Залежыць ад магутнасці вашага працэсара."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/bg.po
+++ b/po/bg.po
@@ -2970,7 +2970,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/bn.po
+++ b/po/bn.po
@@ -2958,7 +2958,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/ca.po
+++ b/po/ca.po
@@ -3149,7 +3149,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/cairo-dock.pot
+++ b/po/cairo-dock.pot
@@ -2709,7 +2709,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/cs.po
+++ b/po/cs.po
@@ -3238,7 +3238,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "v Hz. Toto nastavení ovlivňuje zatížení procesoru."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/cy.po
+++ b/po/cy.po
@@ -2945,7 +2945,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/da.po
+++ b/po/da.po
@@ -2940,7 +2940,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/de.po
+++ b/po/de.po
@@ -3546,7 +3546,7 @@ msgstr ""
 "Geschwindigkeit gedacht."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Auffrischfrequenz, wenn der Mauszeiger auf das Dock bewegt wird:"
 
 #: ../data/messages:417

--- a/po/el.po
+++ b/po/el.po
@@ -3231,7 +3231,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "σε Hz. Η διευθέτησή του εξαρτάται από την ισχύ του επεξεργαστή σας."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -3398,8 +3398,8 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "in Hz. This is to adjust behaviour relative to your CPU power."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
-msgstr "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
+msgstr "Refresh rate when moving cursor into the dock:"
 
 #: ../data/messages:417
 msgid "Animation frequency for the OpenGL backend:"

--- a/po/eo.po
+++ b/po/eo.po
@@ -2942,7 +2942,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/es.po
+++ b/po/es.po
@@ -3466,7 +3466,7 @@ msgstr ""
 "en Hz. Esto es para ajustar con respecto a la potencia del procesador."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Tasa de refresco mientras el cursor semueve por los iconos"
 
 #: ../data/messages:417

--- a/po/et.po
+++ b/po/et.po
@@ -2961,7 +2961,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/eu.po
+++ b/po/eu.po
@@ -3406,7 +3406,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "Hz-etan. Portaera PUZaren energiaren arabera doitzeko da hau."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Freskatze-tasa kurtsoaren dockaren barruan mugitzean:"
 
 #: ../data/messages:417

--- a/po/fi.po
+++ b/po/fi.po
@@ -2956,7 +2956,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/fo.po
+++ b/po/fo.po
@@ -2958,7 +2958,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/fr.po
+++ b/po/fr.po
@@ -3502,7 +3502,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "en Hz. Ceci est à ajuster en fonction de la puissance du processeur."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 "Fréquence de rafraîchissement lors du déplacement du curseur dans le dock"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -3001,7 +3001,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/he.po
+++ b/po/he.po
@@ -3035,7 +3035,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/hu.po
+++ b/po/hu.po
@@ -3397,7 +3397,7 @@ msgstr ""
 "be."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/id.po
+++ b/po/id.po
@@ -2955,7 +2955,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/it.po
+++ b/po/it.po
@@ -3455,7 +3455,7 @@ msgstr ""
 "in Hz. Questo è da aggiustare in base alla potenza della propria CPU."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Velocità di aggiornamento al passaggio del cursore sulla dock:"
 
 #: ../data/messages:417

--- a/po/ja.po
+++ b/po/ja.po
@@ -3201,7 +3201,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "Hz 単位。CPU パワーに合わせた調整のためです。"
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "カーソルをドック内で動かしているときのリフレッシュレート："
 
 #: ../data/messages:417

--- a/po/ko.po
+++ b/po/ko.po
@@ -3009,7 +3009,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "Hz 단위. CPU 성능과 관련하여 조절하십시오."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/lt.po
+++ b/po/lt.po
@@ -2971,7 +2971,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/nb.po
+++ b/po/nb.po
@@ -3053,7 +3053,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "i hertz. Dette er for å tilpasse adferden til din CPU-kraft."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/nl.po
+++ b/po/nl.po
@@ -3473,7 +3473,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "In Hz. Dit is om het processorgebruik aan te passen."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Vernieuwingstijd bij verplaatsen van muisaanwijzer naar het dock"
 
 #: ../data/messages:417

--- a/po/nn.po
+++ b/po/nn.po
@@ -3363,7 +3363,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/oc.po
+++ b/po/oc.po
@@ -2941,7 +2941,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/pl.po
+++ b/po/pl.po
@@ -3392,7 +3392,7 @@ msgstr ""
 "w Hercach (Hz). Dla dostosowania zachowania w stosunku do możliwości CPU."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/pt.po
+++ b/po/pt.po
@@ -3428,7 +3428,7 @@ msgstr ""
 "em Hz. Deve ajustar o comportamento em relação à frequência do seu CPU."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Taxa de actualização ao mover o cursor pela doca:"
 
 #: ../data/messages:417

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3204,7 +3204,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "em Hz. Ajustar dependendo da frequência do seu CPU."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/ro.po
+++ b/po/ro.po
@@ -2967,7 +2967,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/ru.po
+++ b/po/ru.po
@@ -3345,7 +3345,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "в Гц. Зависит от мощности вашего процессора."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/sk.po
+++ b/po/sk.po
@@ -3179,7 +3179,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "v Hz. Toto je úprava týkajúca sa vášho výkonu CPU."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/sl.po
+++ b/po/sl.po
@@ -3038,7 +3038,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "v Hz. Prilagojeno bo glede na moč vaše CPE."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/sr.po
+++ b/po/sr.po
@@ -3383,7 +3383,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "у Hz. Одређује понашање у односу на снагу процесора."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Учесталост освежавања при померању показивача у док:"
 
 #: ../data/messages:417

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -3104,7 +3104,7 @@ msgstr ""
 "u Hz. Ovo je u vezi podašavanja ponašanja u odnosu na snagu procesora."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/sv.po
+++ b/po/sv.po
@@ -3413,7 +3413,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "i Hz. Detta är för att justera beteendet efter din processorkraft."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Uppdateringsfrekvens då pekaren flyttas till dockan:"
 
 #: ../data/messages:417

--- a/po/tr.po
+++ b/po/tr.po
@@ -3075,7 +3075,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/uk.po
+++ b/po/uk.po
@@ -3397,7 +3397,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "у Гц. Залежить від потужності вашого процесора."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr "Частота оновлення при переміщенні курсора по панелі:"
 
 #: ../data/messages:417

--- a/po/uz.po
+++ b/po/uz.po
@@ -3402,7 +3402,7 @@ msgstr ""
 "Hz да. Бу сизнинг CPU қувватига нисбатан ўзини тутишни мослаштириш учун."
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/vi.po
+++ b/po/vi.po
@@ -2966,7 +2966,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr ""
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3119,7 +3119,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "以Hz为单位。依据你的CPU骠悍度调整此值。"
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3031,7 +3031,7 @@ msgid "in Hz. This is to adjust behaviour relative to your CPU power."
 msgstr "以HZ為單位，這可以調整關於您的 CPU 资源。"
 
 #: ../data/messages:413
-msgid "Refresh rate when mouving cursor into the dock:"
+msgid "Refresh rate when moving cursor into the dock:"
 msgstr ""
 
 #: ../data/messages:417


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57551996/142656740-858086eb-155e-4815-8b18-33fa1cf08e86.png)
Found this small typo (under **refresh rate**)

---
Changed "_mouving_" everywhere to "_moving_"
Used `grep -rl "mouving" cairo-dock-core | xargs sed -i 's/mouving/moving/g'`

Signed-off-by: Anubhav Choudhary <ac.10edu@gmail.com>