### PR TITLE
Help: initialize pCategoryCombo before used

### DIFF
--- a/Help/src/applet-tips-dialog.c
+++ b/Help/src/applet-tips-dialog.c
@@ -276,10 +276,6 @@ void cairo_dock_show_tips (void)
 	pTips->iNumTipGroup = iNumTipGroup;
 	pTips->iNumTipKey = iNumTipKey;
 	
-	// update to the next tip.
-	if (myData.iLastTipGroup >= 0 && myData.iLastTipKey >= 0)  // a previous tip exist => take the next one;
-		_cairo_dock_get_next_tip (pTips);
-	
 	// build a list of the available groups.
 	GtkWidget *pInteractiveWidget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 3);
 	GtkWidget *pComboBox = gtk_combo_box_text_new ();
@@ -290,6 +286,11 @@ void cairo_dock_show_tips (void)
 	}
 	gtk_combo_box_set_active (GTK_COMBO_BOX (pComboBox), pTips->iNumTipGroup);
 	pTips->pCategoryCombo = pComboBox;
+
+	// update to the next tip.
+	if (myData.iLastTipGroup >= 0 && myData.iLastTipKey >= 0)  // a previous tip exist => take the next one;
+		_cairo_dock_get_next_tip (pTips);
+	
 	static gpointer data_combo[2];
 	data_combo[0] = pTips;  // the 2nd data is the dialog, we'll set it after we make it.
 	g_signal_connect (G_OBJECT (pComboBox), "changed", G_CALLBACK(_on_tips_category_changed), data_combo);


### PR DESCRIPTION
cairo_dock_show_tips() calls _cairo_dock_get_next_tip(pTips) , which uses pTips->pCategoryCombo , so this must be properly created (initialized) before calling _cairo_dock_get_next_tip(pTips).