### PR TITLE
Help: remove leading whitespace from comment

### DIFF
--- a/Help/src/applet-tips-dialog.c
+++ b/Help/src/applet-tips-dialog.c
@@ -77,7 +77,13 @@ static void _cairo_dock_get_next_tip (CDTipsData *pTips)
 		// check if the key is an expander widget.
 		const gchar *cKeyName = pTips->pKeyList[pTips->iNumTipKey];
 		gchar *cKeyComment =  g_key_file_get_comment (pTips->pKeyFile, cGroupName, cKeyName, NULL);
-		bOk = (cKeyComment && *cKeyComment == CAIRO_DOCK_WIDGET_EXPANDER);  // whether it's an expander.
+		gchar *cUsefulComment = cKeyComment;
+		if (cUsefulComment)
+		{
+			while (*cUsefulComment == ' ' || *cUsefulComment == '\n')
+				cUsefulComment ++;
+		}
+		bOk = (cUsefulComment && *cUsefulComment == CAIRO_DOCK_WIDGET_EXPANDER);  // whether it's an expander.
 		g_free (cKeyComment);
 	} while (!bOk);
 }
@@ -125,7 +131,14 @@ static void _cairo_dock_get_previous_tip (CDTipsData *pTips)
 		// check if the key is an expander widget.
 		const gchar *cKeyName = pTips->pKeyList[pTips->iNumTipKey];
 		gchar *cKeyComment =  g_key_file_get_comment (pTips->pKeyFile, cGroupName, cKeyName, NULL);
-		bOk = (cKeyComment && *cKeyComment == CAIRO_DOCK_WIDGET_EXPANDER);  // whether it's an expander.
+		gchar *cUsefulComment = cKeyComment;
+		if (cUsefulComment)
+		{
+			while (*cUsefulComment == ' ' || *cUsefulComment == '\n')
+				cUsefulComment ++;
+		}
+		bOk = (cUsefulComment && *cUsefulComment == CAIRO_DOCK_WIDGET_EXPANDER);  // whether it's an expander.
+		g_free(cKeyComment);
 	} while (!bOk);
 }
 


### PR DESCRIPTION
A.
In _cairo_dock_get_next_tip() (or _cairo_dock_get_previous_tip()), g_key_file_get_comment() is called to retrieve comment. According to the specification:
https://docs.gtk.org/glib/method.KeyFile.get_comment.html The above call does not remove the leading whitespace ('#' comment marker is removed).
So currently due to the leading newline, currently `*cKeyComment == CAIRO_DOCK_WIDGET_EXPANDER` never matches, so currently _cairo_dock_get_next_tip() causes infinite loop.

So skip reading whitespace, as this is shown in cairo_dock_parse_key_comment().

B.
The buffer returned by g_key_file_get_comment() must be handled by g_free in _cairo_dock_get_previous_tip()
(as _cairo_dock_get_next_tip() already does).