### PR TITLE
Fixes for presenting a window class on Wayfire

### DIFF
--- a/src/cairo-dock-user-interaction.c
+++ b/src/cairo-dock-user-interaction.c
@@ -227,7 +227,7 @@ gboolean cairo_dock_notification_click_icon (G_GNUC_UNUSED gpointer pUserData, I
 		if (myTaskbarParam.bPresentClassOnClick // if we want to use this feature
 		&& (!myDocksParam.bShowSubDockOnClick  // if sub-docks are shown on mouse over
 			|| gldi_container_is_visible (CAIRO_CONTAINER (icon->pSubDock)))  // or this sub-dock is already visible
-		&& gldi_desktop_present_class (icon->cClass)) // we use the scale plugin if it's possible
+		&& gldi_desktop_present_class (icon->cClass, pContainer)) // we use the scale plugin if it's possible
 		{
 			_show_all_windows (icon->pSubDock->icons); // show all windows
 			// in case the dock is visible or about to be visible, hide it, as it would confuse the user to have both.

--- a/src/gldit/cairo-dock-desktop-manager.c
+++ b/src/gldit/cairo-dock-desktop-manager.c
@@ -26,6 +26,7 @@
 #include "cairo-dock-gnome-shell-integration.h"
 #include "cairo-dock-cinnamon-integration.h"
 #include "cairo-dock-wayfire-integration.h"
+#include "cairo-dock-wayland-manager.h" // gldi_wayland_release_keyboard (needed on Wayfire)
 #define _MANAGER_DEF_
 #include "cairo-dock-desktop-manager.h"
 
@@ -99,11 +100,12 @@ const gchar *gldi_desktop_manager_get_backend_names (void)
 	return s_registered_backends ? s_registered_backends : "none";
 }
 
-gboolean gldi_desktop_present_class (const gchar *cClass)  // scale matching class
+gboolean gldi_desktop_present_class (const gchar *cClass, GldiContainer *pContainer)  // scale matching class
 {
 	g_return_val_if_fail (cClass != NULL, FALSE);
 	if (s_backend.present_class != NULL)
 	{
+		gldi_wayland_release_keyboard (pContainer);
 		return s_backend.present_class (cClass);
 	}
 	return FALSE;

--- a/src/gldit/cairo-dock-desktop-manager.h
+++ b/src/gldit/cairo-dock-desktop-manager.h
@@ -113,9 +113,10 @@ const gchar *gldi_desktop_manager_get_backend_names (void);
 
 /** Present all the windows of a given class.
 *@param cClass the class.
+*@param pContainer currently active container which might need to be unfocused
 *@return TRUE on success
 */
-gboolean gldi_desktop_present_class (const gchar *cClass);
+gboolean gldi_desktop_present_class (const gchar *cClass, GldiContainer *pContainer);
 
 /** Present all the windows of the current desktop.
 *@return TRUE on success

--- a/src/implementations/cairo-dock-wayfire-integration.cpp
+++ b/src/implementations/cairo-dock-wayfire-integration.cpp
@@ -134,8 +134,10 @@ static gboolean _present_windows() {
 /* Start scale including all views of the given class */
 static gboolean _present_class(const gchar *cClass) {
 	const gchar *cWmClass = cairo_dock_get_class_wm_class (cClass);
-	return _call_ipc({{"method", "scale_ipc_filter/activate_appid"}, {"data", {{"all_workspaces", true}, {"app_id", cWmClass}}}});
+	if (cWmClass) return _call_ipc({{"method", "scale_ipc_filter/activate_appid"}, {"data", {{"all_workspaces", true}, {"app_id", cWmClass}}}});
+	else return FALSE;
 }
+
 
 /* Start expo on the current output */
 static gboolean _present_desktops() {


### PR DESCRIPTION
Explicitly try to lose keyboard focus when presenting a class of windows (using scale or similar plugin). This will only have effect on Wayfire (since the function is only available on Wayland, and this feature is only implemented for Wayfire in this case), where it is required, as layer-shell surfaces take precedence for keyboard focus (see [here](https://github.com/WayfireWM/wayfire/issues/2422)). Also avoid calling scale with no app-id.