### PR TITLE
Refactor app-id matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,21 @@ The Cairo-Dock-Session project aims to provide an easy way to install a session 
 Installation
 ------------
 
-Please see our [Wiki at Glx-Dock.org](http://www.glx-dock.org/ww_page.php?p=By%20distributions&lang=en) for an excellent installation guide.
+Please see the [Wiki](https://github.com/Cairo-Dock/cairo-dock-core/wiki/Installation).
 
-Tarballs of the sources are available at: https://launchpad.net/cairo-dock-core and https://launchpad.net/cairo-dock-plug-ins
+Packages for Ubuntu 22.04 and 24.04 are available on Launchpad:
+ - stable version: https://launchpad.net/~cairo-dock-team/+archive/ubuntu/ppa
+ - beta version: https://launchpad.net/~cairo-dock-team/+archive/ubuntu/weekly
 
-Binary packages of the development version for Ubuntu 22.04 and 24.04 are available here : https://launchpad.net/~cairo-dock-team/+archive/ubuntu/weekly
-
-Additional information specific to compiling Cairo-Dock to run under Wayland is available [here](README_Wayland.md).
+Additional information for compiling from source is available [here](https://github.com/Cairo-Dock/cairo-dock-core/wiki/Compiling-from-source).
 
 
 Need some help?
 ---------------
 
-See our wiki! http://www.glx-dock.org/ww_page.php
+See our the updated wiki for the most important information: https://github.com/Cairo-Dock/cairo-dock-core/wiki
+
+See also the original wiki for a lot of additional useful info: http://www.glx-dock.org/ww_page.php
 
 You can find: how to launch the dock at startup, how to customise it, how to resolve some recurrent problems (black background, messages at startup, etc.), how to help us, who we are, etc.
 A useful tutorial is also available to help you customize your dock: http://www.glx-dock.org/ww_page.php?p=Tutorial-Customisation&lang=en
@@ -45,17 +47,17 @@ Join the project
 
 * Want to **HACK** into the dock or write an **APPLET**? see the complete C API here: http://doc.glx-dock.org
 * You don't like C and still want to write an **APPLET** for the dock or **CONTROL** it from a script or the terminal? see its powerful DBus API here: http://www.glx-dock.org/ww_page.php?p=Control_your_dock_with_DBus&lang=en
-* You have some **IDEAS / PROPOSITIONS**? You need some help to develop an applet? Feel free post a topic on our forum! We'll be happy to answer you!
+* You have some **IDEAS / PROPOSITIONS**? You need some help to develop an applet? Feel free to use the Github issues or discussions, or post a topic on our forum! We'll be happy to answer you!
 * You want to **TRANSLATE** Cairo-Dock in your language? Use the 'Translations' tab in Launchpad, it's very simple to use it and helpful for us!
 
 
 Bug reports
 -----------
 
-You can report bugs in **Launchpad** under the '[Bugs](https://bugs.launchpad.net/cairo-dock)' section. If possible:
+You can report bugs using Github [issues](https://github.com/Cairo-Dock/cairo-dock-core/issues). If possible:
 
-* Read our wiki specially the '[Recurring Problems](http://www.glx-dock.org/ww_page.php?p=Recurrents%20problems&lang=en)' section which can help you to resolve some bugs like a black background, messages at startup, etc.
-* Please include also some information like your distribution, your achitecture (32/64bits), your Desktop Manager (Gnome, KDE, XFCE,...) your Window Manager (Compiz, Metacity, Kwin, etc.) or Wayland compositor (Wayfire, Kwin, Labwc, etc.), if you use Cairo-Dock with or without OpenGL, with which theme, etc. You can copy the "Technical info" page from the About dialog (right click on the dock -> Cairo-Dock -> About) which covers the most important details.
+* Read our wiki specially the '[Troubleshooting](https://github.com/Cairo-Dock/cairo-dock-core/wiki/Troubleshooting)' section which can help you to resolve some bugs like a black background, messages at startup, etc.
+* Please include also some information like your distribution, your achitecture (32/64bits), your Desktop Manager (Gnome, KDE, XFCE,...) your Window Manager (Compiz, Metacity, Kwin, etc.) or Wayland compositor (Wayfire, Kwin, Labwc, etc.), if you use Cairo-Dock with or without OpenGL, with which theme, etc. On a recent version (>= 3.5.99), you can just copy the "Technical info" page from the About dialog (right click on the dock -> Cairo-Dock -> About) which covers the most important details.
 * Include the method to reproduce the bug (which actions, which options activated)
 * Run the dock with the command
           cairo-dock -l debug > debug.txt

--- a/copyright
+++ b/copyright
@@ -38,7 +38,8 @@ Copyright: 2007-2014 Fabrice Rey <fabounet@glx-dock.org>
            2020-2024 Daniel Kondor <kondor.dani@gmail.com>
 License: GPL-3+
 
-Files: src/implementations/cairo-dock-foreign-toplevel.?
+Files: src/gldit/cairo-dock-desktop-file-db.?
+ src/implementations/cairo-dock-foreign-toplevel.?
  src/implementations/cairo-dock-plasma-*
  src/implementations/cairo-dock-cosmic-*
  src/implementations/cairo-dock-wayfire-*

--- a/src/gldit/CMakeLists.txt
+++ b/src/gldit/CMakeLists.txt
@@ -64,6 +64,7 @@ SET(core_lib_SRCS
 	cairo-dock-menu.c 					cairo-dock-menu.h
 	cairo-dock-style-manager.c 			cairo-dock-style-manager.h
 	cairo-dock-style-facility.c 		cairo-dock-style-facility.h
+	cairo-dock-desktop-file-db.c		cairo-dock-desktop-file-db.h
 	cdwindow.c                          cdwindow.h
 	texture-gradation.h
 	gtk3imagemenuitem.c 				gtk3imagemenuitem.h

--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -1931,6 +1931,10 @@ gchar *cairo_dock_register_class_full (const gchar *cDesktopFile, const gchar *c
 	gchar *cDesktopFilePath = _search_desktop_file (cDesktopFile?cDesktopFile:cClass);
 	if (cDesktopFilePath == NULL && cWmClass != NULL)
 		cDesktopFilePath = _search_desktop_file (cWmClass);
+	// special handling for Gnome Terminal, required at least on Ubuntu 22.04 and 24.04
+	// (should be fixed in newer versions, see e.g. here: https://gitlab.gnome.org/GNOME/gnome-terminal/-/issues/8033)
+	if (cDesktopFilePath == NULL && !strcmp (cClass, "gnome-terminal-server"))
+		cDesktopFilePath = _search_desktop_file ("org.gnome.terminal");
 	if (cDesktopFilePath == NULL)  // couldn't find the .desktop
 	{
 		if (cClass != NULL)  // make a class anyway to store the few info we have.

--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -1826,13 +1826,15 @@ gchar *cairo_dock_guess_class (const gchar *cCommand, const gchar *cStartupWMCla
 		g_free (cDefaultClass);
 	}
 	else
-	{
 		cResult = g_ascii_strdown (cStartupWMClass, -1);
-/*		gchar *str = strchr (cResult, '.');  // we remove all .xxx otherwise we can't detect the lack of extension when looking for an icon (openoffice.org) or it's a problem when looking for an icon (jbrout.py).
-		if (str != NULL)
-			*str = '\0'; */
+	
+	if (cResult)
+	{
+		// remove some suffices that can be problematic: .exe, .py (note: cResult is already lowercase here)
+		if (g_str_has_suffix (cResult, ".exe")) cResult[strlen (cResult) - 4] = 0;
+		else if (g_str_has_suffix (cResult, ".py")) cResult[strlen (cResult) - 3] = 0;
+		cairo_dock_remove_version_from_string (cResult);
 	}
-	cairo_dock_remove_version_from_string (cResult);
 	cd_debug (" -> '%s'", cResult);
 
 	return cResult;

--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -1622,7 +1622,7 @@ static gchar *_search_desktop_file (const gchar *cDesktopFile)  // file, path or
 		return NULL; // if we got an absolute path, we require it to be correct
 	}
 
-	// note: cDesktopFile will already by lowercase if it is an app-id / class
+	// note: cDesktopFile will already be lowercase if it is an app-id / class
 	gchar *cDesktopFileName = g_ascii_strdown (cDesktopFile, -1);
 	// remove the .desktop suffix if it is present
 	gchar *tmp = g_strrstr (cDesktopFileName, ".desktop");
@@ -1636,8 +1636,16 @@ static gchar *_search_desktop_file (const gchar *cDesktopFile)  // file, path or
 		// handle potential partial matches
 		GString *sID = g_string_new (NULL);
 		
-		// #1: add common prefices
-		// e.g. org.gnome.Evince.desktop, but app-id is only evince on Ubuntu 22.04
+		/* #1: add common prefices
+		 * e.g. org.gnome.Evince.desktop, but app-id is only evince on Ubuntu 22.04 and 24.04
+		 * More generally, this can happen with GTK+3 apps that have only "partially" migrated
+		 * to using the "new" (reverse DNS style) .desktop format.
+		 * See e.g.
+		 * https://gitlab.gnome.org/GNOME/gtk/-/issues/2822
+		 * https://gitlab.gnome.org/GNOME/gtk/-/issues/2034
+		 * https://honk.sigxcpu.org/con/GTK__and_the_application_id.html
+		 * https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id
+		 */
 		const char *prefices[] = {"org.gnome.", "org.kde.", "org.freedesktop.", NULL};
 		int j;
 		
@@ -1651,7 +1659,7 @@ static gchar *_search_desktop_file (const gchar *cDesktopFile)  // file, path or
 		if (!res)
 		{
 			// #2: snap "namespaced" names -- these could be anything, we just handle the "common" case where
-			// simply the app-id is duplicated (e.g. "firefox_firefox.desktop" as on Ubuntu 22.04)
+			// simply the app-id is duplicated (e.g. "firefox_firefox.desktop" as on Ubuntu 22.04 and 24.04)
 			g_string_printf (sID, "%s_%s", cDesktopFileName, cDesktopFileName);
 			res = gldi_desktop_file_db_lookup (sID->str);
 		}

--- a/src/gldit/cairo-dock-desktop-file-db.c
+++ b/src/gldit/cairo-dock-desktop-file-db.c
@@ -1,0 +1,241 @@
+/**
+* This file is a part of the Cairo-Dock project
+*
+* Copyright : (C) see the 'copyright' file.
+* E-mail    : see the 'copyright' file.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 3
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <glib.h>
+#include <string.h>
+#include <gio/gio.h>
+#include <gmodule.h>
+#include <gio/gdesktopappinfo.h>
+#include "cairo-dock-desktop-file-db.h"
+#include "cairo-dock-class-manager.h" // cairo_dock_guess_class
+#include "cairo-dock-log.h" // cd_error
+
+static GAppInfoMonitor *monitor = NULL;
+
+typedef struct _desktop_db {
+	GHashTable *class_table; // main table mapping desktop file IDs (without the extension) to file paths
+	GHashTable *alt_class_table; // alternative mapping based on the StartupWMClass (if exists) or command line
+} desktop_db;
+
+static desktop_db *db_current = NULL; // current database (used for lookups)
+static desktop_db *db_pending = NULL; // pending database (created by our worker thread)
+
+static GMutex mutex; // mutex for accessing db_pending
+static GCond cond; // condition to signal that db_pending has been updated (only used if db_current == NULL)
+static GThread *thread = NULL; // our worker thread
+
+static gboolean update_pending = FALSE; // update of apps is already pending
+static gboolean more_work = FALSE; // more work to do for the worker thread (apps on the system have changed)
+static gboolean thread_running = FALSE; // worker thread is running (doing work updating the app DB; set to TRUE in _start_thread())
+static gboolean error = FALSE; // set if the worker cannot retrieve apps
+
+static void _desktop_db_free (desktop_db *db)
+{
+	if (db)
+	{
+		if (db->alt_class_table) g_hash_table_unref(db->alt_class_table);
+		if (db->class_table) g_hash_table_unref(db->class_table);
+		g_free (db);
+	}
+}
+
+static void _process_app (gpointer data, gpointer user_data)
+{
+	if (!data) return;
+	desktop_db *db = (desktop_db*)user_data;
+	GAppInfo *app = (GAppInfo*)data;
+	const char *id = g_app_info_get_id (app);
+	if (!id) return;
+	
+	GDesktopAppInfo *desktop_app = G_DESKTOP_APP_INFO(app);
+	if (!desktop_app) return;
+	
+	const char *fn = g_desktop_app_info_get_filename (desktop_app);
+	if (!fn) return;
+	
+	const char *wmclass = g_desktop_app_info_get_startup_wm_class (desktop_app);
+	const char *cmdline = g_app_info_get_commandline (app);
+	
+	// process ID: make it lowercase and remove .desktop extension
+	char *id_lower = NULL;
+	const char *tmp = strrchr (id, '.');
+	if (tmp && !strcmp(tmp, ".desktop"))
+		id_lower = g_ascii_strdown (id, tmp - id);
+	else id_lower = g_ascii_strdown (id, -1);
+	
+	// process commandline and / or wm class (note: this will always return lower case as well)
+	char *alt_id = cairo_dock_guess_class (cmdline, wmclass);
+	if (alt_id && !strcmp (alt_id, id))
+	{
+		g_free (alt_id);
+		alt_id = NULL;
+	}
+	
+	// check if this app is already present in our table -- we cannot do much in this case
+	if (g_hash_table_contains (db->class_table, id_lower) || g_hash_table_contains(db->alt_class_table, id_lower) ||
+		(alt_id && (g_hash_table_contains (db->class_table, alt_id) ||
+			g_hash_table_contains(db->alt_class_table, alt_id))))
+	{
+		g_free (id_lower);
+		g_free (alt_id);
+		return;
+	}
+	
+	// valid app, add to the hash table
+	char *fn_dup = g_strdup (fn);
+	g_hash_table_insert (db->class_table, id_lower, fn_dup);
+	if (alt_id) g_hash_table_insert (db->alt_class_table, alt_id, fn_dup);
+}
+
+static gpointer _thread_func (gpointer)
+{
+	while (1)
+	{
+		desktop_db *db = NULL;
+		GList *list = g_app_info_get_all ();
+		
+		if (list)
+		{
+			db = g_malloc (sizeof(desktop_db));
+			db->class_table = g_hash_table_new_full (g_str_hash, g_str_equal,
+				g_free, g_free);
+			db->alt_class_table = g_hash_table_new_full (g_str_hash, g_str_equal,
+				g_free, NULL);
+			g_list_foreach (list, _process_app, db);
+			g_list_free_full (list, g_object_unref);
+		}
+		
+		gboolean exit = TRUE;
+		g_mutex_lock (&mutex);
+		if (db)
+		{
+			_desktop_db_free (db_pending);
+			db_pending = db;
+			if (more_work) exit = FALSE;
+		}
+		else error = TRUE;
+		more_work = FALSE;
+		if (exit) thread_running = FALSE;
+		g_cond_signal (&cond);
+		g_mutex_unlock (&mutex);
+		if (exit) break;
+	}
+	
+	return NULL;
+}
+
+static gboolean _start_thread (gpointer)
+{
+	if (!update_pending) return FALSE;
+	g_mutex_lock (&mutex);
+	if (thread_running) more_work = TRUE;
+	else if (!error)
+	{
+		if (thread) g_thread_join (thread);
+		thread_running = TRUE;
+		thread = g_thread_new ("desktop-file-db", _thread_func, NULL);
+	}
+	g_mutex_unlock (&mutex);
+	update_pending = FALSE;
+	return FALSE; // needed to remove timeout
+}
+
+static void _on_apps_changed(GAppInfoMonitor*, void*) {
+	if(update_pending) return;
+	update_pending = TRUE;
+	g_timeout_add_seconds (5, _start_thread, NULL);
+}
+
+
+void gldi_desktop_file_db_init ()
+{
+	update_pending = TRUE;
+	_start_thread (NULL);
+	monitor = g_app_info_monitor_get();
+	g_signal_connect (monitor, "changed", G_CALLBACK(_on_apps_changed), NULL);
+}
+
+void gldi_desktop_file_db_stop (void)
+{
+	if (monitor)
+	{
+		g_object_unref (monitor);
+		monitor = NULL;
+	}
+	update_pending = FALSE;
+	
+	g_mutex_lock (&mutex);
+	more_work = FALSE;
+	g_mutex_unlock (&mutex);
+	
+	if (thread)
+	{
+		g_thread_join (thread);
+		thread = NULL;
+	}
+	_desktop_db_free (db_current);
+	_desktop_db_free (db_pending);
+	db_current = NULL;
+	db_pending = NULL;
+	error = FALSE;
+}
+
+const char *gldi_desktop_file_db_lookup (const char *class)
+{
+	if (!db_current || g_atomic_pointer_get (&db_pending))
+	{
+		// update db_current
+		g_mutex_lock (&mutex);
+		if (!db_pending)
+		{
+			// in this case db_current == NULL, we have to wait for the thread (which should be running)
+			if (!thread_running)
+			{
+				g_mutex_unlock (&mutex);
+				cd_error ("no worker thread!\n");
+				return NULL;
+			}
+			
+			while (!(db_pending || error))
+				g_cond_wait (&cond, &mutex);
+			
+			if (error)
+			{
+				g_mutex_unlock (&mutex);
+				cd_error ("cannot get app database!\n");
+				return NULL;
+			}
+		}
+		
+		// here db_pending is valid, we have to swap with db_current
+		_desktop_db_free (db_current);
+		db_current = db_pending;
+		db_pending = NULL;
+		g_mutex_unlock (&mutex);
+	}
+	
+	const char *ret = g_hash_table_lookup (db_current->class_table, class);
+	if (!ret) ret = g_hash_table_lookup (db_current->alt_class_table, class);
+	
+	return ret;
+}
+
+
+

--- a/src/gldit/cairo-dock-desktop-file-db.h
+++ b/src/gldit/cairo-dock-desktop-file-db.h
@@ -1,0 +1,37 @@
+/**
+* This file is a part of the Cairo-Dock project
+*
+* Copyright : (C) see the 'copyright' file.
+* E-mail    : see the 'copyright' file.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 3
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef CAIRO_DOCK_DESKTOP_FILE_DB_H
+#define CAIRO_DOCK_DESKTOP_FILE_DB_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+void gldi_desktop_file_db_init (void);
+
+void gldi_desktop_file_db_stop (void);
+
+const char *gldi_desktop_file_db_lookup (const char *class);
+
+G_END_DECLS
+
+#endif
+

--- a/src/gldit/cairo-dock-windows-manager.c
+++ b/src/gldit/cairo-dock-windows-manager.c
@@ -406,11 +406,10 @@ gchar* gldi_window_parse_class(const gchar* res_class, const gchar* res_name) {
 			// cClass = g_strdup (res_class);
 		}
 
+		// remove some suffices that can be problematic: .exe, .py (note: cClass is already lowercase here)
+		if (g_str_has_suffix (cClass, ".exe")) cClass[strlen (cClass) - 4] = 0;
+		else if (g_str_has_suffix (cClass, ".py")) cClass[strlen (cClass) - 3] = 0;
 		cairo_dock_remove_version_from_string (cClass);  // we remore number of version (e.g. Openoffice.org-3.1)
-
-//		gchar *str = strchr (cClass, '.');  // we remove all .xxx otherwise we can't detect the lack of extension when looking for an icon (openoffice.org) or it's a problem when looking for an icon (jbrout.py).
-//		if (str != NULL)
-//			*str = '\0';
 		cd_debug ("got an application with class '%s'", cClass);
 	}
 	return cClass;


### PR DESCRIPTION
This allows properly identifying more apps, including cases where the reported app-id / WMClass and the .desktop file name differ.

Also update the README with links to the now updated stable packages and Github Wiki