### PR TITLE
Improvements to matching apps

### DIFF
--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -1679,6 +1679,7 @@ static gchar *_search_desktop_file (const gchar *cDesktopFile, gboolean bReturnK
 	if (cDesktopFile == NULL)
 		return NULL;
 	gchar *cDesktopFileName = NULL;
+	gboolean bPath = FALSE;
 	if (*cDesktopFile == '/') 
 	{
 		if (g_file_test (cDesktopFile, G_FILE_TEST_EXISTS))  // it's a path and it exists.
@@ -1687,6 +1688,7 @@ static gchar *_search_desktop_file (const gchar *cDesktopFile, gboolean bReturnK
 		char *tmp = g_path_get_basename (cDesktopFile);
 		cDesktopFileName = g_ascii_strdown (tmp, -1);
 		g_free (tmp);
+		bPath = TRUE;
 	}
 	else
 	{
@@ -1707,6 +1709,14 @@ static gchar *_search_desktop_file (const gchar *cDesktopFile, gboolean bReturnK
 			g_free (cDesktopFileName);
 			return g_strdup (res);
 		}
+	}
+	else if (bPath)
+	{
+		// if the query was an absolute path, we don't try the heuristics
+		// (we are only interested if the exact same file is found in
+		//  some other location)
+		g_free (cDesktopFileName);
+		return NULL;
 	}
 	
 	// handle potential partial matches

--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -1615,15 +1615,21 @@ static gchar *_search_desktop_file (const gchar *cDesktopFile)  // file, path or
 {
 	if (cDesktopFile == NULL)
 		return NULL;
+	gchar *cDesktopFileName = NULL;
 	if (*cDesktopFile == '/') 
 	{
 		if (g_file_test (cDesktopFile, G_FILE_TEST_EXISTS))  // it's a path and it exists.
 			return g_strdup (cDesktopFile);
-		return NULL; // if we got an absolute path, we require it to be correct
+		// if not found, try searching based on the basename
+		char *tmp = g_path_get_basename (cDesktopFile);
+		cDesktopFileName = g_ascii_strdown (tmp, -1);
+		g_free (tmp);
 	}
-
-	// note: cDesktopFile will already be lowercase if it is an app-id / class
-	gchar *cDesktopFileName = g_ascii_strdown (cDesktopFile, -1);
+	else
+	{
+		// note: cDesktopFile will already be lowercase if it is an app-id / class
+		cDesktopFileName = g_ascii_strdown (cDesktopFile, -1);
+	}
 	// remove the .desktop suffix if it is present
 	gchar *tmp = g_strrstr (cDesktopFileName, ".desktop");
 	if (tmp) *tmp = 0;

--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -155,8 +155,8 @@ static CairoDockClassAppli *cairo_dock_get_class (const gchar *cClass)
 
 static gboolean _cairo_dock_add_inhibitor_to_class (const gchar *cClass, Icon *pIcon)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
-	g_return_val_if_fail (pClassAppli!= NULL, FALSE);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
+	g_return_val_if_fail (pClassAppli != NULL, FALSE);
 
 	g_return_val_if_fail (g_list_find (pClassAppli->pIconsOfClass, pIcon) == NULL, TRUE);
 	pClassAppli->pIconsOfClass = g_list_prepend (pClassAppli->pIconsOfClass, pIcon);
@@ -166,16 +166,16 @@ static gboolean _cairo_dock_add_inhibitor_to_class (const gchar *cClass, Icon *p
 
 CairoDock *cairo_dock_get_class_subdock (const gchar *cClass)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
-	g_return_val_if_fail (pClassAppli!= NULL, NULL);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
+	g_return_val_if_fail (pClassAppli != NULL, NULL);
 
 	return gldi_dock_get (pClassAppli->cDockName);
 }
 
 CairoDock* cairo_dock_create_class_subdock (const gchar *cClass, CairoDock *pParentDock)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
-	g_return_val_if_fail (pClassAppli!= NULL, NULL);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
+	g_return_val_if_fail (pClassAppli != NULL, NULL);
 
 	CairoDock *pDock = gldi_dock_get (pClassAppli->cDockName);
 	if (pDock == NULL)  // cDockName not yet defined, or previous class subdock no longer exists
@@ -190,8 +190,8 @@ CairoDock* cairo_dock_create_class_subdock (const gchar *cClass, CairoDock *pPar
 
 static void cairo_dock_destroy_class_subdock (const gchar *cClass)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
-	g_return_if_fail (pClassAppli!= NULL);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
+	g_return_if_fail (pClassAppli != NULL);
 
 	CairoDock *pDock = gldi_dock_get (pClassAppli->cDockName);
 	if (pDock)
@@ -213,8 +213,8 @@ gboolean cairo_dock_add_appli_icon_to_class (Icon *pIcon)
 		cd_message (" %s doesn't have any class, not good!", pIcon->cName);
 		return FALSE;
 	}
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (pIcon->cClass);
-	g_return_val_if_fail (pClassAppli!= NULL, FALSE);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (pIcon->cClass);
+	g_return_val_if_fail (pClassAppli != NULL, FALSE);
 
 	///if (pClassAppli->iAge == 0)  // age is > 0, so it means we have never set it yet.
 	if (pClassAppli->pAppliOfClass == NULL)  // the first appli of a class defines the age of the class.
@@ -231,8 +231,8 @@ gboolean cairo_dock_remove_appli_from_class (Icon *pIcon)
 	g_return_val_if_fail (pIcon!= NULL, FALSE);
 	cd_debug ("%s (%s, %s)", __func__, pIcon->cClass, pIcon->cName);
 
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (pIcon->cClass);
-	g_return_val_if_fail (pClassAppli!= NULL, FALSE);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (pIcon->cClass);
+	g_return_val_if_fail (pClassAppli != NULL, FALSE);
 
 	pClassAppli->pAppliOfClass = g_list_remove (pClassAppli->pAppliOfClass, pIcon);
 
@@ -241,8 +241,8 @@ gboolean cairo_dock_remove_appli_from_class (Icon *pIcon)
 
 gboolean cairo_dock_set_class_use_xicon (const gchar *cClass, gboolean bUseXIcon)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
-	g_return_val_if_fail (pClassAppli!= NULL, FALSE);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
+	g_return_val_if_fail (pClassAppli != NULL, FALSE);
 
 	if (pClassAppli->bUseXIcon == bUseXIcon)  // nothing to do.
 		return FALSE;
@@ -638,7 +638,7 @@ cairo_surface_t *cairo_dock_create_surface_from_class (const gchar *cClass, int 
 {
 	cd_debug ("%s (%s)", __func__, cClass);
 	// first we try to get an icon from one of the inhibitor.
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
 	if (pClassAppli != NULL)
 	{
 		cd_debug ("bUseXIcon:%d", pClassAppli->bUseXIcon);
@@ -717,7 +717,7 @@ cairo_surface_t *cairo_dock_create_surface_from_class (const gchar *cClass, int 
 /**
 void cairo_dock_update_visibility_on_inhibitors (const gchar *cClass, GldiWindowActor *pAppli, gboolean bIsHidden)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
 	if (pClassAppli != NULL)
 	{
 		GList *pElement;
@@ -741,7 +741,7 @@ void cairo_dock_update_visibility_on_inhibitors (const gchar *cClass, GldiWindow
 
 void cairo_dock_update_activity_on_inhibitors (const gchar *cClass, GldiWindowActor *pAppli)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
 	if (pClassAppli != NULL)
 	{
 		GList *pElement;
@@ -763,7 +763,7 @@ void cairo_dock_update_activity_on_inhibitors (const gchar *cClass, GldiWindowAc
 
 void cairo_dock_update_inactivity_on_inhibitors (const gchar *cClass, GldiWindowActor *pAppli)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
 	if (pClassAppli != NULL)
 	{
 		GList *pElement;
@@ -782,7 +782,7 @@ void cairo_dock_update_inactivity_on_inhibitors (const gchar *cClass, GldiWindow
 
 void cairo_dock_update_name_on_inhibitors (const gchar *cClass, GldiWindowActor *actor, gchar *cNewName)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
 	if (pClassAppli != NULL)
 	{
 		GList *pElement;
@@ -815,7 +815,7 @@ void cairo_dock_update_name_on_inhibitors (const gchar *cClass, GldiWindowActor 
 */
 void gldi_window_foreach_inhibitor (GldiWindowActor *actor, GldiIconRFunc callback, gpointer data)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (actor->cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (actor->cClass);
 	if (pClassAppli != NULL)
 	{
 		Icon *pInhibitorIcon;
@@ -836,9 +836,8 @@ void gldi_window_foreach_inhibitor (GldiWindowActor *actor, GldiIconRFunc callba
 Icon *cairo_dock_get_classmate (Icon *pIcon)  // gets an icon of the same class, that is inside a dock (or will be for an inhibitor), but not inside the class sub-dock
 {
 	cd_debug ("%s (%s)", __func__, pIcon->cClass);
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (pIcon->cClass);
-	if (pClassAppli == NULL)
-		return NULL;
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (pIcon->cClass);
+	g_return_val_if_fail (pClassAppli != NULL, NULL);
 
 	Icon *pFriendIcon = NULL;
 	GList *pElement;
@@ -980,8 +979,8 @@ void cairo_dock_set_overwrite_exceptions (const gchar *cExceptions)
 	int i;
 	for (i = 0; cClassList[i] != NULL; i ++)
 	{
-		pClassAppli = cairo_dock_get_class (cClassList[i]);
-		pClassAppli->bUseXIcon = TRUE;
+		pClassAppli = _cairo_dock_lookup_class_appli (cClassList[i]);
+		if (pClassAppli) pClassAppli->bUseXIcon = TRUE;
 	}
 
 	g_strfreev (cClassList);
@@ -1007,8 +1006,8 @@ void cairo_dock_set_group_exceptions (const gchar *cExceptions)
 	int i;
 	for (i = 0; cClassList[i] != NULL; i ++)
 	{
-		pClassAppli = cairo_dock_get_class (cClassList[i]);
-		pClassAppli->bExpand = TRUE;
+		pClassAppli = _cairo_dock_lookup_class_appli (cClassList[i]);
+		if (pClassAppli) pClassAppli->bExpand = TRUE;
 	}
 
 	g_strfreev (cClassList);
@@ -1029,9 +1028,8 @@ Icon *cairo_dock_get_prev_next_classmate_icon (Icon *pIcon, gboolean bNext)
 
 	//\________________ We are looking in the class of the active window and take the next or previous one.
 	Icon *pNextIcon = NULL;
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (pIcon->cClass);
-	if (pClassAppli == NULL)
-		return NULL;
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (pIcon->cClass);
+	g_return_val_if_fail (pClassAppli != NULL, NULL);
 
 	//\________________ We are looking in icons of apps.
 	Icon *pClassmateIcon;
@@ -1091,7 +1089,7 @@ Icon *cairo_dock_get_prev_next_classmate_icon (Icon *pIcon, gboolean bNext)
 
 Icon *cairo_dock_get_inhibitor (Icon *pIcon, gboolean bOnlyInDock)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (pIcon->cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (pIcon->cClass);
 	if (pClassAppli != NULL)
 	{
 		GList *pElement;
@@ -1226,7 +1224,7 @@ static inline int _get_class_age (CairoDockClassAppli *pClassAppli)
 void cairo_dock_set_class_order_in_dock (Icon *pIcon, CairoDock *pDock)
 {
 	//g_print ("%s (%s, %d)\n", __func__, pIcon->cClass, pIcon->iAge);
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (pIcon->cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (pIcon->cClass);
 	g_return_if_fail (pClassAppli != NULL);
 
 	// Look for an icon of the same class in the dock, to place ourself relatively to it.
@@ -1400,7 +1398,7 @@ void cairo_dock_set_class_order_in_dock (Icon *pIcon, CairoDock *pDock)
 
 void cairo_dock_set_class_order_amongst_applis (Icon *pIcon, CairoDock *pDock)  // set the order of an appli amongst the other applis of a given dock (class sub-dock or main dock).
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (pIcon->cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (pIcon->cClass);
 	g_return_if_fail (pClassAppli != NULL);
 
 	// place the icon amongst the other appli icons of this class, or after the last appli if none.
@@ -2225,7 +2223,7 @@ void cairo_dock_set_data_from_class (const gchar *cClass, Icon *pIcon)
 
 static gboolean _stop_opening_timeout (const gchar *cClass)
 {
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
 	g_return_val_if_fail (pClassAppli != NULL, FALSE);
 	pClassAppli->iSidOpeningTimeout = 0;
 	gldi_class_startup_notify_end (cClass);
@@ -2234,7 +2232,7 @@ static gboolean _stop_opening_timeout (const gchar *cClass)
 void gldi_class_startup_notify (Icon *pIcon)
 {
 	const gchar *cClass = pIcon->cClass;
-	CairoDockClassAppli *pClassAppli = cairo_dock_get_class (cClass);
+	CairoDockClassAppli *pClassAppli = _cairo_dock_lookup_class_appli (cClass);
 	if (! pClassAppli || pClassAppli->bIsLaunching)
 		return;
 

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -586,7 +586,7 @@ static void _cairo_dock_dialog_calculate_aimed_point (Icon *pIcon, GldiContainer
 				*iX = pContainer->iWindowPositionX +
 					pDock->iMaxDockWidth/2
 					- pDock->fFlatDockWidth/2
-					+ pIcon->fXAtRest + pIcon->fWidth/2;
+					+ (pIcon ? pIcon->fXAtRest + pIcon->fWidth/2 : 0);
 					///(pIcon ? (pIcon->fXAtRest + pIcon->fWidth/2) / pDock->fFlatDockWidth * pDock->iMaxDockWidth : 0);
 			}
 			else


### PR DESCRIPTION
 - workaround if the original .desktop file that created a launcher was deleted, but is available elsewhere on the system (partially fixes #41 ?)
 - handle some edge cases better when a .desktop file can be found for an app, but it cannot be matched to its launcher
 - refactor to avoid creating a new `CairoDockClassAppli` when not intended
 - also fix a potential crash when a dialog is created without a corresponding icon