### PR TITLE
fix a crash when changing themes

### DIFF
--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -683,7 +683,7 @@ void cairo_dock_reset_class_table (void)
 {
 	g_hash_table_remove_all (s_hClassTable);
 	g_hash_table_remove_all (s_hAltClass);
-	gldi_desktop_file_db_stop ();
+	// gldi_desktop_file_db_stop (); -- TODO: call this when exiting, but not when loading a new theme !!
 }
 
 


### PR DESCRIPTION
cairo_dock_reset_class_table () can be called whenever the current theme is reloaded / changed, which results in the DB backend also unloaded and then later crashing

TODO: add a separate function for stopping and unloading the DB backend when quiting