### PR TITLE
Update to menu positioning and focus handling

### DIFF
--- a/src/gldit/cairo-dock-core.c
+++ b/src/gldit/cairo-dock-core.c
@@ -183,6 +183,10 @@ bWAYFIRE = TRUE;
 		}
 #endif
 #endif
+
+	gboolean bIsWayland = gldi_container_is_wayland_backend ();
+	gchar *compositor_type = "";
+	if (bIsWayland) compositor_type = g_strdup_printf (" * detected Wayland compositor:  %s\n", gldi_wayland_get_detected_compositor ());
 	
 	gchar *text = g_strdup_printf (
 		"Cairo-Dock version: %s\n"
@@ -202,7 +206,8 @@ bWAYFIRE = TRUE;
 		" * OpenGL:                       %s\n"
 		" * taskbar backend:              %s\n"
 		" * desktop manager backend(s):   %s\n"
-		" * detected desktop environment: %s\n",
+		" * detected desktop environment: %s\n"
+		"%s",
 		GLDI_VERSION,
 		__DATE__, __TIME__,
 		GTK_MAJOR_VERSION, GTK_MINOR_VERSION,
@@ -213,12 +218,13 @@ bWAYFIRE = TRUE;
 		bGTK_LAYER_SHELL ? "yes" : "no",
 		bWAYLAND_PROTOCOLS ? "yes" : "no",
 		bWAYFIRE ? "yes" : "no",
-		gldi_container_is_wayland_backend () ? "Wayland" : "X11",
+		bIsWayland ? "Wayland" : "X11",
 		layer_shell_info ? layer_shell_info : "",
 		g_bUseOpenGL ? gldi_gl_get_backend_name() : "no",
 		gldi_windows_manager_get_name (),
 		gldi_desktop_manager_get_backend_names (),
-		cairo_dock_fm_get_desktop_name ());
+		cairo_dock_fm_get_desktop_name (),
+		compositor_type);
 
 	g_free (layer_shell_info);
 	

--- a/src/gldit/cairo-dock-desktop-manager.c
+++ b/src/gldit/cairo-dock-desktop-manager.c
@@ -115,6 +115,7 @@ gboolean gldi_desktop_present_windows (void)  // scale
 {
 	if (s_backend.present_windows != NULL)
 	{
+		gldi_wayland_release_keyboard (pContainer, GLDI_KEYBOARD_RELEASE_PRESENT_WINDOWS);
 		return s_backend.present_windows ();
 	}
 	return FALSE;

--- a/src/gldit/cairo-dock-desktop-manager.c
+++ b/src/gldit/cairo-dock-desktop-manager.c
@@ -105,7 +105,7 @@ gboolean gldi_desktop_present_class (const gchar *cClass, GldiContainer *pContai
 	g_return_val_if_fail (cClass != NULL, FALSE);
 	if (s_backend.present_class != NULL)
 	{
-		gldi_wayland_release_keyboard (pContainer);
+		gldi_wayland_release_keyboard (pContainer, GLDI_KEYBOARD_RELEASE_PRESENT_WINDOWS);
 		return s_backend.present_class (cClass);
 	}
 	return FALSE;

--- a/src/gldit/cairo-dock-menu.c
+++ b/src/gldit/cairo-dock-menu.c
@@ -483,7 +483,7 @@ static void _on_menu_deactivated (GtkMenuShell *pMenu, G_GNUC_UNUSED gpointer da
 	}
 	if (gldi_container_is_wayland_backend ())
 	{
-		gldi_wayland_release_keyboard (pContainer);
+		gldi_wayland_release_keyboard (pContainer, GLDI_KEYBOARD_RELEASE_MENU_CLOSED);
 	}
 }
 

--- a/src/implementations/cairo-dock-cosmic-toplevel.c
+++ b/src/implementations/cairo-dock-cosmic-toplevel.c
@@ -198,6 +198,7 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED wfthandle *handle
 {
 	if (!data) return;
 	GldiWaylandWindowActor* wactor = (GldiWaylandWindowActor*)data;
+	gboolean activated_pending = FALSE;
 	gboolean maximized_pending = FALSE;
 	gboolean minimized_pending = FALSE;
 	gboolean fullscreen_pending = FALSE;
@@ -207,7 +208,7 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED wfthandle *handle
 	{
 		if (stdata[i] == ZCOSMIC_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED)
 		{
-			gldi_wayland_wm_activated (wactor, FALSE);
+			activated_pending = TRUE;
 			gldi_wayland_wm_stack_on_top ((GldiWindowActor*)wactor);
 		}
 		else if (stdata[i] == ZCOSMIC_TOPLEVEL_HANDLE_V1_STATE_MAXIMIZED)
@@ -218,6 +219,7 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED wfthandle *handle
 			fullscreen_pending = TRUE;
 	}
 	
+	gldi_wayland_wm_activated (wactor, activated_pending, FALSE);
 	gldi_wayland_wm_maximized_changed (wactor, maximized_pending, FALSE);
 	gldi_wayland_wm_minimized_changed (wactor, minimized_pending, FALSE);
 	gldi_wayland_wm_fullscreen_changed (wactor, fullscreen_pending, FALSE);

--- a/src/implementations/cairo-dock-foreign-toplevel.c
+++ b/src/implementations/cairo-dock-foreign-toplevel.c
@@ -145,6 +145,7 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED wfthandle *handle
 {
 	if (!data) return;
 	GldiWaylandWindowActor* wactor = (GldiWaylandWindowActor*)data;
+	gboolean activated_pending = FALSE;
 	gboolean maximized_pending = FALSE;
 	gboolean minimized_pending = FALSE;
 	gboolean fullscreen_pending = FALSE;
@@ -153,7 +154,7 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED wfthandle *handle
 	for (i = 0; i*sizeof(uint32_t) < state->size; i++)
 	{
 		if (stdata[i] == ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED)
-			gldi_wayland_wm_activated (wactor, FALSE);
+			activated_pending = TRUE;
 		else if (stdata[i] == ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MAXIMIZED)
 			maximized_pending = TRUE;
 		else if (stdata[i] == ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MINIMIZED)
@@ -162,6 +163,7 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED wfthandle *handle
 			fullscreen_pending = TRUE;
 	}
 	
+	gldi_wayland_wm_activated (wactor, activated_pending, FALSE);
 	gldi_wayland_wm_maximized_changed (wactor, maximized_pending, FALSE);
 	gldi_wayland_wm_minimized_changed (wactor, minimized_pending, FALSE);
 	gldi_wayland_wm_fullscreen_changed (wactor, fullscreen_pending, FALSE);

--- a/src/implementations/cairo-dock-plasma-window-manager.c
+++ b/src/implementations/cairo-dock-plasma-window-manager.c
@@ -248,16 +248,17 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED pwhandle *handle,
 	gldi_wayland_wm_sticky_changed (wactor, !!(flags & ORG_KDE_PLASMA_WINDOW_MANAGEMENT_STATE_ON_ALL_DESKTOPS), FALSE);
 	if (flags & ORG_KDE_PLASMA_WINDOW_MANAGEMENT_STATE_ACTIVE)
 	{
-		gldi_wayland_wm_activated (wactor, FALSE);
+		gldi_wayland_wm_activated (wactor, TRUE, FALSE);
 		// versions >= 12 and < 17 have stacking_order_uuid_changed which
 		// is handled separately below; for versions >= 17, we would need
 		// to support stacking_order_changed_2
 		if (protocol_version < 12 || protocol_version >= 17)
 			gldi_wayland_wm_stack_on_top ((GldiWindowActor*)wactor);
 	}
+	else gldi_wayland_wm_activated (wactor, FALSE, FALSE);
 	if (wactor->init_done) gldi_wayland_wm_done (wactor);
 }
-	
+
 
 /* this is sent after the initial state has been sent, i.e. only once */
 static void _gldi_toplevel_done_cb ( void *data, G_GNUC_UNUSED pwhandle *handle)

--- a/src/implementations/cairo-dock-wayland-hotspots.c
+++ b/src/implementations/cairo-dock-wayland-hotspots.c
@@ -464,9 +464,9 @@ gboolean gldi_wayland_hotspots_match_protocol (uint32_t id, const char *interfac
 }
 
 /// Try to init based on the protocols found
-gboolean gldi_wayland_hotspots_try_init (struct wl_registry *registry)
+GldiWaylandHotspotsType gldi_wayland_hotspots_try_init (struct wl_registry *registry)
 {
-	gboolean can_init = FALSE;
+	GldiWaylandHotspotsType type = GLDI_WAYLAND_HOTSPOTS_NONE;
 	
 #ifdef HAVE_WAYLAND_PROTOCOLS
 	if (wf_shell_found)
@@ -482,7 +482,7 @@ gboolean gldi_wayland_hotspots_try_init (struct wl_registry *registry)
 			s_backend.output_removed = _wf_shell_output_removed;
 			s_backend.update_hotspot = _wf_shell_update_dock_hotspots;
 			s_backend.destroy_hotspot = _wf_shell_destroy_hotspot;
-			can_init = TRUE;
+			type = GLDI_WAYLAND_HOTSPOTS_WAYFIRE;
 		}
 		else cd_message ("Could not bind zwf-shell!");
     }
@@ -492,17 +492,17 @@ gboolean gldi_wayland_hotspots_try_init (struct wl_registry *registry)
 #endif
 
 #ifdef HAVE_GTK_LAYER_SHELL
-    if (!can_init && !g_bDisableLayerShell && gtk_layer_is_supported ())
+    if (type == GLDI_WAYLAND_HOTSPOTS_NONE && !g_bDisableLayerShell && gtk_layer_is_supported ())
     {
 		s_backend.new_output = _layer_shell_new_output;
 		s_backend.output_removed = _layer_shell_output_removed;
 		s_backend.update_hotspot = _layer_shell_update_hotspot;
 		s_backend.destroy_hotspot = _layer_shell_destroy_hotspot;
-		can_init = TRUE;
+		type = GLDI_WAYLAND_HOTSPOTS_LAYER_SHELL;
 	}
 #endif
 	
-    if (can_init)
+    if (type != GLDI_WAYLAND_HOTSPOTS_NONE)
     {
 		gldi_object_register_notification (&myWaylandMgr, NOTIFICATION_WAYLAND_MONITOR_ADDED, (GldiNotificationFunc)_monitor_added, GLDI_RUN_FIRST, NULL);
 		gldi_object_register_notification (&myWaylandMgr, NOTIFICATION_WAYLAND_MONITOR_REMOVED, (GldiNotificationFunc)_monitor_removed, GLDI_RUN_FIRST, NULL);
@@ -512,7 +512,7 @@ gboolean gldi_wayland_hotspots_try_init (struct wl_registry *registry)
 		int i;
 		for (i = 0; i < iNumMonitors; i++) _monitor_added (NULL, monitors[i]);
 	}
-    return can_init;
+    return type;
 }
 
 #endif // HAVE_WAYLAND

--- a/src/implementations/cairo-dock-wayland-hotspots.h
+++ b/src/implementations/cairo-dock-wayland-hotspots.h
@@ -33,8 +33,14 @@
 /// Try to match Wayland protocols that we need to use
 gboolean gldi_wayland_hotspots_match_protocol (uint32_t id, const char *interface, uint32_t version);
 
+typedef enum {
+	GLDI_WAYLAND_HOTSPOTS_NONE, // we could not init support for hotspots
+	GLDI_WAYLAND_HOTSPOTS_LAYER_SHELL, // we use a 1 pixel tall layer shell windows at the screen edges
+	GLDI_WAYLAND_HOTSPOTS_WAYFIRE // we use wf-shell
+} GldiWaylandHotspotsType;
+
 /// Initialize the interface for monitoring hotspots
-gboolean gldi_wayland_hotspots_try_init (struct wl_registry *registry);
+GldiWaylandHotspotsType gldi_wayland_hotspots_try_init (struct wl_registry *registry);
 
 /// Update the hotspots we are listening to (based on the configuration of all root docks)
 void gldi_wayland_hotspots_update (void);

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -75,6 +75,36 @@ static struct wl_display *s_pDisplay = NULL;
 static struct wl_compositor* s_pCompositor = NULL;
 static gboolean s_bHave_Layer_Shell = FALSE;
 
+
+// detect and store the compositor that we are running under
+// this can be used to handle quirks
+typedef enum {
+	WAYLAND_COMPOSITOR_NONE, // we are not running under Wayland
+	WAYLAND_COMPOSITOR_UNKNOWN, // unable to detect compositor
+	WAYLAND_COMPOSITOR_GENERIC, // compositor which does not require specific quirks (functionally same as UNKNOWN)
+	WAYLAND_COMPOSITOR_WAYFIRE,
+	WAYLAND_COMPOSITOR_KWIN
+} GldiWaylandCompositorType;
+
+static GldiWaylandCompositorType s_CompositorType = WAYLAND_COMPOSITOR_NONE;
+
+
+static void _try_detect_compositor (void)
+{
+	const char *dmb_names = gldi_desktop_manager_get_backend_names ();
+	if (dmb_names)
+	{
+		if (strstr (dmb_names, "Wayfire"))
+			s_CompositorType = WAYLAND_COMPOSITOR_WAYFIRE;
+		else if (strstr (dmb_names, "plasma"))
+			s_CompositorType = WAYLAND_COMPOSITOR_KWIN;
+		else if (strstr (dmb_names, "KWin"))
+			s_CompositorType = WAYLAND_COMPOSITOR_KWIN;
+		else if (strstr (dmb_names, "cosmic")) // will also match Labwc which implements the cosmic workspaces protocols
+			s_CompositorType = WAYLAND_COMPOSITOR_GENERIC;
+	}
+}
+
 // manage screens -- instead of wl_output, we use GdkDisplay and GdkMonitors
 // list of monitors -- corresponds to pScreens in g_desktopGeometry from
 // cairo-dock-desktop-manager.c, and kept in sync with that
@@ -441,14 +471,53 @@ void gldi_wayland_grab_keyboard (GldiContainer *pContainer)
 #endif
 }
 
-void gldi_wayland_release_keyboard ( G_GNUC_UNUSED GldiContainer *pContainer)
+
+static void _release_keyboard_activate (void)
 {
 	GldiWindowActor *actor = gldi_windows_get_active ();
 	if (actor && !actor->bIsHidden) {
 		if (gldi_window_manager_can_track_workspaces () && !gldi_window_is_on_current_desktop (actor))
 			return;
-		// TODO: avoid activating a window not on the current workspace in other cases!
 		gldi_window_show (actor);
+	}
+}
+
+static void _release_keyboard_layer_shell (GldiContainer *pContainer)
+{
+#ifdef HAVE_GTK_LAYER_SHELL
+	GtkWindow* window = GTK_WINDOW (pContainer->pWidget);
+	gtk_layer_set_keyboard_mode (window, GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
+	wl_surface_commit (gdk_wayland_window_get_wl_surface (
+		gldi_container_get_gdk_window (pContainer)));
+	gtk_layer_set_keyboard_mode (window, GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+#endif	
+}
+
+void gldi_wayland_release_keyboard (GldiContainer *pContainer, GldiWaylandReleaseKeyboardReason reason)
+{
+	if (s_CompositorType == WAYLAND_COMPOSITOR_NONE)
+		return; // not a Wayland session
+	
+	if (s_CompositorType == WAYLAND_COMPOSITOR_UNKNOWN)
+		_try_detect_compositor ();
+	
+	if (s_CompositorType != WAYLAND_COMPOSITOR_WAYFIRE && reason == GLDI_KEYBOARD_RELEASE_PRESENT_WINDOWS)
+		return; // extra keyboard release in this case is only needed on Wayfire
+	
+	switch (s_CompositorType)
+	{
+		// note: NONE is handled above already
+		case WAYLAND_COMPOSITOR_WAYFIRE:
+			if (reason == GLDI_KEYBOARD_RELEASE_PRESENT_WINDOWS)
+				_release_keyboard_layer_shell (pContainer); // depends on https://github.com/WayfireWM/wayfire/pull/2530
+			break; // no need to do anything when closing menus
+		case WAYLAND_COMPOSITOR_KWIN:
+			_release_keyboard_activate ();
+			break;
+		default: // generic and unknown
+			//!! TODO: Cosmic also needs the activate method?
+			_release_keyboard_layer_shell (pContainer);
+			break;
 	}
 }
 
@@ -597,19 +666,33 @@ static void init (void)
 		}
 	}
 #endif
-	if (gldi_wayland_hotspots_try_init (registry))
+	GldiWaylandHotspotsType hotspots_type = gldi_wayland_hotspots_try_init (registry);
+
+	if (hotspots_type != GLDI_WAYLAND_HOTSPOTS_NONE)
+	{
 		cmb.update_polling_screen_edge = gldi_wayland_hotspots_update;
+		if (hotspots_type == GLDI_WAYLAND_HOTSPOTS_WAYFIRE)
+			s_CompositorType = WAYLAND_COMPOSITOR_WAYFIRE;
+	}
 #ifdef HAVE_WAYLAND_PROTOCOLS
 	gboolean bCosmic = gldi_cosmic_toplevel_try_init (registry);
-	if (!bCosmic) if (!gldi_plasma_window_manager_try_init (registry))
-			gldi_wlr_foreign_toplevel_try_init (registry);
 	if (bCosmic)
 	{
+		if (s_CompositorType != WAYLAND_COMPOSITOR_UNKNOWN)
+			cd_warning ("inconsistent compositor types detected!");
+		s_CompositorType = WAYLAND_COMPOSITOR_GENERIC; // Cosmic is treated as generic for now
 		if (!gldi_cosmic_workspaces_try_init (registry))
 			gldi_plasma_virtual_desktop_try_init (registry);
 	}
 	else
 	{
+		if (gldi_plasma_window_manager_try_init (registry))
+		{
+			if (s_CompositorType != WAYLAND_COMPOSITOR_UNKNOWN)
+				cd_warning ("inconsistent compositor types detected!");
+			s_CompositorType = WAYLAND_COMPOSITOR_KWIN;
+		}
+		else gldi_wlr_foreign_toplevel_try_init (registry);
 		if (!gldi_plasma_virtual_desktop_try_init (registry))
 			gldi_cosmic_workspaces_try_init (registry);
 	}
@@ -638,6 +721,7 @@ void gldi_register_wayland_manager (void)
 		return;
 	}
 	
+	s_CompositorType = WAYLAND_COMPOSITOR_UNKNOWN;
 	g_desktopGeometry.iNbDesktops = g_desktopGeometry.iNbViewportX = g_desktopGeometry.iNbViewportY = 1;
 	
 	// Manager
@@ -689,6 +773,28 @@ gboolean gldi_wayland_manager_have_layer_shell ()
 	return s_bHave_Layer_Shell;
 }
 
+const gchar *gldi_wayland_get_detected_compositor (void)
+{
+	switch (s_CompositorType)
+	{
+		case WAYLAND_COMPOSITOR_NONE:
+			return "none";
+		case WAYLAND_COMPOSITOR_KWIN:
+			return "KWin";
+		case WAYLAND_COMPOSITOR_WAYFIRE:
+			return "Wayfire";
+		case WAYLAND_COMPOSITOR_GENERIC:
+			return "generic";
+		case WAYLAND_COMPOSITOR_UNKNOWN:
+			// try to detect based on the desktop manager backend
+			_try_detect_compositor ();
+			if (s_CompositorType != WAYLAND_COMPOSITOR_UNKNOWN)
+				return gldi_wayland_get_detected_compositor ();
+			break;
+	}
+	return "unknown";
+}
+
 #else
 #include "cairo-dock-log.h"
 #include "cairo-dock-container.h"
@@ -703,7 +809,12 @@ gboolean gldi_wayland_manager_have_layer_shell ()
 	return FALSE;
 }
 
-void gldi_wayland_grab_keyboard ( G_GNUC_UNUSED GldiContainer *pContainer) { }
-void gldi_wayland_release_keyboard ( G_GNUC_UNUSED GldiContainer *pContainer) { }
+void gldi_wayland_grab_keyboard (GldiContainer*) { }
+void gldi_wayland_release_keyboard (GldiContainer*, GldiWaylandReleaseKeyboardReason) { }
+
+const gchar *gldi_wayland_get_detected_compositor (void)
+{
+	return "none";
+}
 
 #endif

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -83,7 +83,8 @@ typedef enum {
 	WAYLAND_COMPOSITOR_UNKNOWN, // unable to detect compositor
 	WAYLAND_COMPOSITOR_GENERIC, // compositor which does not require specific quirks (functionally same as UNKNOWN)
 	WAYLAND_COMPOSITOR_WAYFIRE,
-	WAYLAND_COMPOSITOR_KWIN
+	WAYLAND_COMPOSITOR_KWIN,
+	WAYLAND_COMPOSITOR_COSMIC
 } GldiWaylandCompositorType;
 
 static GldiWaylandCompositorType s_CompositorType = WAYLAND_COMPOSITOR_NONE;
@@ -499,10 +500,10 @@ void gldi_wayland_release_keyboard (GldiContainer *pContainer, GldiWaylandReleas
 				_release_keyboard_layer_shell (pContainer); // depends on https://github.com/WayfireWM/wayfire/pull/2530
 			break; // no need to do anything when closing menus
 		case WAYLAND_COMPOSITOR_KWIN:
+		case WAYLAND_COMPOSITOR_COSMIC:
 			_release_keyboard_activate ();
 			break;
 		default: // generic and unknown
-			//!! TODO: Cosmic also needs the activate method?
 			_release_keyboard_layer_shell (pContainer);
 			break;
 	}
@@ -667,7 +668,7 @@ static void init (void)
 	{
 		if (s_CompositorType != WAYLAND_COMPOSITOR_UNKNOWN)
 			cd_warning ("inconsistent compositor types detected!");
-		s_CompositorType = WAYLAND_COMPOSITOR_GENERIC; // Cosmic is treated as generic for now
+		s_CompositorType = WAYLAND_COMPOSITOR_COSMIC;
 		if (!gldi_cosmic_workspaces_try_init (registry))
 			gldi_plasma_virtual_desktop_try_init (registry);
 	}
@@ -758,6 +759,8 @@ const gchar *gldi_wayland_get_detected_compositor (void)
 			return "KWin";
 		case WAYLAND_COMPOSITOR_WAYFIRE:
 			return "Wayfire";
+		case WAYLAND_COMPOSITOR_COSMIC:
+			return "Cosmic";
 		case WAYLAND_COMPOSITOR_GENERIC:
 			return "generic";
 		case WAYLAND_COMPOSITOR_UNKNOWN:

--- a/src/implementations/cairo-dock-wayland-manager.h
+++ b/src/implementations/cairo-dock-wayland-manager.h
@@ -64,8 +64,17 @@ GdkMonitor *const *gldi_wayland_get_monitors (int *iNumMonitors);
 /// these work quite differently from X11 and can result in a disorienting
 /// user experience. This way, these can be used only in situations where
 /// necessary and where their usefulness can be properly tested.
+
+typedef enum {
+	GLDI_KEYBOARD_RELEASE_MENU_CLOSED,
+	GLDI_KEYBOARD_RELEASE_PRESENT_WINDOWS
+} GldiWaylandReleaseKeyboardReason;
+
 void gldi_wayland_grab_keyboard (GldiContainer *pContainer);
-void gldi_wayland_release_keyboard (GldiContainer *pContainer);
+void gldi_wayland_release_keyboard (GldiContainer *pContainer, GldiWaylandReleaseKeyboardReason reason);
+
+/// Get the name of the Wayland compositor that was detected
+const gchar *gldi_wayland_get_detected_compositor (void);
 
 G_END_DECLS
 #endif

--- a/src/implementations/cairo-dock-wayland-wm.c
+++ b/src/implementations/cairo-dock-wayland-wm.c
@@ -34,8 +34,10 @@ GldiObjectManager myWaylandWMObjectMgr;
 
 static void (*s_handle_destroy_cb)(gpointer handle) = NULL;
 
-/* current active window -- last one to receive activated signal */
+/* current active window */
 static GldiWindowActor* s_pActiveWindow = NULL;
+/* last window to receive activated signal, might have been deactivated by now */
+static GldiWindowActor* s_pLastActiveWindow = NULL;
 /* maybe new active window -- this is set if the activated signal is
  * received for a window that is not "created" yet, i.e. has not done
  * the initial init yet or has a parent */
@@ -307,6 +309,7 @@ void gldi_wayland_wm_done (GldiWaylandWindowActor *wactor)
 				if (actor->bDisplayed) gldi_object_notify (&myWindowObjectMgr, NOTIFICATION_WINDOW_DESTROYED, actor);
 				if (actor == s_pSelf) s_pSelf = NULL;
 				if (actor == s_pActiveWindow) s_pActiveWindow = NULL;
+				if (actor == s_pLastActiveWindow) s_pLastActiveWindow = NULL;
 				if (actor == s_pMaybeActiveWindow) s_pMaybeActiveWindow = NULL;
 				gldi_object_unref (GLDI_OBJECT(actor));
 				break;
@@ -368,6 +371,7 @@ void gldi_wayland_wm_done (GldiWaylandWindowActor *wactor)
 				gldi_object_notify (&myWindowObjectMgr, NOTIFICATION_WINDOW_DESTROYED, actor);
 				if (actor == s_pSelf) s_pSelf = NULL;
 				if (actor == s_pActiveWindow) s_pActiveWindow = NULL;
+				if (actor == s_pLastActiveWindow) s_pLastActiveWindow = NULL;
 				if (actor == s_pMaybeActiveWindow) s_pMaybeActiveWindow = NULL;
 				continue;
 			}
@@ -407,6 +411,7 @@ void gldi_wayland_wm_done (GldiWaylandWindowActor *wactor)
 				if (s_pActiveWindow != actor)
 				{
 					s_pActiveWindow = actor;
+					s_pLastActiveWindow = actor;
 					bUnfocused = FALSE;
 					gldi_object_notify (&myWindowObjectMgr, NOTIFICATION_WINDOW_ACTIVATED, actor);
 				}
@@ -473,6 +478,11 @@ void gldi_wayland_wm_stack_on_top (GldiWindowActor *actor)
 GldiWindowActor* gldi_wayland_wm_get_active_window ()
 {
 	return s_pActiveWindow;
+}
+
+GldiWindowActor* gldi_wayland_wm_get_last_active_window ()
+{
+	return s_pLastActiveWindow;
 }
 
 GldiWaylandWindowActor* gldi_wayland_wm_new_toplevel (gpointer handle)

--- a/src/implementations/cairo-dock-wayland-wm.h
+++ b/src/implementations/cairo-dock-wayland-wm.h
@@ -77,6 +77,8 @@ void gldi_wayland_wm_done (GldiWaylandWindowActor *wactor);
 
 GldiWindowActor* gldi_wayland_wm_get_active_window ();
 
+GldiWindowActor* gldi_wayland_wm_get_last_active_window ();
+
 GldiWindowActor* gldi_wayland_wm_pick_window (GtkWindow *pParentWindow);
 
 /** Change the stacking order such that actor is on top. Does not send

--- a/src/implementations/cairo-dock-wayland-wm.h
+++ b/src/implementations/cairo-dock-wayland-wm.h
@@ -44,6 +44,7 @@ struct _GldiWaylandWindowActor {
 	gboolean skip_taskbar; // should not be shown in taskbar (only KDE)
 	gboolean sticky_pending; // sticky state received (only KDE)
 	gboolean close_pending; // this window has been closed
+	gboolean unfocused_pending; // this window has lost focus
 	
 	gboolean init_done; // initial state has been configured
 	gboolean in_queue; // this actor has been added to the s_pending_queue
@@ -68,7 +69,7 @@ void gldi_wayland_wm_fullscreen_changed (GldiWaylandWindowActor *wactor, gboolea
 void gldi_wayland_wm_attention_changed (GldiWaylandWindowActor *wactor, gboolean attention, gboolean notify);
 void gldi_wayland_wm_skip_changed (GldiWaylandWindowActor *wactor, gboolean skip, gboolean notify);
 void gldi_wayland_wm_sticky_changed (GldiWaylandWindowActor *wactor, gboolean sticky, gboolean notify);
-void gldi_wayland_wm_activated (GldiWaylandWindowActor *wactor, gboolean notify);
+void gldi_wayland_wm_activated (GldiWaylandWindowActor *wactor, gboolean activated, gboolean notify);
 
 void gldi_wayland_wm_closed (GldiWaylandWindowActor *wactor, gboolean notify);
 


### PR DESCRIPTION
Do not use relative positioning, avoiding the hack of hiding and re-showing the menu to adjust its position. Also include keyboard focus handling on Wayland with compositor-specific workarounds.