### PR TITLE
Kwin integration updates

### DIFF
--- a/src/implementations/cairo-dock-X-manager.c
+++ b/src/implementations/cairo-dock-X-manager.c
@@ -1535,6 +1535,16 @@ static void _adjust_aimed_point (const Icon *pIcon, GtkWidget *pWidget,
 	}
 }
 
+unsigned long gldi_X_manager_get_window_xid (GldiWindowActor *actor)
+{
+	if (gldi_object_is_manager_child (GLDI_OBJECT(actor), &myXObjectMgr))
+	{
+		GldiXWindowActor *xactor = (GldiXWindowActor*)actor;
+		return xactor->Xid; // Window defined as unsigned long or unsigned int in X.h or Xmd.h
+	}
+	return 0; // None
+}
+
   ////////////
  /// INIT ///
 ////////////

--- a/src/implementations/cairo-dock-X-manager.h
+++ b/src/implementations/cairo-dock-X-manager.h
@@ -32,5 +32,7 @@ G_BEGIN_DECLS
 
 void gldi_register_X_manager (void);
 
+unsigned long gldi_X_manager_get_window_xid (GldiWindowActor *actor);
+
 G_END_DECLS
 #endif

--- a/src/implementations/cairo-dock-plasma-window-manager.c
+++ b/src/implementations/cairo-dock-plasma-window-manager.c
@@ -549,3 +549,13 @@ gboolean gldi_plasma_window_manager_try_init (struct wl_registry *registry)
     return FALSE;
 }
 
+const char *gldi_plasma_window_manager_get_uuid (GldiWindowActor *actor)
+{
+	if (gldi_object_is_manager_child (GLDI_OBJECT(actor), &myPlasmaWindowObjectMgr))
+	{
+		GldiPlasmaWindowActor *pactor = (GldiPlasmaWindowActor*)actor;
+		return pactor->uuid;
+	}
+	return NULL;
+}
+

--- a/src/implementations/cairo-dock-plasma-window-manager.h
+++ b/src/implementations/cairo-dock-plasma-window-manager.h
@@ -31,4 +31,6 @@
 gboolean gldi_plasma_window_manager_match_protocol (uint32_t id, const char *interface, uint32_t version);
 gboolean gldi_plasma_window_manager_try_init (struct wl_registry *registry);
 
+const char *gldi_plasma_window_manager_get_uuid (GldiWindowActor *actor);
+
 #endif


### PR DESCRIPTION
This makes the implemented functions (present windows & class, show desktop, "widget layer") work on KWin 5, both X11 and Wayland. Untested on KWin 6, but will likely work as well.