### PR TITLE
rework launch_command() functions + small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include ("${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/GNUInstallDirs.cmake")
 ########### project ###############
 
 project ("cairo-dock")
-set (VERSION "3.5.99.beta5") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.5.99.beta6") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/src/cairo-dock-user-interaction.c
+++ b/src/cairo-dock-user-interaction.c
@@ -362,7 +362,17 @@ gboolean cairo_dock_notification_drop_data_selection (G_GNUC_UNUSED gpointer pUs
 			if (bIsSpace) g_free (data[i]);
 			else
 			{
-				if (i != j) data[j] = data[i];
+				gchar *tmp3 = NULL;
+				if (data[i][0] == '/')
+				{
+					// convert absolute paths to URI style (if it is not an
+					// absolute path, we cannot do much, just hope that the
+					// app can interpret it as a command line argument)
+					tmp3 = data[i];
+					data[j] = g_strdup_printf ("file://%s", tmp3);
+					g_free (tmp3);
+				}
+				else if (i != j) data[j] = data[i];
 				j++;
 			}
 		}

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -174,7 +174,7 @@ static gboolean _cairo_dock_successful_launch (gpointer data)
 }
 static gboolean _cairo_dock_first_launch_setup (G_GNUC_UNUSED gpointer data)
 {
-	cairo_dock_launch_command (CAIRO_DOCK_SHARE_DATA_DIR"/scripts/initial-setup.sh");
+	cairo_dock_launch_command_single (CAIRO_DOCK_SHARE_DATA_DIR"/scripts/initial-setup.sh");
 	return FALSE;
 }
 static void _cairo_dock_quit (G_GNUC_UNUSED int signal)

--- a/src/gldit/cairo-dock-applet-facility.c
+++ b/src/gldit/cairo-dock-applet-facility.c
@@ -208,20 +208,25 @@ void cairo_dock_play_sound (const gchar *cSoundPath)
 		return;
 	}
 	
-	gchar *cSoundCommand = NULL;
+	const gchar *args[] = {NULL, NULL, NULL, NULL};
 	if (g_file_test ("/usr/bin/paplay", G_FILE_TEST_EXISTS))
-		cSoundCommand = g_strdup_printf("paplay --client-name=cairo-dock \"%s\"", cSoundPath);
-
+	{
+		args[0] = "/usr/bin/paplay";
+		args[1] = "--client-name=cairo-dock";
+		args[2] = cSoundPath;
+	}
 	else if (g_file_test ("/usr/bin/aplay", G_FILE_TEST_EXISTS))
-		cSoundCommand = g_strdup_printf("aplay \"%s\"", cSoundPath);
-
+	{
+		args[0] = "/usr/bin/aplay";
+		args[1] = cSoundPath;
+	}
 	else if (g_file_test ("/usr/bin/play", G_FILE_TEST_EXISTS))
-		cSoundCommand = g_strdup_printf("play \"%s\"", cSoundPath);
+	{
+		args[0] = "/usr/bin/play";
+		args[1] = cSoundPath;
+	}
 	
-	
-	cairo_dock_launch_command (cSoundCommand);
-	
-	g_free (cSoundCommand);
+	if (args[0]) cairo_dock_launch_command_argv (args);
 }
 
 // should be in gnome-integration if needed...

--- a/src/gldit/cairo-dock-application-facility.c
+++ b/src/gldit/cairo-dock-application-facility.c
@@ -34,7 +34,6 @@
 #include "cairo-dock-desktop-manager.h"
 #include "cairo-dock-indicator-manager.h"  // myIndicatorsParam.bUseClassIndic
 #include "cairo-dock-class-icon-manager.h"  // gldi_class_icon_new
-#include "cairo-dock-utils.h"  // cairo_dock_launch_command_full
 #include "cairo-dock-application-facility.h"
 
 extern CairoDock *g_pMainDock;

--- a/src/gldit/cairo-dock-desktop-manager.c
+++ b/src/gldit/cairo-dock-desktop-manager.c
@@ -111,10 +111,11 @@ gboolean gldi_desktop_present_class (const gchar *cClass, GldiContainer *pContai
 	return FALSE;
 }
 
-gboolean gldi_desktop_present_windows (void)  // scale
+gboolean gldi_desktop_present_windows (GldiContainer *pContainer)  // scale
 {
 	if (s_backend.present_windows != NULL)
 	{
+		gldi_wayland_release_keyboard (pContainer, GLDI_KEYBOARD_RELEASE_PRESENT_WINDOWS);
 		return s_backend.present_windows ();
 	}
 	return FALSE;

--- a/src/gldit/cairo-dock-desktop-manager.h
+++ b/src/gldit/cairo-dock-desktop-manager.h
@@ -191,7 +191,7 @@ gboolean gldi_desktop_present_class (const gchar *cClass, GldiContainer *pContai
 /** Present all the windows of the current desktop.
 *@return TRUE on success
 */
-gboolean gldi_desktop_present_windows (void);
+gboolean gldi_desktop_present_windows (GldiContainer *pContainer);
 
 /** Present all the desktops.
 *@return TRUE on success

--- a/src/gldit/cairo-dock-file-manager.h
+++ b/src/gldit/cairo-dock-file-manager.h
@@ -202,7 +202,7 @@ gboolean cairo_dock_fm_move_file (const gchar *cURI, const gchar *cDirectoryURI)
 */
 gboolean cairo_dock_fm_create_file (const gchar *cURI, gboolean bDirectory);
 
-/** Get the list of applications that can open a given file. Returns a list of strings arrays : {name, command, icon}.
+/** Get the list of applications that can open a given file. Returns a list of GAppInfo
 */
 GList *cairo_dock_fm_list_apps_for_file (const gchar *cURI);
 
@@ -280,6 +280,26 @@ gboolean cairo_dock_fm_monitor_pid (const gchar *cProcessName, gboolean bCheckSa
 const gchar *cairo_dock_fm_get_desktop_name (void);
 
 void gldi_register_desktop_environment_manager (void);
+
+typedef void (*CairoDockFMOpenedWithCallback) (gpointer ptr);
+/** Create a submenu for presenting options to open a file and add it to the given menu.
+ * @param pAppList a list with GAppInfo elements to add to the submenu (e.g. the return
+ *        value of cairo_dock_fm_list_apps_for_file ()). Owned by the caller, but apps
+ *        added to the menu will be refed, so can be freed.
+ * @param cPath path of the file to open
+ * @param pMenu menu to add a submenu to
+ * @param cLabel label of the submenu item
+ * @param cImage stock image to use with the label
+ * @param pCallback an optional callback function to call when the app was launched (can be NULL)
+ * @param user_data data to pass to pCallback
+ * @return TRUE if the submenu was successfully created and added to pMenu
+ * 
+ * Note: the created submenu is managed internally and will be freed when the menu is destroyed. If given,
+ * user_data should remain valid while the menu is open. The callback function is only called if the app
+ * is launched, so it is possible that it is never called.
+ */
+gboolean cairo_dock_fm_add_open_with_submenu (GList *pAppList, const gchar *cPath, GtkWidget *pMenu, const gchar *cLabel,
+	const gchar *cImage, CairoDockFMOpenedWithCallback pCallback, gpointer user_data);
 
 G_END_DECLS
 #endif

--- a/src/gldit/cairo-dock-gui-factory.c
+++ b/src/gldit/cairo-dock-gui-factory.c
@@ -30,7 +30,6 @@
 #include "cairo-dock-struct.h"
 #include "cairo-dock-module-manager.h"
 #include "cairo-dock-log.h"
-#include "cairo-dock-utils.h"  // cairo_dock_launch_command_sync
 #include "cairo-dock-animations.h"
 #include "cairo-dock-gui-manager.h"
 #include "cairo-dock-icon-facility.h"  // gldi_icons_get_any_without_dialog
@@ -49,7 +48,6 @@
 #include "cairo-dock-task.h"
 #include "cairo-dock-image-buffer.h"
 #include "cairo-dock-desktop-manager.h"
-#include "cairo-dock-launcher-manager.h" // cairo_dock_launch_command_sync
 #include "cairo-dock-separator-manager.h" // GLDI_OBJECT_IS_SEPARATOR_ICON
 #include "cairo-dock-menu.h" // gldi_menu_item_new_full2
 #include "cairo-dock-gui-factory.h"

--- a/src/gldit/cairo-dock-icon-facility.c
+++ b/src/gldit/cairo-dock-icon-facility.c
@@ -35,7 +35,6 @@
 #include "cairo-dock-module-instance-manager.h"  // GldiModuleInstance
 #include "cairo-dock-dock-facility.h"
 #include "cairo-dock-dock-manager.h"
-#include "cairo-dock-utils.h"  // cairo_dock_launch_command_full
 #include "cairo-dock-class-manager.h"  // gldi_class_startup_notify
 #include "cairo-dock-indicator-manager.h"
 #include "cairo-dock-applications-manager.h"  // GLDI_OBJECT_IS_APPLI_ICON

--- a/src/gldit/cairo-dock-menu.c
+++ b/src/gldit/cairo-dock-menu.c
@@ -749,8 +749,17 @@ static void _popup_menu (GtkWidget *menu, const GdkEvent *event)
 			}
 			else
 			{
-				// add an offset -- unfortunately, we can only add an absolute offset, but we do not know our size
-				// by the time we get the size on _menu_realized_cb (), setting an offset does not have an effect
+				/* add an offset -- unfortunately, we can only add an absolute offset, but we
+				 * do not know our size, and by the time we get it in _menu_realized_cb (),
+				 * setting an offset does not have an effect
+				 * see e.g. (links to the latest GTK+3 release when writing this):
+https://gitlab.gnome.org/GNOME/gtk/-/blob/e1d664da630ee32c4068c8ead4101bce94e7e24a/gtk/gtkmenu.c#L5218
+https://gitlab.gnome.org/GNOME/gtk/-/blob/e1d664da630ee32c4068c8ead4101bce94e7e24a/gtk/gtkmenu.c#L5303
+https://gitlab.gnome.org/GNOME/gtk/-/blob/e1d664da630ee32c4068c8ead4101bce94e7e24a/gtk/gtkmenu.c#L5325
+				 * so we just use a dummy size that works in most cases (note: this is only
+				 * used by the "modern" renderer, all others have fAlign == 0.0, 0.5 or 1.0
+				 * which is handled correctly by setting anchors)
+				 */
 				const double dummy_width = 240.0;
 				const double dummy_height = 120.0;
 				if (pContainer->bIsHorizontal)

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20241130
+#define GLDI_ABI_VERSION 20241213
 
 // manager
 typedef struct _GldiModulesParam GldiModulesParam;

--- a/src/gldit/cairo-dock-style-facility.c
+++ b/src/gldit/cairo-dock-style-facility.c
@@ -119,16 +119,13 @@ gchar *_get_default_system_font (void)
 	{
 		if (g_iDesktopEnv == CAIRO_DOCK_GNOME)
 		{
-			s_cFontName = cairo_dock_launch_command_sync ("gconftool-2 -g /desktop/gnome/interface/font_name");  // GTK2
-			if (! s_cFontName)
+			const char * const args[] = {"gsettings", "get", "org.gnome.desktop.interface", "font-name", NULL};
+			s_cFontName = cairo_dock_launch_command_argv_sync_with_stderr (args, FALSE);  // GTK3
+			cd_debug ("s_cFontName: %s", s_cFontName);
+			if (s_cFontName && *s_cFontName == '\'')  // the value may be between quotes... get rid of them!
 			{
-				s_cFontName = cairo_dock_launch_command_sync ("gsettings get org.gnome.desktop.interface font-name");  // GTK3
-				cd_debug ("s_cFontName: %s", s_cFontName);
-				if (s_cFontName && *s_cFontName == '\'')  // the value may be between quotes... get rid of them!
-				{
-					s_cFontName ++;  // s_cFontName is never freeed
-					s_cFontName[strlen(s_cFontName) - 1] = '\0';
-				}
+				s_cFontName ++;  // s_cFontName is never freeed
+				s_cFontName[strlen(s_cFontName) - 1] = '\0';
 			}
 		}
 		if (! s_cFontName)

--- a/src/gldit/cairo-dock-utils.h
+++ b/src/gldit/cairo-dock-utils.h
@@ -56,12 +56,17 @@ gboolean cairo_dock_string_is_address (const gchar *cString);
 gboolean cairo_dock_string_contains (const char *cNames, const gchar *cName, const gchar *separators);
 
 
+gchar *cairo_dock_launch_command_argv_sync_with_stderr (const gchar * const * argv, gboolean bPrintStdErr);
 gchar *cairo_dock_launch_command_sync_with_stderr (const gchar *cCommand, gboolean bPrintStdErr);
 #define cairo_dock_launch_command_sync(cCommand) cairo_dock_launch_command_sync_with_stderr (cCommand, TRUE)
 
 gboolean cairo_dock_launch_command_printf (const gchar *cCommandFormat, const gchar *cWorkingDirectory, ...) G_GNUC_PRINTF (1, 3);
 gboolean cairo_dock_launch_command_full (const gchar *cCommand, const gchar *cWorkingDirectory);
 #define cairo_dock_launch_command(cCommand) cairo_dock_launch_command_full (cCommand, NULL)
+gboolean cairo_dock_launch_command_argv_full (const gchar * const * args, const gchar *cWorkingDirectory, gboolean bGraphicalApp);
+#define cairo_dock_launch_command_argv(argv) cairo_dock_launch_command_argv_full (argv, NULL, FALSE);
+gboolean cairo_dock_launch_command_single (const gchar *cExec);
+gboolean cairo_dock_launch_command_single_gui (const gchar *cExec);
 
 /** Get the command to launch the default terminal
  */

--- a/src/implementations/cairo-dock-X-manager.c
+++ b/src/implementations/cairo-dock-X-manager.c
@@ -1059,7 +1059,8 @@ static GldiWindowActor *_pick_window (G_GNUC_UNUSED GtkWindow *pParentWindow)
 	GldiWindowActor *actor = NULL;
 	
 	// let the user grab the window, and get the result.
-	gchar *cProp = cairo_dock_launch_command_sync ("xwininfo");
+	const char * const args[] = {"xwininfo", NULL};
+	gchar *cProp = cairo_dock_launch_command_argv_sync_with_stderr (args, TRUE);
 	
 	// get the corresponding actor
 	// look for the window ID in this chain: xwininfo: Window id: 0xc00009 "name-of-the-window"

--- a/src/implementations/cairo-dock-compiz-integration.c
+++ b/src/implementations/cairo-dock-compiz-integration.c
@@ -30,7 +30,7 @@
 #include "cairo-dock-icon-factory.h"  // pAppli
 #include "cairo-dock-container.h"  // gldi_container_get_gdk_window
 #include "cairo-dock-class-manager.h"
-#include "cairo-dock-utils.h"  // cairo_dock_launch_command_sync
+#include "cairo-dock-utils.h"  // cairo_dock_launch_command_argv_sync_with_stderr
 #include "cairo-dock-X-utilities.h"  // cairo_dock_get_X_display, cairo_dock_change_nb_viewports
 #include "cairo-dock-compiz-integration.h"
 
@@ -221,9 +221,8 @@ static void _on_got_active_plugins (DBusGProxy *proxy, DBusGProxyCall *call_id, 
 		{
 			gchar *cPluginsList = g_strjoinv (",", plugins2);
 			cd_debug ("Compiz Plugins List: %s", cPluginsList);
-			cairo_dock_launch_command_printf ("bash "SHARE_DATA_DIR"/scripts/help_scripts.sh \"compiz_new_replace_list_plugins\" \"%s\"",
-				NULL,
-				cPluginsList);
+			const gchar * const args[] = {SHARE_DATA_DIR"/scripts/help_scripts.sh", "compiz_new_replace_list_plugins", cPluginsList, NULL};
+			cairo_dock_launch_command_argv (args);
 			g_free (cPluginsList);
 		}
 		else
@@ -372,7 +371,8 @@ gboolean cd_is_the_new_compiz (void)
 	if (!s_bHasBeenChecked)
 	{
 		s_bHasBeenChecked = TRUE;
-		gchar *cVersion = cairo_dock_launch_command_sync ("compiz --version");
+		const char * const args[] = {"compiz", "--version", NULL};
+		gchar *cVersion = cairo_dock_launch_command_argv_sync_with_stderr (args, FALSE);
 		if (cVersion != NULL)
 		{
 			gchar *str = strchr (cVersion, ' ');  // "compiz 0.8.6"

--- a/src/implementations/cairo-dock-wayfire-integration.c
+++ b/src/implementations/cairo-dock-wayfire-integration.c
@@ -36,7 +36,6 @@
 #include "cairo-dock-icon-factory.h"  // pAppli
 #include "cairo-dock-container.h"  // gldi_container_get_gdk_window
 #include "cairo-dock-class-manager.h"
-#include "cairo-dock-utils.h"  // cairo_dock_launch_command_sync
 
 static const char default_socket[] = "/tmp/wayfire-wayland-1.socket";
 

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -472,6 +472,7 @@ static void _release_keyboard_activate (void)
 
 static void _release_keyboard_layer_shell (GldiContainer *pContainer)
 {
+	if (!pContainer) return;
 #ifdef HAVE_GTK_LAYER_SHELL
 	GtkWindow* window = GTK_WINDOW (pContainer->pWidget);
 	gtk_layer_set_keyboard_mode (window, GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);


### PR DESCRIPTION
New API to allow passing argument vectors, avoiding conversion to and from a pasted command line and potential quoting and escaping issues. Additionally, use g_spawn* consistently and support startup notifications for GUI programs.

Additional changes: 
 - release the keyboard focus in gldi_desktop_present_windows () as well (needed on Wayfire for the scale plugin)
 - add a helper function to create a submenu for selecting an app to open a file (used by several plugins)