### PR TITLE
Small fixes

### DIFF
--- a/data/systemd/cairo-dock.service
+++ b/data/systemd/cairo-dock.service
@@ -7,6 +7,7 @@ Requisite=graphical-session.target
 [Service]
 ExecStart=cairo-dock
 BusName=org.cairodock.CairoDock
+KillMode=process
 
 [Install]
 WantedBy=graphical-session.target

--- a/src/gldit/cairo-dock-draw-opengl.c
+++ b/src/gldit/cairo-dock-draw-opengl.c
@@ -488,6 +488,7 @@ void cairo_dock_render_hidden_dock_opengl (CairoDock *pDock)
 {
 	//g_print ("%s (%d, %x)\n", __func__, pDock->bIsMainDock, g_pVisibleZoneSurface);
 	//\_____________________ on dessine la zone de rappel.
+	_cairo_dock_set_alpha (1.0);
 	if (g_pVisibleZoneBuffer.iTexture != 0)
 	{
 		_cairo_dock_enable_texture ();


### PR DESCRIPTION
- dialogs: close dialogs without a parent (avoids a crash on Wayland)
- systemd: ensure that child processes are not killed if Cairo-Dock exits
- fix not showing the recall image for hidden docks