### PR TITLE
Fix setting a custom class / app-id for a launcher

### DIFF
--- a/src/gldit/cairo-dock-launcher-manager.c
+++ b/src/gldit/cairo-dock-launcher-manager.c
@@ -264,7 +264,11 @@ static GKeyFile* reload_object (GldiObject *obj, gboolean bReloadConf, GKeyFile 
 	}
 	if (myTaskbarParam.bMixLauncherAppli && cNowClass != NULL && (cClass == NULL || strcmp (cNowClass, cClass) != 0))  // la classe a change, on inhibe la nouvelle.
 		cairo_dock_inhibite_class (cNowClass, icon);
-
+	
+	//\_____________ do the same with the WmClass if it was / is set
+	const gchar *cNewWmClass = cairo_dock_get_class_wm_class (cClass);
+	if (cNewWmClass) cairo_dock_inhibite_class (cNewWmClass, icon);
+	
 	//\_____________ redraw dock.
 	cairo_dock_redraw_icon (icon);
 	

--- a/src/implementations/cairo-dock-plasma-window-manager.c
+++ b/src/implementations/cairo-dock-plasma-window-manager.c
@@ -264,7 +264,6 @@ static void _gldi_toplevel_state_cb (void *data, G_GNUC_UNUSED pwhandle *handle,
 static void _gldi_toplevel_done_cb ( void *data, G_GNUC_UNUSED pwhandle *handle)
 {
 	GldiWaylandWindowActor* wactor = (GldiWaylandWindowActor*)data;
-	wactor->init_done = TRUE;
 	gldi_wayland_wm_done (wactor);
 }
 

--- a/src/implementations/cairo-dock-wayland-wm.c
+++ b/src/implementations/cairo-dock-wayland-wm.c
@@ -172,7 +172,7 @@ void gldi_wayland_wm_activated (GldiWaylandWindowActor *wactor, gboolean activat
 	{
 		s_pMaybeActiveWindow = (GldiWindowActor*)wactor;
 		wactor->unfocused_pending = FALSE;
-		if (s_activated_callback) s_activated_callback(wactor, s_activated_callback_data);
+		if (wactor->init_done && s_activated_callback) s_activated_callback (wactor, s_activated_callback_data);
 	}
 	else
 	{
@@ -291,6 +291,9 @@ void gldi_wayland_wm_done (GldiWaylandWindowActor *wactor)
 		// Set that we are already potentially processing a notification for this actor.
 		s_pCurrent = wactor;
 		wactor->in_queue = FALSE;
+		
+		// mark that we received all initial info about this window
+		wactor->init_done = TRUE;
 		
 		GldiWindowActor* actor = (GldiWindowActor*)wactor;
 		gchar* cOldClass = NULL;


### PR DESCRIPTION
This was not working (due to multiple reasons) since recent changes.