### PR TITLE
Support putting apps in a separate systemd slice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include ("${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/GNUInstallDirs.cmake")
 ########### project ###############
 
 project ("cairo-dock")
-set (VERSION "3.5.99.beta6") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.5.99.rc1") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/copyright
+++ b/copyright
@@ -8,11 +8,14 @@ Copyright: 2007-2014 Fabrice Rey <fabounet@glx-dock.org>
 License: GPL-3+
 
 Files:  src/cairo-dock.c
+ src/cairo-dock-user-interaction.c
+ src/cairo-dock-user-menu.c
  src/gldit/cairo-dock-animations.c
+ src/gldit/cairo-dock-applet-canvas.h
  src/gldit/cairo-dock-application-facility.?
  src/gldit/cairo-dock-applications-manager.?
  src/gldit/cairo-dock-class-icon-manager.c
- src/gldit/cairo-dock-class-manager.c
+ src/gldit/cairo-dock-class-manager.?
  src/gldit/cairo-dock-container.?
  src/gldit/cairo-dock-core.c
  src/gldit/cairo-dock-desktop-manager.c
@@ -22,37 +25,49 @@ Files:  src/cairo-dock.c
  src/gldit/cairo-dock-dock-factory.c
  src/gldit/cairo-dock-dock-manager.?
  src/gldit/cairo-dock-draw-opengl.c
+ src/gldit/cairo-dock-file-manager.?
  src/gldit/cairo-dock-gui-factory.c
- src/gldit/cairo-dock-icon-manager.c
+ src/gldit/cairo-dock-icon-facility.c
+ src/gldit/cairo-dock-icon-factory.h
+ src/gldit/cairo-dock-icon-manager.?
  src/gldit/cairo-dock-image-buffer.c
  src/gldit/cairo-dock-indicator-manager.c
+ src/gldit/cairo-dock-launcher-manager.?
  src/gldit/cairo-dock-menu.c
- src/gldit/cairo-dock-opengl.c
- src/gldit/cairo-dock-opengl.h
+ src/gldit/cairo-dock-module-manager.?
+ src/gldit/cairo-dock-opengl.?
  src/gldit/cairo-dock-surface-factory.?
+ src/gldit/cairo-dock-user-icon-manager.?
+ src/gldit/cairo-dock-utils.?
  src/gldit/cairo-dock-windows-manager.?
+ src/gldit/cdwindow.*
  src/implementations/cairo-dock-egl.?
  src/implementations/cairo-dock-wayland-manager.c
  src/implementations/cairo-dock-wayland-manager.h
 Copyright: 2007-2014 Fabrice Rey <fabounet@glx-dock.org>
-           2020-2024 Daniel Kondor <kondor.dani@gmail.com>
+           2020-2025 Daniel Kondor <kondor.dani@gmail.com>
 License: GPL-3+
 
 Files: src/gldit/cairo-dock-desktop-file-db.?
  src/implementations/cairo-dock-foreign-toplevel.?
  src/implementations/cairo-dock-plasma-*
  src/implementations/cairo-dock-cosmic-*
+ src/implementations/cairo-dock-systemd-integration.?
  src/implementations/cairo-dock-wayfire-*
  src/implementations/cairo-dock-wayland-wm.?
  src/implementations/cairo-dock-wayland-hotspots.?
  README_Wayland.md
-Copyright: 2020-2024 Daniel Kondor <kondor.dani@gmail.com>
+Copyright: 2020-2025 Daniel Kondor <kondor.dani@gmail.com>
 License: GPL-3+
 
 Files: src/implementations/gdk-move-to-rect-hack.?
 Copyright: 2020 Sophie Winter
            2020 Daniel Kondor
 License: Expat
+
+Files: data/systemd/*
+Copyright: 2024 Daniel Kondor <kondor.dani@gmail.com>
+License: MIT-no-advertising
 
 Files: src/gldit/cairo-dock-dbus.*
 Copyright: Adrien Pilleboue <adrien.pilleboue@gmail.com>

--- a/data/scripts/cairo-dock-package-theme.sh
+++ b/data/scripts/cairo-dock-package-theme.sh
@@ -423,6 +423,5 @@ rm -rf "$CURRENT_WORKING_DIR"
 
 echo ""
 echo "The theme has been packaged. It is available in ${SAVE_LOCATION} dir."
-sleep 3
 
 exit 0

--- a/data/systemd/cairo-dock.service
+++ b/data/systemd/cairo-dock.service
@@ -7,7 +7,6 @@ Requisite=graphical-session.target
 [Service]
 ExecStart=cairo-dock
 BusName=org.cairodock.CairoDock
-KillMode=process
 
 [Install]
 WantedBy=graphical-session.target

--- a/src/cairo-dock-user-interaction.c
+++ b/src/cairo-dock-user-interaction.c
@@ -415,17 +415,13 @@ gboolean cairo_dock_notification_drop_data_selection (G_GNUC_UNUSED gpointer pUs
 		GDesktopAppInfo *app = icon->pClassApp ? icon->pClassApp : icon->pCustomLauncher;
 		if (app)
 		{
-			// GdkAppLaunchContext will automatically use startup notify / xdg-activation,
-			// allowing e.g. the app to raise itself if necessary
 			GList *list = NULL;
 			gchar **tmp;
-			GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
 			// we always treat the parameters as URIs, this will work for apps that expect URIs (most cases)
 			// and GIO will anyway try to convert to files (and potentially mess things up) for apps that only expect files
 			for (tmp = data; *tmp; ++tmp) list = g_list_append (list, *tmp);
-			g_app_info_launch_uris (G_APP_INFO (app), list, G_APP_LAUNCH_CONTEXT (context), NULL);
+			cairo_dock_launch_app_info_with_uris (app, list);
 			g_list_free (list);
-			g_object_unref (context); // will be kept by GIO if necessary (and we don't care about the "launched" signal in this case)
 			ret = GLDI_NOTIFICATION_INTERCEPT;
 			*bHandled = TRUE;
 		}

--- a/src/cairo-dock-user-interaction.c
+++ b/src/cairo-dock-user-interaction.c
@@ -276,7 +276,7 @@ gboolean cairo_dock_notification_middle_click_icon (G_GNUC_UNUSED gpointer pUser
 				}
 			break;
 			case CAIRO_APPLI_ACTION_LAUNCH_NEW:  // launch new
-				if (icon->pClassApp || icon->pCustomLauncher)
+				if (icon->pAppInfo || icon->pCustomLauncher)
 				{
 					gldi_object_notify (pDock, NOTIFICATION_CLICK_ICON, icon, pDock, GDK_SHIFT_MASK);  // emulate a shift+left click
 				}
@@ -297,7 +297,7 @@ gboolean cairo_dock_notification_middle_click_icon (G_GNUC_UNUSED gpointer pUser
 				_cairo_dock_hide_show_in_class_subdock (icon);
 			break;
 			case CAIRO_APPLI_ACTION_LAUNCH_NEW:  // launch new
-				if (icon->pClassApp || icon->pCustomLauncher)
+				if (icon->pAppInfo || icon->pCustomLauncher)
 				{
 					gldi_object_notify (CAIRO_CONTAINER (pDock), NOTIFICATION_CLICK_ICON, icon, pDock, GDK_SHIFT_MASK);  // emulate a shift+left click
 				}
@@ -412,7 +412,9 @@ gboolean cairo_dock_notification_drop_data_selection (G_GNUC_UNUSED gpointer pUs
 			|| CAIRO_DOCK_ICON_TYPE_IS_APPLI (icon)
 			|| CAIRO_DOCK_ICON_TYPE_IS_CLASS_CONTAINER (icon)))
 	{
-		GDesktopAppInfo *app = icon->pClassApp ? icon->pClassApp : icon->pCustomLauncher;
+		GDesktopAppInfo *app = NULL;
+		if (icon->pAppInfo && icon->pAppInfo->app) app = icon->pAppInfo->app;
+		else app = icon->pCustomLauncher; // TODO: prefer pCustomLauncher if available?
 		if (app)
 		{
 			GList *list = NULL;

--- a/src/cairo-dock-user-menu.c
+++ b/src/cairo-dock-user-menu.c
@@ -1500,6 +1500,7 @@ static void _cairo_dock_launch_class_action (G_GNUC_UNUSED GtkMenuItem *pMenuIte
 	// GdkAppLaunchContext will automatically use startup notify / xdg-activation,
 	// allowing e.g. the app to raise itself if necessary
 	GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
+	//!! TODO: port this to _launch_as_manager () case (no equivalent API currently)
 	g_desktop_app_info_launch_action (pAction->app, pAction->action, G_APP_LAUNCH_CONTEXT (context));
 	g_object_unref (context); // will be kept by GIO if necessary (and we don't care about the "launched" signal in this case)
 }

--- a/src/cairo-dock-user-menu.c
+++ b/src/cairo-dock-user-menu.c
@@ -874,7 +874,7 @@ static void _cairo_dock_launch_new (G_GNUC_UNUSED GtkMenuItem *pMenuItem, gpoint
 {
 	struct _MenuParams *params = (struct _MenuParams*) data;
 	Icon *icon = params->pIcon;
-	if (icon->pClassApp || icon->pCustomLauncher)
+	if (icon->pAppInfo || icon->pCustomLauncher)
 	{
 		gldi_object_notify (params->pContainer, NOTIFICATION_CLICK_ICON, icon,
 			params->pContainer, GDK_SHIFT_MASK);  // on emule un shift+clic gauche .
@@ -1176,7 +1176,7 @@ gboolean cairo_dock_notification_build_container_menu (G_GNUC_UNUSED gpointer *p
 		{
 			gboolean bSensitive = FALSE;
 			if ( (CAIRO_DOCK_IS_APPLI (icon) || CAIRO_DOCK_ICON_TYPE_IS_CLASS_CONTAINER (pIcon))
-				&& (icon->pClassApp || icon->pCustomLauncher))
+				&& (icon->pAppInfo || icon->pCustomLauncher))
 			{
 				_add_entry_in_menu (_("Launch a new (Shift+clic)"), GLDI_ICON_NAME_ADD, _cairo_dock_launch_new, pItemSubMenu, params);
 				bSensitive = TRUE;
@@ -1191,7 +1191,7 @@ gboolean cairo_dock_notification_build_container_menu (G_GNUC_UNUSED gpointer *p
 		else
 		{
 			if ( (CAIRO_DOCK_IS_APPLI (icon) || CAIRO_DOCK_ICON_TYPE_IS_CLASS_CONTAINER (pIcon))
-					&& (icon->pClassApp || icon->pCustomLauncher))
+					&& (icon->pAppInfo || icon->pCustomLauncher))
 				_add_entry_in_menu (_("Launch a new (Shift+clic)"), GLDI_ICON_NAME_ADD, _cairo_dock_launch_new, pItemSubMenu, params);
 			
 			if ((CAIRO_DOCK_ICON_TYPE_IS_LAUNCHER (pIcon)
@@ -1477,7 +1477,7 @@ static void _add_desktops_entry (GtkWidget *pMenu, gboolean bAll, struct _MenuPa
 
 
 struct _AppAction {
-	GDesktopAppInfo *app;
+	GldiAppInfo *app;
 	const gchar *action;
 	gchar *action_name;
 };
@@ -1488,6 +1488,7 @@ static void _menu_item_destroyed (gpointer data, GObject*)
 	{
 		struct _AppAction *pAction = (struct _AppAction*)data;
 		if (pAction->action_name) g_free (pAction->action_name);
+		if (pAction->app) gldi_object_unref (GLDI_OBJECT (pAction->app));
 		g_free (pAction);
 	}
 }
@@ -1497,12 +1498,7 @@ static void _cairo_dock_launch_class_action (G_GNUC_UNUSED GtkMenuItem *pMenuIte
 	if (!data) return;
 	struct _AppAction *pAction = (struct _AppAction*)data;
 	
-	// GdkAppLaunchContext will automatically use startup notify / xdg-activation,
-	// allowing e.g. the app to raise itself if necessary
-	GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
-	//!! TODO: port this to _launch_as_manager () case (no equivalent API currently)
-	g_desktop_app_info_launch_action (pAction->app, pAction->action, G_APP_LAUNCH_CONTEXT (context));
-	g_object_unref (context); // will be kept by GIO if necessary (and we don't care about the "launched" signal in this case)
+	gldi_app_info_launch_action (pAction->app, pAction->action);
 }
 
 static void _cairo_dock_show_class (G_GNUC_UNUSED GtkMenuItem *pMenuItem, gpointer *data)
@@ -1861,33 +1857,30 @@ gboolean cairo_dock_notification_build_icon_menu (G_GNUC_UNUSED gpointer *pUserD
 	//\_________________________ class actions.
 	if (icon && icon->cClass != NULL && ! icon->bIgnoreQuicklist)
 	{
-		GDesktopAppInfo *app = icon->pClassApp;
-		if (app != NULL)
+		GldiAppInfo *app = icon->pAppInfo;
+		if (app && app->actions)
 		{
-			const gchar* const* actions = g_desktop_app_info_list_actions (app);
-			if (actions && *actions)
+			if (bAddSeparator)
 			{
-				if (bAddSeparator)
-				{
-					pMenuItem = gtk_separator_menu_item_new ();
-					gtk_menu_shell_append (GTK_MENU_SHELL (menu), pMenuItem);
-				}
-				bAddSeparator = TRUE;
-				for (; *actions; ++actions)
-				{
-					struct _AppAction *pAction = g_new0 (struct _AppAction, 1);
-					pAction->app = app;
-					pAction->action = *actions;
-					pAction->action_name = g_desktop_app_info_get_action_name (app, *actions);
-					
-					// note: app is guaranteed to live as long as icon (it holds a ref to it)
-					// and our menu is destroyed with the icon, so we can use the strings here directly
-					pMenuItem = cairo_dock_add_in_menu_with_stock_and_data (pAction->action_name,
-						NULL,
-						G_CALLBACK (_cairo_dock_launch_class_action),
-						menu, (gpointer)pAction);
-					g_object_weak_ref (G_OBJECT (pMenuItem), _menu_item_destroyed, (gpointer)pAction);
-				}
+				pMenuItem = gtk_separator_menu_item_new ();
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), pMenuItem);
+			}
+			bAddSeparator = TRUE;
+			
+			const gchar* const *actions = app->actions;
+			for (; *actions; ++actions)
+			{
+				struct _AppAction *pAction = g_new0 (struct _AppAction, 1);
+				gldi_object_ref (GLDI_OBJECT (app));
+				pAction->app = app;
+				pAction->action = *actions;
+				pAction->action_name = g_desktop_app_info_get_action_name (app->app, *actions);
+				
+				pMenuItem = cairo_dock_add_in_menu_with_stock_and_data (pAction->action_name,
+					NULL,
+					G_CALLBACK (_cairo_dock_launch_class_action),
+					menu, (gpointer)pAction);
+				g_object_weak_ref (G_OBJECT (pMenuItem), _menu_item_destroyed, (gpointer)pAction);
 			}
 		}
 	}

--- a/src/cairo-dock-widget-items.c
+++ b/src/cairo-dock-widget-items.c
@@ -745,7 +745,6 @@ ItemsWidget *cairo_dock_items_widget_new (GtkWindow *pMainWindow)
 	pItemsWidget->pTreeView = gtk_tree_view_new_with_model (model);
 	g_object_unref (model);
 	gtk_tree_view_set_headers_visible (GTK_TREE_VIEW (pItemsWidget->pTreeView), FALSE);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (pItemsWidget->pTreeView), TRUE);
 	gtk_tree_view_set_reorderable (GTK_TREE_VIEW (pItemsWidget->pTreeView), TRUE);  // enables drag and drop of rows -> row-inserted and row-deleted signals
 	g_signal_connect (G_OBJECT (pItemsWidget->pTreeView),
 		"button-release-event",  // on release, so that the clicked line is already selected

--- a/src/gldit/cairo-dock-applications-manager.c
+++ b/src/gldit/cairo-dock-applications-manager.c
@@ -329,10 +329,10 @@ static gboolean _on_window_class_changed (G_GNUC_UNUSED gpointer data, GldiWindo
 	
 	// set the new class
 	g_free (icon->cClass);
-	if (icon->pClassApp)
+	if (icon->pAppInfo)
 	{
-		g_object_unref (icon->pClassApp);
-		icon->pClassApp = NULL;
+		gldi_object_unref (GLDI_OBJECT (icon->pAppInfo));
+		icon->pAppInfo = NULL;
 	}
 	icon->cClass = g_strdup (actor->cClass);
 

--- a/src/gldit/cairo-dock-class-icon-manager.c
+++ b/src/gldit/cairo-dock-class-icon-manager.c
@@ -91,8 +91,11 @@ static void init_object (GldiObject *obj, gpointer attr)
 	
 	const gchar *cClassName = cairo_dock_get_class_name(pSameClassIcon->cClass);
 	pIcon->cName = g_strdup (cClassName ? cClassName : pSameClassIcon->cClass);
-	if (pSameClassIcon->pClassApp)
-		pIcon->pClassApp = g_object_ref (pSameClassIcon->pClassApp);
+	if (pSameClassIcon->pAppInfo)
+	{
+		pIcon->pAppInfo = pSameClassIcon->pAppInfo;
+		gldi_object_ref (GLDI_OBJECT (pIcon->pAppInfo));
+	}
 	if (pSameClassIcon->pCustomLauncher)
 		pIcon->pCustomLauncher = g_object_ref (pSameClassIcon->pCustomLauncher);
 	pIcon->cClass = g_strdup (pSameClassIcon->cClass);

--- a/src/gldit/cairo-dock-class-manager.h
+++ b/src/gldit/cairo-dock-class-manager.h
@@ -23,12 +23,28 @@
 
 #include <gio/gdesktopappinfo.h>
 #include "cairo-dock-struct.h"
+#include "cairo-dock-object.h"
 G_BEGIN_DECLS
 
 /**
 *@file cairo-dock-class-manager.h This class handles the managment of the applications classes.
 * Classes are used to group the windows of a same program, and to bind a launcher to the launched application.
 */
+
+
+/** Helper object for launching desktop file actions.
+ * This is needed since g_desktop_app_info_launch_action() does not provide
+ * all of the functionality of g_desktop_app_info_launch_uris_as_manager
+ */
+struct _GldiAppInfo {
+	GldiObject object;
+	GDesktopAppInfo *app; // the desktop app info -- this object holds one reference to it
+	const gchar* const *actions; // additional actions supported by this app (belongs to app, no need to free)
+	gchar ***action_args; // parsed Exec key to launch actions
+};
+
+void gldi_app_info_launch_action (GldiAppInfo *app, const gchar *cAction);
+
 
 /*
 * Initialise le gestionnaire de classes. Ne fait rien la 2eme fois.
@@ -174,6 +190,8 @@ GDesktopAppInfo *cairo_dock_get_class_app_info (const gchar *cClass);
 
 const CairoDockImageBuffer *cairo_dock_get_class_image_buffer (const gchar *cClass);
 
+const gchar* const *cairo_dock_get_class_actions (const gchar *cClass);
+
 
 gchar *cairo_dock_guess_class (const gchar *cCommand, const gchar *cStartupWMClass);
 
@@ -227,12 +245,13 @@ gchar *cairo_dock_register_class (const gchar *cSearchTerm);
 void cairo_dock_set_data_from_class (const gchar *cClass, Icon *pIcon);
 
 
-
 void gldi_class_startup_notify (Icon *pIcon);
 
 void gldi_class_startup_notify_end (const gchar *cClass);
 
 gboolean gldi_class_is_starting (const gchar *cClass);
+
+void gldi_register_class_manager (void);
 
 G_END_DECLS
 #endif

--- a/src/gldit/cairo-dock-core.c
+++ b/src/gldit/cairo-dock-core.c
@@ -39,6 +39,7 @@
 #include "cairo-dock-windows-manager.h"
 #include "cairo-dock-X-manager.h"
 #include "cairo-dock-wayland-manager.h"
+#include "cairo-dock-systemd-integration.h"
 #include "cairo-dock-module-manager.h"
 #include "cairo-dock-module-instance-manager.h"
 #include "cairo-dock-packages.h"
@@ -97,6 +98,7 @@ static void _gldi_register_core_managers (void)
 	gldi_register_style_manager ();  // get config before other manager that could use this manager
 	if (!g_bForceWayland) gldi_register_X_manager ();
 	if (!g_bForceX11) gldi_register_wayland_manager ();
+	cairo_dock_systemd_integration_init ();
 }
 
 void gldi_init (GldiRenderingMethod iRendering)

--- a/src/gldit/cairo-dock-core.c
+++ b/src/gldit/cairo-dock-core.c
@@ -37,6 +37,7 @@
 #include "cairo-dock-backends-manager.h"
 #include "cairo-dock-desktop-manager.h"
 #include "cairo-dock-windows-manager.h"
+#include "cairo-dock-class-manager.h"
 #include "cairo-dock-X-manager.h"
 #include "cairo-dock-wayland-manager.h"
 #include "cairo-dock-systemd-integration.h"
@@ -83,6 +84,7 @@ static void _gldi_register_core_managers (void)
 	gldi_register_class_icons_manager ();
 	gldi_register_separator_icons_manager ();
 	gldi_register_applications_manager ();
+	gldi_register_class_manager ();
 	gldi_register_applet_icons_manager ();
 	gldi_register_modules_manager ();
 	gldi_register_module_instances_manager ();

--- a/src/gldit/cairo-dock-icon-facility.c
+++ b/src/gldit/cairo-dock-icon-facility.c
@@ -45,6 +45,7 @@
 #include "cairo-dock-draw-opengl.h"
 #include "cairo-dock-draw.h"
 #include "cairo-dock-animations.h"  // CairoDockHidingEffect
+#include "cairo-dock-utils.h"  // cairo_dock_launch_app_info
 #include "cairo-dock-icon-facility.h"
 
 extern gchar *g_cCurrentLaunchersPath;
@@ -732,12 +733,7 @@ gboolean gldi_icon_launch_command (Icon *pIcon)
 	if (app)
 	{
 		cd_debug ("launching app from desktop file info: %s", pIcon->cClass);
-		// GdkAppLaunchContext will automatically use startup notify / xdg-activation
-		GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
-		gboolean ret = g_app_info_launch (G_APP_INFO (app), NULL, G_APP_LAUNCH_CONTEXT(context), NULL);
-		g_object_unref (context); // will be kept by GIO if necessary
-		return ret;
-		//!! TODO: use the "launched" and / or "launch-failed" signal to end our startup animation
+		return cairo_dock_launch_app_info (app);;
 	}
 	cd_warning ("cannot launch icon with no app associated to it!");
 	return FALSE;

--- a/src/gldit/cairo-dock-icon-facility.c
+++ b/src/gldit/cairo-dock-icon-facility.c
@@ -729,11 +729,12 @@ gboolean gldi_icon_launch_command (Icon *pIcon)
 	// notify startup
 	gldi_class_startup_notify (pIcon);
 
-	GDesktopAppInfo *app = pIcon->pCustomLauncher ? pIcon->pCustomLauncher : pIcon->pClassApp;
+	GDesktopAppInfo *app = pIcon->pCustomLauncher;
+	if (!app && pIcon->pAppInfo) app = pIcon->pAppInfo->app;
 	if (app)
 	{
 		cd_debug ("launching app from desktop file info: %s", pIcon->cClass);
-		return cairo_dock_launch_app_info (app);;
+		return cairo_dock_launch_app_info (app);
 	}
 	cd_warning ("cannot launch icon with no app associated to it!");
 	return FALSE;

--- a/src/gldit/cairo-dock-icon-factory.h
+++ b/src/gldit/cairo-dock-icon-factory.h
@@ -119,7 +119,7 @@ struct _Icon {
 	gchar *cInitialName; // original name replaced by e.g. the actual app title matched to a launcher
 	// GAppInfo(s) that are used to launch the app corresponding to this icon (if it is a launcher or appli)
 	// These are only set on creation and do not change during the lifetime of the icon.
-	GDesktopAppInfo *pClassApp; // GAppInfo corresponding to the .desktop file installed on the system
+	GldiAppInfo *pAppInfo; // app info from a .desktop file installed on the system
 	GDesktopAppInfo *pCustomLauncher; // GAppInfo with custom launch command (if set)
 	
 	// Appli.

--- a/src/gldit/cairo-dock-icon-manager.c
+++ b/src/gldit/cairo-dock-icon-manager.c
@@ -1022,7 +1022,7 @@ static void reset_object (GldiObject *obj)
 	g_free (icon->cQuickInfo);
 	///g_free (icon->cLastAttentionDemand);
 	g_free (icon->pHiddenBgColor);
-	if (icon->pClassApp) g_object_unref (icon->pClassApp);
+	if (icon->pAppInfo) gldi_object_unref (GLDI_OBJECT (icon->pAppInfo));
 	if (icon->pCustomLauncher) g_object_unref (icon->pCustomLauncher);
 	
 	cairo_dock_unload_image_buffer (&icon->image);

--- a/src/gldit/cairo-dock-launcher-manager.c
+++ b/src/gldit/cairo-dock-launcher-manager.c
@@ -177,7 +177,7 @@ static void init_object (GldiObject *obj, gpointer attr)
 	GKeyFile *pKeyFile = pAttributes->pKeyFile;
 	gboolean bNeedUpdate = _get_launcher_params (icon, pKeyFile);
 	
-	if ( !(icon->pClassApp || icon->pCustomLauncher))  // no command could be found for this launcher -> mark it as invalid
+	if ( !(icon->pAppInfo || icon->pCustomLauncher))  // no command could be found for this launcher -> mark it as invalid
 		icon->reserved[0] = (gpointer)-1; // we use this as a way to tell the UserIcon manager that the icon is invalid (should add a new flag, but that would break ABI)
 	
 	//\____________ Make it an inhibator for its class.
@@ -218,10 +218,10 @@ static GKeyFile* reload_object (GldiObject *obj, gboolean bReloadConf, GKeyFile 
 		g_object_unref (icon->pCustomLauncher);
 		icon->pCustomLauncher = NULL;
 	}
-	if (icon->pClassApp)
+	if (icon->pAppInfo)
 	{
-		g_object_unref (icon->pClassApp);
-		icon->pClassApp = NULL;
+		gldi_object_unref (GLDI_OBJECT (icon->pAppInfo));
+		icon->pAppInfo = NULL;
 	}
 	
 	//\__________________ get parameters

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20241213
+#define GLDI_ABI_VERSION 20250115
 
 // manager
 typedef struct _GldiModulesParam GldiModulesParam;

--- a/src/gldit/cairo-dock-struct.h
+++ b/src/gldit/cairo-dock-struct.h
@@ -413,6 +413,7 @@ typedef struct _CairoDialogDecorator CairoDialogDecorator;
 
 typedef struct _IconInterface IconInterface;
 typedef struct _Icon Icon;
+typedef struct _GldiAppInfo GldiAppInfo;
 typedef struct _GldiContainer GldiContainer;
 typedef struct _GldiContainerInterface GldiContainerInterface;
 typedef struct _CairoDock CairoDock;

--- a/src/gldit/cairo-dock-utils.c
+++ b/src/gldit/cairo-dock-utils.c
@@ -287,19 +287,6 @@ gchar *cairo_dock_launch_command_sync_with_stderr (const gchar *cCommand, gboole
 	return standard_output;
 }
 
-gboolean cairo_dock_launch_command_printf (const gchar *cCommandFormat, const gchar *cWorkingDirectory, ...)
-{
-	va_list args;
-	va_start (args, cWorkingDirectory);
-	gchar *cCommand = g_strdup_vprintf (cCommandFormat, args);
-	va_end (args);
-	
-	gboolean r = cairo_dock_launch_command_full (cCommand, cWorkingDirectory);
-	g_free (cCommand);
-	
-	return r;
-}
-
 static void _child_watch_dummy (GPid pid, gint, gpointer)
 {
 	g_spawn_close_pid (pid); // note: this is a no-op

--- a/src/gldit/cairo-dock-utils.c
+++ b/src/gldit/cairo-dock-utils.c
@@ -27,6 +27,8 @@
 
 extern CairoDockDesktopEnv g_iDesktopEnv;
 
+static GldiChildProcessManagerBackend s_backend = { 0 };
+
 gchar *cairo_dock_cut_string (const gchar *cString, int iNbCaracters)  // gere l'UTF-8
 {
 	g_return_val_if_fail (cString != NULL, NULL);
@@ -408,6 +410,54 @@ gchar * cairo_dock_get_command_with_right_terminal (const gchar *cCommand)
 		return g_strdup_printf ("%s -e \"%s\"", cTerm, cCommand);
 }
 
+
+static void _pid_callback (GDesktopAppInfo* appinfo, GPid pid, gpointer)
+{
+	cd_debug ("Launched process for app: %s (pid: %d)\n", g_app_info_get_display_name (G_APP_INFO (appinfo)), pid);
+	if (s_backend.new_app_launched)
+	{
+		char *desc = g_strdup_printf ("%s - %s", g_app_info_get_display_name (G_APP_INFO (appinfo)), g_app_info_get_description (G_APP_INFO (appinfo)));
+		s_backend.new_app_launched (g_app_info_get_id (G_APP_INFO (appinfo)), desc, pid);
+		g_free (desc);
+	}
+	else g_child_watch_add (pid, _child_watch_dummy, NULL);
+}
+
+gboolean cairo_dock_launch_app_info_with_uris (GDesktopAppInfo* appinfo, GList* uris)
+{
+	GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
+	GError *erreur = NULL;
+	
+	gboolean ret = g_desktop_app_info_launch_uris_as_manager (appinfo, uris, G_APP_LAUNCH_CONTEXT (context),
+		G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_LEAVE_DESCRIPTORS_OPEN |
+		G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL, // spawn flags
+		NULL, NULL, // user_setup and user_data
+		_pid_callback, NULL, // pid callback and pid data
+		&erreur);
+	g_object_unref (context); // will be kept by GIO if necessary (and we don't care about the "launched" signal in this case)
+	
+	if (!ret)
+	{
+		cd_warning ("Cannot launch app: %s (%s)", g_app_info_get_id (G_APP_INFO (appinfo)), erreur->message);
+		g_error_free (erreur);
+	}
+	
+	return ret;
+}
+
+
+void gldi_register_process_manager_backend (GldiChildProcessManagerBackend *backend)
+{
+	gpointer *ptr = (gpointer*)&s_backend;
+	gpointer *src = (gpointer*)backend;
+	gpointer *src_end = (gpointer*)(backend + 1);
+	while (src != src_end)
+	{
+		*ptr = *src;
+		src ++;
+		ptr ++;
+	}
+}
 
 #ifdef HAVE_X11
 

--- a/src/gldit/cairo-dock-utils.c
+++ b/src/gldit/cairo-dock-utils.c
@@ -400,18 +400,6 @@ const gchar * cairo_dock_get_default_terminal (void)
 		return "xterm";
 }
 
-gchar * cairo_dock_get_command_with_right_terminal (const gchar *cCommand)
-{
-	const gchar *cTerm = cairo_dock_get_default_terminal ();
-	/* Very very strange, an exception for KDE! :-)
-	 * From konsole's man: -e <command> [ arguments ]
-	 */
-	if (strncmp (cTerm, "konsole", 7) == 0)
-		return g_strdup_printf ("%s -e %s", cTerm, cCommand);
-	else
-		return g_strdup_printf ("%s -e \"%s\"", cTerm, cCommand);
-}
-
 
 static void _pid_callback (GDesktopAppInfo* appinfo, GPid pid, gpointer)
 {

--- a/src/gldit/cairo-dock-utils.h
+++ b/src/gldit/cairo-dock-utils.h
@@ -86,10 +86,6 @@ gboolean cairo_dock_launch_command_single_gui (const gchar *cExec);
 /** Get the command to launch the default terminal
  */
 const gchar * cairo_dock_get_default_terminal (void);
-/** Get the command to launch another one from a terminal
- * @param cCommand command to launch from a terminal
- */
-gchar * cairo_dock_get_command_with_right_terminal (const gchar *cCommand);
 
 
 /** Launch an app with optionally a list of URIs provided as the argument.

--- a/src/gldit/cairo-dock-utils.h
+++ b/src/gldit/cairo-dock-utils.h
@@ -63,11 +63,23 @@ gchar *cairo_dock_launch_command_argv_sync_with_stderr (const gchar * const * ar
 gchar *cairo_dock_launch_command_sync_with_stderr (const gchar *cCommand, gboolean bPrintStdErr);
 #define cairo_dock_launch_command_sync(cCommand) cairo_dock_launch_command_sync_with_stderr (cCommand, TRUE)
 
-gboolean cairo_dock_launch_command_printf (const gchar *cCommandFormat, const gchar *cWorkingDirectory, ...) G_GNUC_PRINTF (1, 3);
-gboolean cairo_dock_launch_command_full (const gchar *cCommand, const gchar *cWorkingDirectory);
-#define cairo_dock_launch_command(cCommand) cairo_dock_launch_command_full (cCommand, NULL)
-gboolean cairo_dock_launch_command_argv_full (const gchar * const * args, const gchar *cWorkingDirectory, gboolean bGraphicalApp);
-#define cairo_dock_launch_command_argv(argv) cairo_dock_launch_command_argv_full (argv, NULL, FALSE)
+
+/** Flags given to cairo_dock_launch_command_argv_full() */
+typedef enum {
+	GLDI_LAUNCH_DEFAULT = 0,
+	/// This is a GUI app, use GdkAppLaunchContext to create an activation token for it
+	GLDI_LAUNCH_GUI = 1<<0,
+	/// This is a potentially long-lived app, try to put it in a separate process accounting
+	/// group with the session manager. Currently, this means putting the app in a separate
+	/// slice if running with systemd. This has the effect that e.g. resource use is accounted
+	/// separately, and the app is not automatically killed if cairo-dock exits.
+	GLDI_LAUNCH_SLICE = 1<<1
+} GldiLaunchFlags;
+
+gboolean cairo_dock_launch_command_full (const gchar *cCommand, const gchar *cWorkingDirectory, GldiLaunchFlags flags);
+#define cairo_dock_launch_command(cCommand) cairo_dock_launch_command_full (cCommand, NULL, GLDI_LAUNCH_DEFAULT)
+gboolean cairo_dock_launch_command_argv_full (const gchar * const * args, const gchar *cWorkingDirectory, GldiLaunchFlags flags);
+#define cairo_dock_launch_command_argv(argv) cairo_dock_launch_command_argv_full (argv, NULL, GLDI_LAUNCH_DEFAULT)
 gboolean cairo_dock_launch_command_single (const gchar *cExec);
 gboolean cairo_dock_launch_command_single_gui (const gchar *cExec);
 

--- a/src/gldit/cairo-dock-windows-manager.c
+++ b/src/gldit/cairo-dock-windows-manager.c
@@ -294,6 +294,12 @@ guint gldi_window_get_id (GldiWindowActor *actor)
 	return 0;
 }
 
+void gldi_window_get_menu_address (GldiWindowActor *actor, char **service_name, char **object_path)
+{
+	if (actor && s_backend.get_menu_address)
+		s_backend.get_menu_address (actor, service_name, object_path);
+}
+
 GldiWindowActor *gldi_window_pick (GtkWindow *pParentWindow)
 {
 	if (s_backend.pick_window)

--- a/src/gldit/cairo-dock-windows-manager.h
+++ b/src/gldit/cairo-dock-windows-manager.h
@@ -87,6 +87,7 @@ struct _GldiWindowManagerBackend {
 	const gchar *name; // name of the current backend
 	void (*move_to_viewport_abs) (GldiWindowActor *actor, int iNumDesktop, int iViewportX, int iViewportY); // like move_to_nth_desktop, but use absolute viewport coordinates
 	gpointer flags; // GldiWMBackendFlags, cast to pointer
+	void (*get_menu_address) (GldiWindowActor *actor, char **service_name, char **object_path);
 	} ;
 
 /// Definition of a window actor.
@@ -184,6 +185,15 @@ gboolean gldi_window_is_on_desktop (GldiWindowActor *pAppli, int iNumDesktop, in
 void gldi_window_move_to_current_desktop (GldiWindowActor *pAppli);
 
 guint gldi_window_get_id (GldiWindowActor *pAppli);
+
+/** Get the object path at which this window's app might export its global menus if supported by the backend.
+ *@param actor the window whose menu is requested
+ *@param service_name return location for the dbus service name
+ *@param object_path return location for the object path
+ * Note: the returned values in service_name and object_path point to strings owned by this window
+ * actor instance and should not be modified or freed by the caller.
+ */
+void gldi_window_get_menu_address (GldiWindowActor *actor, char **service_name, char **object_path);
 
 GldiWindowActor *gldi_window_pick (GtkWindow *pParentWindow);
 

--- a/src/implementations/CMakeLists.txt
+++ b/src/implementations/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(impl_SRCS
 	cairo-dock-gnome-shell-integration.c cairo-dock-gnome-shell-integration.h
 	cairo-dock-cinnamon-integration.c    cairo-dock-cinnamon-integration.h
 	cairo-dock-wayfire-integration.c     cairo-dock-wayfire-integration.h
+	cairo-dock-systemd-integration.c     cairo-dock-systemd-integration.h
 	cairo-dock-X-manager.c               cairo-dock-X-manager.h
 	cairo-dock-X-utilities.c             cairo-dock-X-utilities.h
 	cairo-dock-glx.c                     cairo-dock-glx.h

--- a/src/implementations/cairo-dock-systemd-integration.c
+++ b/src/implementations/cairo-dock-systemd-integration.c
@@ -1,0 +1,136 @@
+/**
+* This file is a part of the Cairo-Dock project
+*
+* Copyright : (C) see the 'copyright' file.
+* E-mail    : see the 'copyright' file.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 3
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <stdio.h>
+#include <glib.h>
+#include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
+#include "cairo-dock-systemd-integration.h"
+#include <cairo-dock-log.h>
+
+GDBusProxy *s_proxy = NULL;
+
+static void _child_watch_dummy (GPid pid, gint, gpointer)
+{
+	g_spawn_close_pid (pid); // note: this is a no-op
+}
+
+static void _create_scope_end (GObject*, GAsyncResult *res, gpointer ptr)
+{
+	GError *err = NULL;
+	GVariant *ret = g_dbus_proxy_call_finish (s_proxy, res, &err);
+	if (ret) g_variant_unref (ret);
+	else
+	{
+		cd_warning ("couldn't set scope for child process: %s", err->message);
+		g_error_free (err);
+	}
+	
+	// we only create the child watch after the DBus call to systemd finished
+	// hopefully this avoids pid reuse race conditions (i.e. until it has been
+	// waited for, the pid should become a zombie if the process exits)
+	g_child_watch_add (GPOINTER_TO_INT (ptr), _child_watch_dummy, NULL);
+}
+
+static void _create_transient_scope (const char *id, const char *desc, GPid pid)
+{
+	if (!s_proxy) return;
+	
+	GVariantBuilder var_builder;
+	/*
+	       StartTransientUnit(in  s name,
+                         in  s mode,
+                         in  a(sv) properties,
+                         in  a(sa(sv)) aux,
+                         out o job);
+	*/
+	GVariantType *full_type  = g_variant_type_new ("(ssa(sv)a(sa(sv)))");
+	GVariantType *props_type = g_variant_type_new ("a(sv)");
+	GVariantType *aux_type   = g_variant_type_new ("a(sa(sv))");
+	
+	char *name;
+	size_t len = strlen (id);
+	const size_t max_len =
+		255 // length allowed by systemd
+		- 42 // length of our prefix + dash + suffix
+		- 9; // max length of %d specifier (assuming pid_t is 32 bits)
+	if (len > max_len)
+		name = g_strdup_printf ("cairo-dock-launched-%.*s-%d.scope", (int)max_len, id, pid);
+	else name = g_strdup_printf ("cairo-dock-launched-%s-%d.scope", id, pid);
+	unsigned int tmp = (unsigned int)pid;
+	
+	g_variant_builder_init  (&var_builder, full_type);
+	g_variant_builder_add   (&var_builder, "s", name);
+	g_variant_builder_add   (&var_builder, "s", "fail");
+	g_variant_builder_open  (&var_builder, props_type);
+	g_variant_builder_add   (&var_builder, "(sv)", "Description", g_variant_new_string (desc));
+	g_variant_builder_add   (&var_builder, "(sv)", "PIDs", g_variant_new_fixed_array (G_VARIANT_TYPE_UINT32, &tmp, 1, 4));
+	g_variant_builder_close (&var_builder);
+	g_variant_builder_open  (&var_builder, aux_type);
+	g_variant_builder_close (&var_builder);
+	
+	GVariant *var = g_variant_ref_sink (g_variant_builder_end (&var_builder));
+	g_dbus_proxy_call (s_proxy, "StartTransientUnit", var, G_DBUS_CALL_FLAGS_NONE, -1, NULL, _create_scope_end, GINT_TO_POINTER (pid));
+	
+	g_variant_unref (var);
+	g_free (name);
+	g_variant_type_free (full_type);
+	g_variant_type_free (props_type);
+	g_variant_type_free (aux_type);
+}
+
+
+static void _proxy_connected (GObject*, GAsyncResult *res, gpointer)
+{
+	s_proxy = g_dbus_proxy_new_for_bus_finish (res, NULL);
+	if (s_proxy)
+	{
+		const char *owner = g_dbus_proxy_get_name_owner (s_proxy);
+		if (!owner)
+		{
+			// we expect that systemd should be on the bus before 
+			// TODO: or possibly wait for it to appear later?
+			cd_message ("no owner for org.freedesktop.systemd1, not registering");
+			g_object_unref (s_proxy);
+			s_proxy = NULL;
+			return;
+		}
+		
+		GldiChildProcessManagerBackend backend;
+		backend.new_app_launched = _create_transient_scope;
+		gldi_register_process_manager_backend (&backend);
+	}
+}
+
+
+void cairo_dock_systemd_integration_init (void)
+{
+	g_dbus_proxy_new_for_bus (G_BUS_TYPE_SESSION,
+		G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
+		NULL, // GDBusInterfaceInfo
+		"org.freedesktop.systemd1",
+		"/org/freedesktop/systemd1",
+		"org.freedesktop.systemd1.Manager",
+		NULL, // GCancellable
+		_proxy_connected,
+		NULL);
+}
+
+

--- a/src/implementations/cairo-dock-systemd-integration.h
+++ b/src/implementations/cairo-dock-systemd-integration.h
@@ -1,0 +1,31 @@
+/*
+* This file is a part of the Cairo-Dock project
+*
+* Copyright : (C) see the 'copyright' file.
+* E-mail    : see the 'copyright' file.
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 3
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __CAIRO_DOCK_SYSTEMD_INTEGRATION__
+#define __CAIRO_DOCK_SYSTEMD_INTEGRATION__
+
+#include "cairo-dock-utils.h"
+G_BEGIN_DECLS
+
+void cairo_dock_systemd_integration_init (void);
+
+G_END_DECLS
+#endif
+
+


### PR DESCRIPTION
Fixes #51  (hopefully also fixing the original problem there)

 - Rework the way apps are launched, using `g_desktop_app_info_launch_uris_as_manager()` where possible, and defining a new backend that can operate on newly launched processes.
 - Create a "systemd" backend that uses the "org.freedesktop.systemd1.Manager" interface to put child processes in their own slice (using "transient units")
 - Extend the other existing APIs for launching commands to support this
 - Some additional minor improvements
 - Support for getting the DBus name of apps from KWin (needed for the Global-Menu plugin)
