### PR TITLE
X11: use the res_name part of WM_CLASS as well

### DIFF
--- a/src/gldit/cairo-dock-menu.c
+++ b/src/gldit/cairo-dock-menu.c
@@ -474,6 +474,7 @@ static void _on_menu_deactivated (GtkMenuShell *pMenu, G_GNUC_UNUSED gpointer da
 	if (!pParams)
 		return;
 	Icon *pIcon = pParams->pIcon;
+	if (!pIcon) return;
 	GldiContainer *pContainer = cairo_dock_get_icon_container (pIcon);
 	if (pIcon->iHideLabel > 0)
 	{

--- a/src/gldit/cairo-dock-windows-manager.c
+++ b/src/gldit/cairo-dock-windows-manager.c
@@ -493,6 +493,7 @@ static void reset_object (GldiObject *obj)
 	g_free (actor->cName);
 	g_free (actor->cClass);
 	g_free (actor->cWmClass);
+	g_free (actor->cWmName);
 	g_free (actor->cLastAttentionDemand);
 	s_pWindowsList = g_list_remove (s_pWindowsList, actor);
 }

--- a/src/gldit/cairo-dock-windows-manager.h
+++ b/src/gldit/cairo-dock-windows-manager.h
@@ -102,9 +102,10 @@ struct _GldiWindowActor {
 	gint iNumDesktop;  // can be -1
 	gint iViewPortX, iViewPortY;
 	gint iStackOrder;
-	gchar *cClass;
-	gchar *cWmClass;
-	gchar *cName;
+	gchar *cClass; // parsed class of this window (i.e. the result of gldi_window_parse_class ())
+	gchar *cWmClass; // original class as reported by the WM (needed in some cases to match it)
+	gchar *cName; // window title, displayed as label
+	gchar *cWmName; // only used on X11, res_name part of XClassHint (i.e. the first string in WM_CLASS), not parsed
 	gchar *cLastAttentionDemand;
 	gint iAge;  // age of the window (a mere growing integer).
 	gboolean bIsTransientFor;  // TRUE if the window is transient (for a parent window).

--- a/src/implementations/cairo-dock-X-utilities.c
+++ b/src/implementations/cairo-dock-X-utilities.c
@@ -1129,14 +1129,18 @@ gchar *cairo_dock_get_xwindow_name (Window Xid, gboolean bSearchWmName)
 	return cName;
 }
 
-gchar *cairo_dock_get_xwindow_class (Window Xid, gchar **cWMClass)
+gchar *cairo_dock_get_xwindow_class (Window Xid, gchar **cWMClass, gchar **cWMName)
 {
 	XClassHint *pClassHint = XAllocClassHint ();
 	gchar *cClass = NULL;
 	if (XGetClassHint (s_XDisplay, Xid, pClassHint) != 0 && pClassHint->res_class)
 	{
 		cClass = gldi_window_parse_class(pClassHint->res_class, pClassHint->res_name);
-		if (cWMClass) *cWMClass = g_strdup (pClassHint->res_class);
+		if (cClass)
+		{
+			if (cWMClass) *cWMClass = g_strdup (pClassHint->res_class);
+			if (pClassHint->res_name && cWMName) *cWMName = g_ascii_strdown (pClassHint->res_name, -1);
+		}
 		XFree (pClassHint->res_name);
 		XFree (pClassHint->res_class);
 		XFree (pClassHint);

--- a/src/implementations/cairo-dock-X-utilities.h
+++ b/src/implementations/cairo-dock-X-utilities.h
@@ -108,7 +108,7 @@ void cairo_dock_set_xwindow_border (Window Xid, gboolean bWithBorder);
 // GET //
 gulong cairo_dock_get_xwindow_timestamp (Window Xid);
 gchar *cairo_dock_get_xwindow_name (Window Xid, gboolean bSearchWmName);
-gchar *cairo_dock_get_xwindow_class (Window Xid, gchar **cWMClass);
+gchar *cairo_dock_get_xwindow_class (Window Xid, gchar **cWMClass, gchar **cWMName);
 
 gboolean cairo_dock_xwindow_is_maximized (Window Xid);
 gboolean cairo_dock_xwindow_is_fullscreen (Window Xid);


### PR DESCRIPTION
This seems necessary to identify some apps.