### PR TITLE
backport: container: do not emit "fake" leave/enter events

### DIFF
--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -359,13 +359,15 @@ gboolean cairo_dock_emit_signal_on_container (GldiContainer *pContainer, const g
 }
 gboolean cairo_dock_emit_leave_signal (GldiContainer *pContainer)
 {
-	// actualize the coordinates of the pointer, since they are most probably out-dated (because the mouse has left the dock, or because a right-click generates an event with (0;0) coordinates)
-	gldi_container_update_mouse_position (pContainer);
-	return cairo_dock_emit_signal_on_container (pContainer, "leave-notify-event");
+	if (CAIRO_DOCK_IS_DOCK (pContainer))
+		gldi_dock_leave_synthetic (CAIRO_DOCK (pContainer));
+	return FALSE;
 }
 gboolean cairo_dock_emit_enter_signal (GldiContainer *pContainer)
 {
-	return cairo_dock_emit_signal_on_container (pContainer, "enter-notify-event");
+	if (CAIRO_DOCK_IS_DOCK (pContainer))
+		gldi_dock_enter_synthetic (CAIRO_DOCK (pContainer));
+	return FALSE;
 }
 
 

--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -674,6 +674,13 @@ static gboolean _on_leave_notify (G_GNUC_UNUSED GtkWidget* pWidget, GdkEventCros
 	return TRUE;
 }
 
+void gldi_dock_leave_synthetic (CairoDock *pDock)
+{
+	// actualize the coordinates of the pointer, since they are most probably out-dated (because the mouse has left the dock, or because a right-click generates an event with (0;0) coordinates)
+	gldi_container_update_mouse_position (&pDock->container);
+	_on_leave_notify (NULL, NULL, pDock);
+}
+
 static gboolean _on_enter_notify (G_GNUC_UNUSED GtkWidget* pWidget, GdkEventCrossing* pEvent, CairoDock *pDock)
 {
 	//g_print ("%s (bIsMainDock : %d; bInside:%d; state:%d; iMagnitudeIndex:%d; input shape:%p; event:%p)\n", __func__, pDock->bIsMainDock, pDock->container.bInside, pDock->iInputState, pDock->iMagnitudeIndex, pDock->pShapeBitmap, pEvent);
@@ -816,6 +823,11 @@ static gboolean _on_enter_notify (G_GNUC_UNUSED GtkWidget* pWidget, GdkEventCros
 	}
 	
 	return TRUE;
+}
+
+void gldi_dock_enter_synthetic (CairoDock *pDock)
+{
+	_on_enter_notify (NULL, NULL, pDock);
 }
 
 

--- a/src/gldit/cairo-dock-dock-factory.h
+++ b/src/gldit/cairo-dock-dock-factory.h
@@ -341,5 +341,21 @@ void cairo_dock_set_icon_size_in_dock (CairoDock *pDock, Icon *icon);
 
 void cairo_dock_create_redirect_texture_for_dock (CairoDock *pDock);
 
+/** Notify pDock that the mouse has possibly left it, just as if it
+*  received the "leave-notify-event" signal from GTK. Use this e.g.
+*  when a subdock, dialog or menu is closed and the dock should shrink
+*  down if the mouse is not over it.
+*@param pDock a dock.
+*/
+void gldi_dock_leave_synthetic (CairoDock *pDock);
+
+/** Notify pDock that the mouse has possibly entered it, just as if it
+*  received the "enter-notify-event" signal from GTK. Use this e.g.
+*  when a dialog is shown to prevent the dock from hiding.
+*@param pDock a dock.
+*/
+void gldi_dock_enter_synthetic (CairoDock *pDock);
+
+
 G_END_DECLS
 #endif


### PR DESCRIPTION
This can lead to crashes on newer GTK versions. It is simpler to just call our signal handlers directly.

This backports changes proposed for the development version that fix a critical bug.