### PR TITLE
Update API for synthetic leave / enter events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include ("${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/GNUInstallDirs.cmake")
 ########### project ###############
 
 project ("cairo-dock")
-set (VERSION "3.5.99.rc1") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.5.99.rc2") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/src/cairo-dock-user-interaction.c
+++ b/src/cairo-dock-user-interaction.c
@@ -215,7 +215,7 @@ gboolean cairo_dock_notification_click_icon (G_GNUC_UNUSED gpointer pUserData, I
 		{
 			_show_all_windows (icon->pSubDock->icons); // show all windows
 			// in case the dock is visible or about to be visible, hide it, as it would confuse the user to have both.
-			cairo_dock_emit_leave_signal (CAIRO_CONTAINER (icon->pSubDock));
+			gldi_dock_leave_synthetic (icon->pSubDock);
 			return GLDI_NOTIFICATION_INTERCEPT;
 		}
 	}

--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -607,26 +607,6 @@ void gldi_container_manager_register_backend (GldiContainerManagerBackend *pBack
 }
 
 
-gboolean cairo_dock_emit_signal_on_container (GldiContainer *pContainer, const gchar *cSignal)
-{
-	static gboolean bReturn;
-	g_signal_emit_by_name (pContainer->pWidget, cSignal, NULL, &bReturn);
-	return FALSE;
-}
-gboolean cairo_dock_emit_leave_signal (GldiContainer *pContainer)
-{
-	if (CAIRO_DOCK_IS_DOCK (pContainer))
-		gldi_dock_leave_synthetic (CAIRO_DOCK (pContainer));
-	return FALSE;
-}
-gboolean cairo_dock_emit_enter_signal (GldiContainer *pContainer)
-{
-	if (CAIRO_DOCK_IS_DOCK (pContainer))
-		gldi_dock_enter_synthetic (CAIRO_DOCK (pContainer));
-	return FALSE;
-}
-
-
 static GtkWidget *s_pMenu = NULL;  // right-click menu
 GtkWidget *gldi_container_build_menu (GldiContainer *pContainer, Icon *icon)
 {

--- a/src/gldit/cairo-dock-container.h
+++ b/src/gldit/cairo-dock-container.h
@@ -433,10 +433,6 @@ GdkAtom gldi_container_icon_dnd_atom (void);
 void gldi_container_notify_drop_data (GldiContainer *pContainer, gchar *cReceivedData, Icon *pPointedIcon, double fOrder);
 
 
-gboolean cairo_dock_emit_signal_on_container (GldiContainer *pContainer, const gchar *cSignal);
-gboolean cairo_dock_emit_leave_signal (GldiContainer *pContainer);
-gboolean cairo_dock_emit_enter_signal (GldiContainer *pContainer);
-
 /** Build the main menu of a Container.
 *@param icon the icon that was left-clicked, or NULL if none.
 *@param pContainer the container that was left-clicked.

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -872,7 +872,7 @@ void gldi_dialog_leave (CairoDialog *pDialog)
 			if (CAIRO_DOCK_IS_DOCK (pContainer) && gtk_window_get_modal (GTK_WINDOW (pDialog->container.pWidget)))
 			{
 				CAIRO_DOCK (pContainer)->bHasModalWindow = FALSE;
-				cairo_dock_emit_leave_signal (pContainer);
+				gldi_dock_leave_synthetic (CAIRO_DOCK (pContainer));
 			}
 		}
 		if (pIcon->iHideLabel > 0)
@@ -953,7 +953,7 @@ static gboolean on_icon_removed (G_GNUC_UNUSED gpointer pUserData, Icon *pIcon, 
 				if (pDialog->pIcon == pIcon && gtk_window_get_modal (GTK_WINDOW (pDialog->container.pWidget)))
 				{
 					pDock->bHasModalWindow = FALSE;
-					cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pDock));
+					gldi_dock_leave_synthetic (pDock);
 					break;  // there can only be 1 modal window at a time.
 				}
 			}
@@ -1198,7 +1198,7 @@ static void init_object (GldiObject *obj, gpointer attr)
 		if (CAIRO_DOCK_IS_DOCK (pContainer))
 		{
 			CAIRO_DOCK (pContainer)->bHasModalWindow = TRUE;
-			cairo_dock_emit_enter_signal (pContainer);  // to prevent the dock from hiding. We want to see it while the dialog is visible (a leave event will be emited when it disappears).
+			gldi_dock_enter_synthetic (CAIRO_DOCK (pContainer));  // to prevent the dock from hiding. We want to see it while the dialog is visible (a leave event will be emited when it disappears).
 		}
 	}
 	pDialog->bHideOnClick = pAttribute->bHideOnClick;

--- a/src/gldit/cairo-dock-dock-facility.c
+++ b/src/gldit/cairo-dock-dock-facility.c
@@ -203,7 +203,7 @@ void cairo_dock_trigger_update_dock_size (CairoDock *pDock)
 
 static gboolean _emit_leave_signal_delayed (CairoDock *pDock)
 {
-	cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pDock));
+	gldi_dock_leave_synthetic (pDock);
 	pDock->iSidLeaveDemand = 0;
 	return FALSE;
 }
@@ -251,7 +251,7 @@ static void cairo_dock_manage_mouse_position (CairoDock *pDock)
 				    */
 				{
 					//g_print ("  we emulate a re-entry (pDock->iMagnitudeIndex:%d)\n", pDock->iMagnitudeIndex);
-					cairo_dock_emit_enter_signal (CAIRO_CONTAINER (pDock));
+					gldi_dock_enter_synthetic (pDock);
 				}
 				else // we settle for growing icons
 				{

--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -138,7 +138,7 @@ static gboolean _on_expose (G_GNUC_UNUSED GtkWidget *pWidget, cairo_t *pCairoCon
 static gboolean _emit_leave_signal_delayed (CairoDock *pDock)
 {
 	//g_print ("%s(%d)\n", __func__, pDock->iRefCount);
-	cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pDock));
+	gldi_dock_leave_synthetic (pDock);
 	pDock->iSidLeaveDemand = 0;
 	return FALSE;
 }
@@ -1602,7 +1602,7 @@ static void _hide_parent_dock (CairoDock *pDock)
 	{
 		if (pParentDock->iRefCount == 0)
 		{
-			cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pParentDock));
+			gldi_dock_leave_synthetic (pParentDock);
 		}
 		else
 		{
@@ -1957,7 +1957,7 @@ static void _on_menu_deactivated (G_GNUC_UNUSED GtkMenuShell *menu, CairoDock *p
 	if (pDock->bHasModalWindow)  // don't send the signal if the menu was already deactivated.
 	{
 		pDock->bHasModalWindow = FALSE;
-		cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pDock));
+		gldi_dock_leave_synthetic (pDock);
 	}
 }
 static void _on_menu_destroyed (GtkWidget *menu, CairoDock *pDock)

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -803,7 +803,7 @@ static void _cairo_dock_quick_hide_one_root_dock (G_GNUC_UNUSED const gchar *cDo
 	if (pDock->iRefCount == 0)
 	{
 		pDock->bAutoHide = TRUE;
-		cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pDock));
+		gldi_dock_leave_synthetic (pDock);
 	}
 }
 void cairo_dock_quick_hide_all_docks (void)
@@ -861,7 +861,7 @@ void cairo_dock_activate_temporary_auto_hide (CairoDock *pDock)
 		pDock->bTemporaryHidden = TRUE;
 		if (!pDock->container.bInside)  // on ne declenche pas le cachage lorsque l'on change par exemple de bureau via le switcher ou un clic sur une appli.
 		{
-			cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pDock));  // un cairo_dock_start_hiding ne cacherait pas les sous-docks.
+			gldi_dock_leave_synthetic (pDock);  // un cairo_dock_start_hiding ne cacherait pas les sous-docks.
 		}
 		gldi_container_update_polling_screen_edge ();
 	}
@@ -1110,7 +1110,7 @@ static gboolean _on_new_dialog (G_GNUC_UNUSED gpointer data, CairoDialog *pDialo
 	
 	if (pIcon->pSubDock)  // un sous-dock par-dessus le dialogue est tres genant.
 	{
-		cairo_dock_emit_leave_signal (CAIRO_CONTAINER (pIcon->pSubDock));
+		gldi_dock_leave_synthetic (pIcon->pSubDock);
 	}
 	
 	GldiContainer *pContainer = cairo_dock_get_icon_container (pIcon);

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20250115
+#define GLDI_ABI_VERSION 20250213
 
 // manager
 typedef struct _GldiModulesParam GldiModulesParam;


### PR DESCRIPTION
Following up on #76 this switches to the new API and removes the old `cairo_dock_emit_*` functions. This makes it clear that these functions are used only for docks. This is also an API / ABI break (just in time to include in 3.6.0)