### PR TITLE
desklet-manager: make desklets distinguishable on Wayland

### DIFF
--- a/src/gldit/cairo-dock-desklet-manager.c
+++ b/src/gldit/cairo-dock-desklet-manager.c
@@ -967,8 +967,17 @@ static void init_object (GldiObject *obj, gpointer attr)
 	Icon *pIcon = pAttributes->pIcon;
 	pDesklet->pIcon = pIcon;
 	cairo_dock_set_icon_container (pIcon, pDesklet);
-	if (CAIRO_DOCK_IS_APPLET (pIcon) && !gldi_container_is_wayland_backend ())
-		gtk_window_set_title (GTK_WINDOW (pDesklet->container.pWidget), pIcon->pModuleInstance->pModule->pVisitCard->cModuleName);
+	if (CAIRO_DOCK_IS_APPLET (pIcon))
+	{
+		if (gldi_container_is_wayland_backend ())
+		{
+			char *tmp = g_strdup_printf ("cairo-dock-desklet-%s", pIcon->pModuleInstance->pModule->pVisitCard->cModuleName);
+			gtk_window_set_title (GTK_WINDOW (pDesklet->container.pWidget), tmp);
+			g_free (tmp);
+		}
+		else
+			gtk_window_set_title (GTK_WINDOW (pDesklet->container.pWidget), pIcon->pModuleInstance->pModule->pVisitCard->cModuleName);
+	}
 	
 	// configure the desklet
 	gldi_desklet_configure (pDesklet, pAttributes);

--- a/src/implementations/cairo-dock-wayland-wm.c
+++ b/src/implementations/cairo-dock-wayland-wm.c
@@ -338,7 +338,7 @@ void gldi_wayland_wm_done (GldiWaylandWindowActor *wactor)
 					// we don't display our own desklets (note: no general "skip taskbar"
 					// hint, so we have to recognize them based on the app_id and title)
 					const gchar *tmp = wactor->cTitlePending ? wactor->cTitlePending : actor->cName;
-					if (tmp && !strcmp (tmp, "cairo-dock-desklet")) displayed = FALSE;
+					if (tmp && !strncmp (tmp, "cairo-dock-desklet", 18)) displayed = FALSE;
 				}
 			}
 			


### PR DESCRIPTION
This allows better using a compositors interface for placement rules.