### PR TITLE
desktop-manager: install files within our installation prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set (exec_prefix ${prefix})
 set (datadir "${prefix}/${CMAKE_INSTALL_DATAROOTDIR}")  # (...)/share
 set (pkgdatadir "${datadir}/${CMAKE_PROJECT_NAME}")  # (...)/cairo-dock
 set (mandir "${prefix}/${CMAKE_INSTALL_MANDIR}")  # (...)/man
+set (unitdir "${prefix}/lib/systemd/user") # for systemd units (if enabled)
 
 if( CMAKE_SIZEOF_VOID_P EQUAL 8 AND (force-lib64 OR "${FORCE_LIB64}" STREQUAL "yes"))  # 64bits and force install in lib64
 	set (libdir "${prefix}/lib64")

--- a/data/desktop-manager/gnome-session-3.28/CMakeLists.txt
+++ b/data/desktop-manager/gnome-session-3.28/CMakeLists.txt
@@ -1,9 +1,9 @@
 install (FILES
 	cairo-dock-compiz.desktop
 	cairo-dock-metacity.desktop
-	DESTINATION /usr/share/xsessions)
+	DESTINATION ${datadir}/xsessions)
 
 install (FILES
 	cairo-dock-compiz.session
 	cairo-dock-metacity.session
-	DESTINATION /usr/share/gnome-session/sessions)
+	DESTINATION ${datadir}/gnome-session/sessions)

--- a/data/desktop-manager/gnome-session-3.36/CMakeLists.txt
+++ b/data/desktop-manager/gnome-session-3.36/CMakeLists.txt
@@ -1,14 +1,14 @@
 install (FILES
 	cairo-dock-compiz.desktop
 	cairo-dock-metacity.desktop
-	DESTINATION /usr/share/xsessions)
+	DESTINATION ${datadir}/xsessions)
 
 install (FILES
 	cairo-dock-compiz.session
 	cairo-dock-metacity.session
-	DESTINATION /usr/share/gnome-session/sessions)
+	DESTINATION ${datadir}/gnome-session/sessions)
 
 install (FILES
 	gnome-session-x11@cairo-dock-compiz.target
 	gnome-session-x11@cairo-dock-metacity.target
-	DESTINATION /usr/lib/systemd/user)
+	DESTINATION ${unitdir})

--- a/data/systemd/CMakeLists.txt
+++ b/data/systemd/CMakeLists.txt
@@ -1,5 +1,4 @@
 if (enable-systemd-service)
 	configure_file (${CMAKE_CURRENT_SOURCE_DIR}/cairo-dock.service.in ${CMAKE_CURRENT_BINARY_DIR}/cairo-dock.service)
-	set (unitdir "${prefix}/lib/systemd/user")
 	install (FILES ${CMAKE_CURRENT_BINARY_DIR}/cairo-dock.service DESTINATION ${unitdir})
 endif()


### PR DESCRIPTION
Previously, these would always be installed under `/usr/local` which could interfere with system packages. This ensures that everything is installed under the prefix selected by the user.

Note: this can cause our sessions not showing up on the login screen if the install prefix is not a standard system location (`/usr/local` still seems to work at least on Ubuntu). If needed, the necessary files can be symlinked to the appropriate locations.