### PR TITLE
build: better detection of systemd for default value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,9 +255,16 @@ if (enable-gtk-layer-shell)
 endif()
 
 # systemd service
-pkg_check_modules ("SYSTEMD" "systemd")
-if (NOT DEFINED enable-systemd-service) # true if not defined
-	set (enable-systemd-service ${SYSTEMD_FOUND})
+if (NOT DEFINED enable-systemd-service)
+	# detect if system is running systemd
+	set (enable-systemd-service FALSE)
+	find_program(SYSTEMD_COMMAND systemd-notify)
+	if(SYSTEMD_COMMAND)
+		execute_process(COMMAND ${SYSTEMD_COMMAND} --booted RESULT_VARIABLE SYSTEMD_RUNNING)
+		if (SYSTEMD_RUNNING EQUAL 0)
+			set (enable-systemd-service TRUE)
+		endif()
+	endif()
 	if (enable-systemd-service)
 		set (with_systemd_service "yes (use '-Denable-systemd-service=False' to disable it)")
 	else()


### PR DESCRIPTION
The "enable-systemd-servie" option controls whether a systemd unit is generated and installed. If this is not set, we try to auto-detect if the host is running systemd and decide to install our unit based on this.

Before, we used pkg-config for this, but this is not necessarily a good idea, since it depends on having the systemd dev packages installed (and thus broke autodetection on e.g. Ubuntu plucky). Instead, we can run "systemd-notify --booted" which reports whether systemd is running (and if the command is not found, we can know systemd is not present anyway).