### PR TITLE
Support scale factor >1 on X11

### DIFF
--- a/src/gldit/cairo-dock-desktop-manager.h
+++ b/src/gldit/cairo-dock-desktop-manager.h
@@ -58,6 +58,10 @@ typedef enum {
 	NOTIFICATION_KEYMAP_CHANGED,
 	/// notification when the user requests the desktop menu to be shown
 	NOTIFICATION_MENU_REQUEST,
+	/// notification called when a new monitor was added, data : the GdkMonitor added
+	NOTIFICATION_DESKTOP_MONITOR_ADDED,
+	/// notification called when a monitor was removed, data : the GdkMonitor removed
+	NOTIFICATION_DESKTOP_MONITOR_REMOVED,
 	NB_NOTIFICATIONS_DESKTOP
 	} CairoDesktopNotifications;
 
@@ -264,6 +268,9 @@ void gldi_desktop_get_current (int *iCurrentDesktop, int *iCurrentViewportX, int
 #define cairo_dock_get_nth_screen(i) (i >= 0 && i < g_desktopGeometry.iNbScreens ? &g_desktopGeometry.pScreens[i] : &g_desktopGeometry.Xscreen)
 #define gldi_desktop_get_width() g_desktopGeometry.Xscreen.width
 #define gldi_desktop_get_height() g_desktopGeometry.Xscreen.height
+
+/// Get the list of monitors currently managed -- caller should not modify the GdkMonitor* pointers stored here
+GdkMonitor *const *gldi_desktop_get_monitors (int *iNumMonitors);
 
   ////////////////////////
  // Desktop background //

--- a/src/implementations/cairo-dock-X-manager.c
+++ b/src/implementations/cairo-dock-X-manager.c
@@ -256,9 +256,6 @@ static void _on_change_nb_desktops (void)
 
 static void _on_change_desktop_geometry (gboolean bIsNetDesktopGeometry)
 {
-	// check if the resolution has changed
-	gboolean bSizeChanged = cairo_dock_update_screen_geometry ();
-	
 	// check if the number of viewports has changed.
 	cairo_dock_get_nb_viewports (&g_desktopGeometry.iNbViewportX, &g_desktopGeometry.iNbViewportY);
 	_cairo_dock_retrieve_current_desktop_and_viewport ();  // au cas ou on enleve le viewport courant.
@@ -266,7 +263,7 @@ static void _on_change_desktop_geometry (gboolean bIsNetDesktopGeometry)
 	// notify everybody
 	// according to LP1901507, the dock ends up on the wrong screen after the screens go to energy-save/off mode (dual-screen/nvidia).
 	// as a workaround, we force the flag to true when it's a NetDesktopGeometry message, even if the size hasn't really changed
-	gldi_object_notify (&myDesktopMgr, NOTIFICATION_DESKTOP_GEOMETRY_CHANGED, bSizeChanged || bIsNetDesktopGeometry);
+	gldi_object_notify (&myDesktopMgr, NOTIFICATION_DESKTOP_GEOMETRY_CHANGED, bIsNetDesktopGeometry);
 }
 
 static void _update_backing_pixmap (GldiXWindowActor *actor)

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -106,174 +106,6 @@ static void _try_detect_compositor (void)
 	}
 }
 
-// manage screens -- instead of wl_output, we use GdkDisplay and GdkMonitors
-// list of monitors -- corresponds to pScreens in g_desktopGeometry from
-// cairo-dock-desktop-manager.c, and kept in sync with that
-GdkMonitor **s_pMonitors = NULL;
-// we keep track of the primary monitor
-GdkMonitor *s_pPrimaryMonitor = NULL;
-
-// refresh s_desktopGeometry.xscreen
-static void _calculate_xscreen ()
-{
-	int i;
-	g_desktopGeometry.Xscreen.x = 0;
-	g_desktopGeometry.Xscreen.y = 0;
-	g_desktopGeometry.Xscreen.width = 0;
-	g_desktopGeometry.Xscreen.height = 0;
-	
-	if (g_desktopGeometry.iNbScreens >= 0)
-		for (i = 0; i < g_desktopGeometry.iNbScreens; i++)
-		{
-			int tmpwidth = g_desktopGeometry.pScreens[i].x + g_desktopGeometry.pScreens[i].width;
-			int tmpheight = g_desktopGeometry.pScreens[i].y + g_desktopGeometry.pScreens[i].height;
-			if (tmpwidth > g_desktopGeometry.Xscreen.width)
-				g_desktopGeometry.Xscreen.width = tmpwidth;
-			if (tmpheight > g_desktopGeometry.Xscreen.height)
-				g_desktopGeometry.Xscreen.height = tmpheight;
-		}
-}
-
-// handle changes in screen / monitor configuration -- note: user_data is a boolean that determines if we should emit a signal
-static void _monitor_added (GdkDisplay *display, GdkMonitor* monitor, gpointer user_data)
-{
-	int iNumScreen = 0;
-	if (!(g_desktopGeometry.pScreens && s_pMonitors && g_desktopGeometry.iNbScreens))
-	{
-		if (g_desktopGeometry.iNbScreens || g_desktopGeometry.pScreens || s_pMonitors)
-			cd_warning ("_monitor_added() inconsistent state of screens / monitors\n");
-		g_desktopGeometry.iNbScreens = 1;
-		g_free (s_pMonitors);
-		g_free (g_desktopGeometry.pScreens);
-		s_pMonitors = g_new0 (GdkMonitor*, g_desktopGeometry.iNbScreens);
-		g_desktopGeometry.pScreens = g_new0 (GtkAllocation, g_desktopGeometry.iNbScreens);
-	}
-	else
-	{
-		iNumScreen = g_desktopGeometry.iNbScreens++;
-		s_pMonitors = g_renew (GdkMonitor*, s_pMonitors, g_desktopGeometry.iNbScreens);
-		g_desktopGeometry.pScreens = g_renew (GtkAllocation, g_desktopGeometry.pScreens, g_desktopGeometry.iNbScreens);
-	}
-	s_pMonitors[iNumScreen] = monitor;
-	// note: GtkAllocation is the same as GdkRectangle
-	gdk_monitor_get_geometry (monitor, g_desktopGeometry.pScreens + iNumScreen);
-	if (monitor == gdk_display_get_primary_monitor (display))
-		s_pPrimaryMonitor = monitor;
-	_calculate_xscreen ();
-	if (user_data) gldi_object_notify (&myDesktopMgr, NOTIFICATION_DESKTOP_GEOMETRY_CHANGED, FALSE);
-	
-	// we always send notification on the Wayland manager object
-	gldi_object_notify (&myWaylandMgr, NOTIFICATION_WAYLAND_MONITOR_ADDED, monitor);
-}
-
-// handle if a monitor was removed
-static void _monitor_removed (GdkDisplay* display, GdkMonitor* monitor, G_GNUC_UNUSED gpointer user_data)
-{
-	if (!(g_desktopGeometry.pScreens && s_pMonitors && g_desktopGeometry.iNbScreens > 0))
-		cd_warning ("_monitor_removed() inconsistent state of screens / monitors\n");
-	else
-	{
-		int i;
-		for (i = 0; i < g_desktopGeometry.iNbScreens; i++)
-			if (s_pMonitors[i] == monitor) break;
-		if (i == g_desktopGeometry.iNbScreens)
-		{
-			cd_warning ("_monitor_removed() inconsistent state of screens / monitors\n");
-			return;
-		}
-		for (; i +1 < g_desktopGeometry.iNbScreens; i++)
-		{
-			s_pMonitors[i] = s_pMonitors[i+1];
-			g_desktopGeometry.pScreens[i] = g_desktopGeometry.pScreens[i+1];
-		}
-		s_pPrimaryMonitor = gdk_display_get_primary_monitor (display);
-		if (!s_pPrimaryMonitor) s_pPrimaryMonitor = s_pMonitors[0];
-		g_desktopGeometry.iNbScreens--;
-		s_pMonitors = g_renew (GdkMonitor*, s_pMonitors, g_desktopGeometry.iNbScreens);
-		g_desktopGeometry.pScreens = g_renew (GtkAllocation, g_desktopGeometry.pScreens, g_desktopGeometry.iNbScreens);
-		_calculate_xscreen ();
-		gldi_object_notify (&myDesktopMgr, NOTIFICATION_DESKTOP_GEOMETRY_CHANGED, FALSE);
-		
-		// we always send notification on the Wayland manager object
-		gldi_object_notify (&myWaylandMgr, NOTIFICATION_WAYLAND_MONITOR_REMOVED, monitor);
-	}
-}
-
-// refresh the size of all monitors -- note: user_data is a boolean that determines if we should emit a signal
-static void _refresh_monitors_size(G_GNUC_UNUSED GdkScreen *screen, gpointer user_data)
-{
-	int i;
-	for (i = 0; i < g_desktopGeometry.iNbScreens; i++)
-		gdk_monitor_get_geometry (s_pMonitors[i], g_desktopGeometry.pScreens + i);
-	_calculate_xscreen ();
-	if (user_data) gldi_object_notify (&myDesktopMgr, NOTIFICATION_DESKTOP_GEOMETRY_CHANGED, FALSE);
-}
-
-// refresh all monitors (if needed) -- note: user_data is a boolean that determines if we should emit a signal
-static void _refresh_monitors (GdkScreen *screen, gpointer user_data)
-{
-	GdkDisplay *display = gdk_screen_get_display (screen);
-	int iNumScreen = gdk_display_get_n_monitors (display);
-	if (iNumScreen != g_desktopGeometry.iNbScreens)
-	{
-		// we don't try to guess what has changed, just refresh all monitors
-		GdkMonitor **tmp = s_pMonitors;
-		s_pMonitors = NULL;
-		int iNumOld = g_desktopGeometry.iNbScreens;
-		g_free (g_desktopGeometry.pScreens);
-		g_desktopGeometry.iNbScreens = iNumScreen;
-		s_pMonitors = g_renew (GdkMonitor*, s_pMonitors, g_desktopGeometry.iNbScreens);
-		g_desktopGeometry.pScreens = g_renew (GtkAllocation, g_desktopGeometry.pScreens, g_desktopGeometry.iNbScreens);
-		int i;
-		for (i = 0; i < iNumScreen; i++)
-		{
-			s_pMonitors[i] = gdk_display_get_monitor (display, i);
-			gdk_monitor_get_geometry (s_pMonitors[i], g_desktopGeometry.pScreens + i);
-		}
-		s_pPrimaryMonitor = gdk_display_get_primary_monitor (display);
-		if (!s_pPrimaryMonitor) s_pPrimaryMonitor = s_pMonitors[0];
-		_calculate_xscreen ();
-		if (user_data) gldi_object_notify (&myDesktopMgr, NOTIFICATION_DESKTOP_GEOMETRY_CHANGED, FALSE);
-		
-		// figure out if any monitors were added / removed and emit the Wayland-specific notifications
-		for (i = 0; i < iNumScreen; i++)
-		{
-			int j;
-			GdkMonitor *mon = s_pMonitors[i];
-			for (j = 0; j < iNumOld; j++) if (tmp[j] == mon) break;
-			if (j < iNumOld)
-			{
-				// this monitor was present before
-				if (j + 1 < iNumOld) tmp[j] = tmp[iNumOld - 1];
-				iNumOld--;
-			}
-			else gldi_object_notify (&myWaylandMgr, NOTIFICATION_WAYLAND_MONITOR_ADDED, mon);
-		}
-		// send notifications for monitors
-		for (i = 0; i < iNumOld; i++) gldi_object_notify (&myWaylandMgr, NOTIFICATION_WAYLAND_MONITOR_REMOVED, tmp[i]);
-		
-		g_free(tmp);
-	}
-	else _refresh_monitors_size (screen, user_data);
-}
-
-static GdkMonitor* _get_monitor (int iNumScreen)
-{
-	GdkMonitor *monitor = (iNumScreen >= 0 && iNumScreen < g_desktopGeometry.iNbScreens) ?
-		s_pMonitors[iNumScreen] : s_pPrimaryMonitor;
-	return monitor;
-}
-
-GdkMonitor* gldi_dock_wayland_get_monitor (CairoDock *pDock)
-{
-	return _get_monitor (pDock->iNumScreen);
-}
-
-GdkMonitor *const *gldi_wayland_get_monitors (int *iNumMonitors)
-{
-	*iNumMonitors = g_desktopGeometry.iNbScreens;
-	return s_pMonitors;
-}
 
 CairoDockPositionType gldi_wayland_get_edge_for_dock (const CairoDock *pDock)
 {
@@ -391,11 +223,15 @@ static void _layer_shell_init_for_window (GldiContainer *pContainer)
 
 static void _layer_shell_move_to_monitor (GldiContainer *pContainer, int iNumScreen)
 {
+	if (iNumScreen < 0) return;
 	GtkWindow *window = GTK_WINDOW (pContainer->pWidget);
 	// this only works for parent windows, not popups
 	if (gtk_window_get_transient_for (window)) return;
-	GdkMonitor *monitor = _get_monitor (iNumScreen);
-	if (monitor) gtk_layer_set_monitor (window, monitor);
+	
+	int iNumMonitors = 0;
+	GdkMonitor *const *pMonitors = gldi_desktop_get_monitors (&iNumMonitors);
+	if (iNumScreen >= iNumMonitors) return;
+	gtk_layer_set_monitor (window, pMonitors[iNumScreen]);
 }
 #endif
 
@@ -735,18 +571,6 @@ void gldi_register_wayland_manager (void)
 	gldi_object_install_notifications (&myWaylandMgr, NB_NOTIFICATIONS_WAYLAND_DESKTOP);
 	// register
 	gldi_object_init (GLDI_OBJECT(&myWaylandMgr), &myManagerObjectMgr, NULL);
-	
-	// get the properties of screens / monitors, set up signals
-	g_desktopGeometry.iNbScreens = 0;
-	g_desktopGeometry.pScreens = NULL;
-	GdkScreen *screen = gdk_display_get_default_screen (dsp);
-	// fill out the list of screens / monitors
-	_refresh_monitors (screen, (gpointer)FALSE);
-	// set up notifications for screens added / removed
-	g_signal_connect (G_OBJECT (screen), "monitors-changed", G_CALLBACK (_refresh_monitors), (gpointer)TRUE);
-	g_signal_connect (G_OBJECT (screen), "size-changed", G_CALLBACK (_refresh_monitors_size), (gpointer)TRUE);
-	g_signal_connect (G_OBJECT (dsp), "monitor-added", G_CALLBACK (_monitor_added), (gpointer)TRUE);
-	g_signal_connect (G_OBJECT (dsp), "monitor-removed", G_CALLBACK (_monitor_removed), (gpointer)TRUE);
 }
 
 gboolean gldi_wayland_manager_have_layer_shell ()

--- a/src/implementations/cairo-dock-wayland-manager.h
+++ b/src/implementations/cairo-dock-wayland-manager.h
@@ -38,11 +38,7 @@ extern GldiManager myWaylandMgr;
 #endif
 
 typedef enum {
-	/// notification called when a new monitor was added, data : the GdkMonitor added
-	NOTIFICATION_WAYLAND_MONITOR_ADDED = NB_NOTIFICATIONS_OBJECT,
-	/// notification called when a monitor was removed, data : the GdkMonitor removed
-	NOTIFICATION_WAYLAND_MONITOR_REMOVED,
-	NB_NOTIFICATIONS_WAYLAND_DESKTOP
+	NB_NOTIFICATIONS_WAYLAND_DESKTOP = NB_NOTIFICATIONS_OBJECT
 	} CairoWaylandDesktopNotifications;
 
 void gldi_register_wayland_manager (void);
@@ -51,12 +47,6 @@ gboolean gldi_wayland_manager_have_layer_shell ();
 
 /// Get the screen edge this dock should be anchored to
 CairoDockPositionType gldi_wayland_get_edge_for_dock (const CairoDock *pDock);
-
-/// Get the GdkMonitor a given dock is on as managed by this class
-GdkMonitor *gldi_dock_wayland_get_monitor (CairoDock *pDock);
-
-/// Get the list of monitors currently managed -- caller should not modify the GdkMonitor* pointers stored here
-GdkMonitor *const *gldi_wayland_get_monitors (int *iNumMonitors);
 
 /// Functions to try to grab / ungrab the keyboard
 ///  (via setting the corresponding keyboard-interactivity property in wlr-layer-shell)


### PR DESCRIPTION
- [x] Always use GDK functions to get screen size (these report scaled sizes which can be used for positioning docks with GTK / GDK)
- [ ] X11: Use correct scale when determining desktop layout (number of desktops, workspaces)
- [ ] X11: Use correct scale when tracking window positions / sending windows to specific workspace / monitor
- [ ] Test with multiple desktops (Openbox), multiple workspaces (Compiz)
- [ ] Test with multiple monitors, potentially different scale