### PR TITLE
wayland-wm: signal a stacking order change when a window is closed

### DIFF
--- a/src/implementations/cairo-dock-wayland-wm.c
+++ b/src/implementations/cairo-dock-wayland-wm.c
@@ -315,6 +315,7 @@ void gldi_wayland_wm_done (GldiWaylandWindowActor *wactor)
 				if (actor == s_pLastActiveWindow) s_pLastActiveWindow = NULL;
 				if (actor == s_pMaybeActiveWindow) s_pMaybeActiveWindow = NULL;
 				gldi_object_unref (GLDI_OBJECT(actor));
+				s_bStackChange = TRUE;
 				break;
 			}
 			


### PR DESCRIPTION
Fixes #88 
This fixes not showing a hidden dock if the window overlapping with it is closed.