### PR TITLE
Some bug fixes

### DIFF
--- a/src/gldit/cairo-dock-applications-manager.c
+++ b/src/gldit/cairo-dock-applications-manager.c
@@ -593,30 +593,14 @@ void cairo_dock_set_icons_geometry_for_window_manager (CairoDock *pDock)
 		return ;
 	//g_print ("%s (main:%d, ref:%d)\n", __func__, pDock->bIsMainDock, pDock->iRefCount);
 	
-	/*long *data = g_new0 (long, 1+6*g_list_length (pDock->icons));
-	int i = 0;*/
 	Icon *icon;
 	GList *ic;
 	for (ic = pDock->icons; ic != NULL; ic = ic->next)
 	{
 		icon = ic->data;
 		if (CAIRO_DOCK_IS_APPLI (icon))
-		{
 			gldi_appli_icon_set_geometry_for_window_manager (icon, pDock);
-			/*data[1+6*i+0] = 5;
-			data[1+6*i+1] = icon->Xid;
-			data[1+6*i+2] = pDock->container.iWindowPositionX + icon->fXAtRest;
-			data[1+6*i+3] = 0;
-			data[1+6*i+4] = icon->fWidth;
-			data[1+6*i+5] = icon->fHeight;
-			i ++;*/
-		}
 	}
-	
-	/*data[0] = i;
-	Atom atom = XInternAtom (gdk_x11_get_default_xdisplay(), "_KDE_WINDOW_PREVIEW", False);
-	Window Xid = GDK_WINDOW_XID (pDock->container.pWidget->window);
-	XChangeProperty(gdk_x11_get_default_xdisplay(), Xid, atom, atom, 32, PropModeReplace, data, 1+6*i);*/
 	
 	if (pDock->bIsMainDock && myTaskbarParam.bHideVisibleApplis)  // on complete avec les applis pas dans le dock, pour que l'effet de minimisation pointe (a peu pres) au bon endroit quand on la minimisera.
 	{

--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -2078,7 +2078,7 @@ static void _detach_icon (GldiContainer *pContainer, Icon *icon)
 	if (icon->pAppli != NULL)
 	{
 		//cd_debug ("on desactive la miniature de %s (Xid : %lx)", icon->cName, icon->Xid);
-		gldi_window_set_thumbnail_area (icon->pAppli, pContainer->pWidget, 0, 0, 0, 0);
+		gldi_window_set_thumbnail_area (icon->pAppli, pContainer, 0, 0, 0, 0);
 	}
 	
 	//\___________________ On l'enleve de la liste.

--- a/src/gldit/cairo-dock-module-instance-manager.c
+++ b/src/gldit/cairo-dock-module-instance-manager.c
@@ -697,6 +697,10 @@ static GKeyFile* reload_object (GldiObject *obj, gboolean bReadConfig, GKeyFile 
 			 * desklet mode, since the desklet doesn't have a renderer yet (so
 			 * buffer can't be loaded).
 			 */
+			 if (pIcon->pSubDock && gldi_container_use_new_positioning_code ())
+			 {
+				 gtk_window_set_transient_for (GTK_WINDOW (pIcon->pSubDock->container.pWidget), GTK_WINDOW (pNewDock->container.pWidget));
+			 }
 		}
 		else  // same dock, just update its size.
 		{

--- a/src/gldit/cairo-dock-utils.c
+++ b/src/gldit/cairo-dock-utils.c
@@ -407,7 +407,9 @@ static void _pid_callback (GDesktopAppInfo* appinfo, GPid pid, gpointer)
 	if (s_backend.new_app_launched)
 	{
 		char *desc = g_strdup_printf ("%s - %s", g_app_info_get_display_name (G_APP_INFO (appinfo)), g_app_info_get_description (G_APP_INFO (appinfo)));
-		s_backend.new_app_launched (g_app_info_get_id (G_APP_INFO (appinfo)), desc, pid);
+		const char *id = g_app_info_get_id (G_APP_INFO (appinfo));
+		if (!id) id = "unknown"; // ID does not matter but should not be NULL
+		s_backend.new_app_launched (id, desc, pid);
 		g_free (desc);
 	}
 	else g_child_watch_add (pid, _child_watch_dummy, NULL);

--- a/src/gldit/cairo-dock-utils.h
+++ b/src/gldit/cairo-dock-utils.h
@@ -107,8 +107,9 @@ struct _GldiChildProcessManagerBackend {
 	/** Handle a newly launched child process, performing any system-specific setup functions.
 	 * This should also eventually call waitpid() or similar to clean up the child process.
 	 *
-	 *@param id  an identifier for the newly launched process, containing only "safe" characters
-	 *           (currently this means only characters valid in systemd unit names: ASCII letters, digits, ":", "-", "_", ".", and "\")
+	 *@param id  a non-NULL identifier for the newly launched process, containing only "safe" characters
+	 *           (currently this means only characters valid in systemd unit names: ASCII letters, digits, ":", "-", "_", ".", and "\");
+	 * 			 does not need to be unique
 	 *@param desc  a description suitable to display to the user
 	 *@param pid  process id of the newly launched process; the caller should not use waitpid()
 	 *            or similar facility to avoid race condition

--- a/src/gldit/cairo-dock-windows-manager.c
+++ b/src/gldit/cairo-dock-windows-manager.c
@@ -194,18 +194,18 @@ void gldi_window_set_above (GldiWindowActor *actor, gboolean bAbove)
 		s_backend.set_above (actor, bAbove);
 }
 
-void gldi_window_set_minimize_position (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y)
+void gldi_window_set_minimize_position (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y)
 {
 	g_return_if_fail (actor != NULL);
 	if (s_backend.set_minimize_position)
-		s_backend.set_minimize_position (actor, pContainerWidget, x, y);
+		s_backend.set_minimize_position (actor, pContainer, x, y);
 }
 
-void gldi_window_set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y, int w, int h)
+void gldi_window_set_thumbnail_area (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y, int w, int h)
 {
 	g_return_if_fail (actor != NULL);
 	if (s_backend.set_thumbnail_area)
-		s_backend.set_thumbnail_area (actor, pContainerWidget, x, y, w, h);
+		s_backend.set_thumbnail_area (actor, pContainer, x, y, w, h);
 }
 
 GldiWindowActor *gldi_windows_get_active (void)

--- a/src/gldit/cairo-dock-windows-manager.h
+++ b/src/gldit/cairo-dock-windows-manager.h
@@ -72,8 +72,8 @@ struct _GldiWindowManagerBackend {
 	void (*maximize) (GldiWindowActor *actor, gboolean bMaximize);
 	void (*set_fullscreen) (GldiWindowActor *actor, gboolean bFullScreen);
 	void (*set_above) (GldiWindowActor *actor, gboolean bAbove);
-	void (*set_minimize_position) (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y);
-	void (*set_thumbnail_area) (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y, int w, int h);
+	void (*set_minimize_position) (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y);
+	void (*set_thumbnail_area) (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y, int w, int h);
 	void (*set_window_border) (GldiWindowActor *actor, gboolean bWithBorder);
 	cairo_surface_t* (*get_icon_surface) (GldiWindowActor *actor, int iWidth, int iHeight);
 	cairo_surface_t* (*get_thumbnail_surface) (GldiWindowActor *actor, int iWidth, int iHeight);
@@ -152,13 +152,11 @@ void gldi_window_maximize (GldiWindowActor *actor, gboolean bMaximize);
 void gldi_window_set_fullscreen (GldiWindowActor *actor, gboolean bFullScreen);
 void gldi_window_set_above (GldiWindowActor *actor, gboolean bAbove);
 
-/// note: on Wayland, coordinates are relative to the passed widget's main surface (the wl_surface corresponding to its GdkWindow)
-/// on X11, pContainerWidget is ignored
-void gldi_window_set_minimize_position (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y);
+/// note: coordinates are relative to the passed container's main surface
+void gldi_window_set_minimize_position (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y);
 
-/// note: on Wayland, coordinates are relative to the passed widget's main surface (the wl_surface corresponding to its GdkWindow)
-/// on X11, pContainerWidget is ignored
-void gldi_window_set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y, int w, int h);
+/// note: coordinates are relative to the passed container's main surface
+void gldi_window_set_thumbnail_area (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y, int w, int h);
 
 void gldi_window_set_border (GldiWindowActor *actor, gboolean bWithBorder);
 

--- a/src/implementations/cairo-dock-X-manager.c
+++ b/src/implementations/cairo-dock-X-manager.c
@@ -982,16 +982,26 @@ static void _set_above (GldiWindowActor *actor, gboolean bAbove)
 	cairo_dock_set_xwindow_above (xactor->Xid, bAbove);
 }
 
-static void _set_minimize_position (GldiWindowActor *actor, G_GNUC_UNUSED GtkWidget* pContainerWidget, int x, int y)
+static void _set_thumbnail_area (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y, int w, int h)
 {
-	GldiXWindowActor *xactor = (GldiXWindowActor *)actor;
-	cairo_dock_set_xicon_geometry (xactor->Xid, x, y, 1, 1);
-}
-
-static void _set_thumbnail_area (GldiWindowActor *actor, G_GNUC_UNUSED GtkWidget* pContainerWidget, int x, int y, int w, int h)
-{
+	if (pContainer->bIsHorizontal)
+	{
+		x += pContainer->iWindowPositionX;
+		y += pContainer->iWindowPositionY;
+	}
+	else
+	{
+		x += pContainer->iWindowPositionY;
+		y += pContainer->iWindowPositionX;
+	}
+	
 	GldiXWindowActor *xactor = (GldiXWindowActor *)actor;
 	cairo_dock_set_xicon_geometry (xactor->Xid, x, y, w, h);
+}
+
+static void _set_minimize_position (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y)
+{
+	_set_thumbnail_area (actor, pContainer, x, y, 1, 1);
 }
 
 static GldiWindowActor* _get_active_window (void)

--- a/src/implementations/cairo-dock-cosmic-toplevel.c
+++ b/src/implementations/cairo-dock-cosmic-toplevel.c
@@ -29,6 +29,7 @@
 #include "wayland-cosmic-toplevel-info-client-protocol.h"
 #include "cairo-dock-desktop-manager.h"
 #include "cairo-dock-windows-manager.h"
+#include "cairo-dock-container.h"
 #include "cairo-dock-log.h"
 #include "cairo-dock-cosmic-toplevel.h"
 #include "cairo-dock-wayland-wm.h"
@@ -115,12 +116,12 @@ static void _can_minimize_maximize_close ( G_GNUC_UNUSED GldiWindowActor *actor,
 
 /// TODO: which one of these two are really used? In cairo-dock-X-manager.c,
 /// they seem to do the same thing
-static void _set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y, int w, int h)
+static void _set_thumbnail_area (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y, int w, int h)
 {
-	if ( ! (actor && pContainerWidget) ) return;
+	if ( ! (actor && pContainer) ) return;
 	if (w < 0 || h < 0) return;
 	GldiWaylandWindowActor *wactor = (GldiWaylandWindowActor *)actor;
-	GdkWindow* window = gtk_widget_get_window (pContainerWidget);
+	GdkWindow* window = gldi_container_get_gdk_window (pContainer);
 	if (!window) return;
 	struct wl_surface* surface = gdk_wayland_window_get_wl_surface (window);
 	if (!surface) return;
@@ -128,9 +129,9 @@ static void _set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWi
 	zcosmic_toplevel_manager_v1_set_rectangle(s_ptoplevel_manager, wactor->handle, surface, x, y, w, h);
 }
 
-static void _set_minimize_position (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y)
+static void _set_minimize_position (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y)
 {
-	_set_thumbnail_area (actor, pContainerWidget, x, y, 1, 1);
+	_set_thumbnail_area (actor, pContainer, x, y, 1, 1);
 }
 
 static void _set_fullscreen (GldiWindowActor *actor, gboolean bFullScreen)

--- a/src/implementations/cairo-dock-foreign-toplevel.c
+++ b/src/implementations/cairo-dock-foreign-toplevel.c
@@ -27,6 +27,7 @@
 #include "wayland-wlr-foreign-toplevel-management-client-protocol.h"
 #include "cairo-dock-desktop-manager.h"
 #include "cairo-dock-windows-manager.h"
+#include "cairo-dock-container.h"
 #include "cairo-dock-log.h"
 #include "cairo-dock-foreign-toplevel.h"
 #include "cairo-dock-wayland-wm.h"
@@ -90,12 +91,12 @@ static void _can_minimize_maximize_close ( G_GNUC_UNUSED GldiWindowActor *actor,
 
 /// TODO: which one of these two are really used? In cairo-dock-X-manager.c,
 /// they seem to do the same thing
-static void _set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y, int w, int h)
+static void _set_thumbnail_area (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y, int w, int h)
 {
-	if ( ! (actor && pContainerWidget) ) return;
+	if ( ! (actor && pContainer) ) return;
 	if (w < 0 || h < 0) return;
 	GldiWaylandWindowActor *wactor = (GldiWaylandWindowActor *)actor;
-	GdkWindow* window = gtk_widget_get_window (pContainerWidget);
+	GdkWindow* window = gldi_container_get_gdk_window (pContainer);
 	if (!window) return;
 	struct wl_surface* surface = gdk_wayland_window_get_wl_surface (window);
 	if (!surface) return;
@@ -103,9 +104,9 @@ static void _set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWi
 	zwlr_foreign_toplevel_handle_v1_set_rectangle(wactor->handle, surface, x, y, w, h);
 }
 
-static void _set_minimize_position (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y)
+static void _set_minimize_position (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y)
 {
-	_set_thumbnail_area (actor, pContainerWidget, x, y, 1, 1);
+	_set_thumbnail_area (actor, pContainer, x, y, 1, 1);
 }
 
 static void _set_fullscreen (GldiWindowActor *actor, gboolean bFullScreen)

--- a/src/implementations/cairo-dock-plasma-window-manager.c
+++ b/src/implementations/cairo-dock-plasma-window-manager.c
@@ -31,6 +31,7 @@
 #include "wayland-plasma-window-management-client-protocol.h"
 #include "cairo-dock-windows-manager.h"
 #include "cairo-dock-desktop-manager.h"
+#include "cairo-dock-container.h"
 #include "cairo-dock-log.h"
 #include "cairo-dock-plasma-window-manager.h"
 #include "cairo-dock-desktop-manager.h"
@@ -172,12 +173,12 @@ static void _can_minimize_maximize_close ( G_GNUC_UNUSED GldiWindowActor *actor,
 
 /// TODO: which one of these two are really used? In cairo-dock-X-manager.c,
 /// they seem to do the same thing
-static void _set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y, int w, int h)
+static void _set_thumbnail_area (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y, int w, int h)
 {
-	if ( ! (actor && pContainerWidget) ) return;
+	if ( ! (actor && pContainer) ) return;
 	if (w < 0 || h < 0) return;
 	GldiWaylandWindowActor *wactor = (GldiWaylandWindowActor *)actor;
-	GdkWindow* window = gtk_widget_get_window (pContainerWidget);
+	GdkWindow* window = gldi_container_get_gdk_window (pContainer);
 	if (!window) return;
 	struct wl_surface* surface = gdk_wayland_window_get_wl_surface (window);
 	if (!surface) return;
@@ -185,9 +186,9 @@ static void _set_thumbnail_area (GldiWindowActor *actor, GtkWidget* pContainerWi
 	org_kde_plasma_window_set_minimized_geometry(wactor->handle, surface, x, y, w, h);
 }
 
-static void _set_minimize_position (GldiWindowActor *actor, GtkWidget* pContainerWidget, int x, int y)
+static void _set_minimize_position (GldiWindowActor *actor, GldiContainer* pContainer, int x, int y)
 {
-	_set_thumbnail_area (actor, pContainerWidget, x, y, 1, 1);
+	_set_thumbnail_area (actor, pContainer, x, y, 1, 1);
 }
 
 


### PR DESCRIPTION
This fixes several issues that I noticed recently:
 - crash in systemd-integration when starting an app with a custom launcher (no desktop file ID is given)
 - crash if an applet with a subdock is moved out from a dock that is deleted + wrong position in other cases (parent window needs to be updated with GTK)
 - window minimize positions should be relative to the dock's surface on Wayland (was still using absolute coordinates)