### PR TITLE
dock-visibility: properly use absolute positions on Wayland and simplify API

### DIFF
--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -45,7 +45,7 @@
 #include "cairo-dock-log.h"
 #include "cairo-dock-menu.h"  // gldi_menu_popup
 #include "cairo-dock-dock-manager.h"
-#include "cairo-dock-dock-visibility.h"  // gldi_dock_search_overlapping_window
+#include "cairo-dock-dock-visibility.h"  // gldi_dock_visibility_refresh
 #include "cairo-dock-flying-container.h"
 #include "cairo-dock-backends-manager.h"
 #include "cairo-dock-class-manager.h"  // cairo_dock_check_class_subdock_is_empty
@@ -1252,35 +1252,7 @@ static gboolean _on_configure (GtkWidget* pWidget, GdkEventConfigure* pEvent, Ca
 	}
 	
 	if (pDock->iRefCount == 0 && (bSizeUpdated || bPositionUpdated))
-	{
-		if (pDock->iVisibility == CAIRO_DOCK_VISI_AUTO_HIDE_ON_OVERLAP)
-		{
-			GldiWindowActor *pActiveAppli = gldi_windows_get_active ();
-			if (_gldi_window_is_on_our_way (pActiveAppli, pDock))  // la fenetre active nous gene.
-			{
-				if (!cairo_dock_is_temporary_hidden (pDock))
-					cairo_dock_activate_temporary_auto_hide (pDock);
-			}
-			else
-			{
-				if (cairo_dock_is_temporary_hidden (pDock))
-					cairo_dock_deactivate_temporary_auto_hide (pDock);
-			}
-		}
-		else if (pDock->iVisibility == CAIRO_DOCK_VISI_AUTO_HIDE_ON_OVERLAP_ANY)
-		{
-			if (gldi_dock_search_overlapping_window (pDock) != NULL)
-			{
-				if (!cairo_dock_is_temporary_hidden (pDock))
-					cairo_dock_activate_temporary_auto_hide (pDock);
-			}
-			else
-			{
-				if (cairo_dock_is_temporary_hidden (pDock))
-					cairo_dock_deactivate_temporary_auto_hide (pDock);
-			}
-		}
-	}
+		gldi_dock_visibility_refresh (pDock);
 	
 	gtk_widget_queue_draw (pWidget);
 	

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -982,24 +982,17 @@ void gldi_dock_set_visibility (CairoDock *pDock, CairoDockVisibility iVisibility
 			pDock->bAutoHide = TRUE;
 			cairo_dock_start_hiding (pDock);
 		}
-		else if (bAutoHideOnAnyOverlap)
+		else if (bAutoHideOnAnyOverlap || bAutoHideOnOverlap)
 		{
 			pDock->bTemporaryHidden = pDock->bAutoHide;  // needed to use the following function
-			gldi_dock_hide_if_any_window_overlap_or_show (pDock);
+			gldi_dock_visibility_refresh (pDock);
 		}
 		else
 		{
-			if (! bAutoHideOnOverlap)
-			{
-				pDock->bTemporaryHidden = FALSE;
-				pDock->bAutoHide = FALSE;
-				cairo_dock_start_showing (pDock);
-			}
-			if (bAutoHideOnOverlap)
-			{
-				pDock->bTemporaryHidden = pDock->bAutoHide;  // needed to use the following function
-				gldi_dock_hide_show_if_current_window_is_on_our_way (pDock);
-			}
+			// all three are false, we should show the dock now
+			pDock->bTemporaryHidden = FALSE;
+			pDock->bAutoHide = FALSE;
+			cairo_dock_start_showing (pDock);
 		}
 	}
 	

--- a/src/gldit/cairo-dock-dock-visibility.c
+++ b/src/gldit/cairo-dock-dock-visibility.c
@@ -32,6 +32,10 @@
  // Dock visibility //
 /////////////////////
 
+#define _gldi_window_is_on_our_way(pAppli, pDock) (pAppli != NULL && gldi_window_is_on_current_desktop (pAppli) &&  pDock->iVisibility == CAIRO_DOCK_VISI_AUTO_HIDE_ON_OVERLAP && gldi_dock_overlaps_window (pDock, pAppli))
+
+static gboolean gldi_dock_overlaps_window (CairoDock *pDock, GldiWindowActor *actor);
+
 static void _show_if_no_overlapping_window (CairoDock *pDock, G_GNUC_UNUSED gpointer data)
 {
 	if (pDock->iVisibility != CAIRO_DOCK_VISI_AUTO_HIDE_ON_OVERLAP_ANY)
@@ -254,15 +258,10 @@ static gboolean _on_active_window_changed (G_GNUC_UNUSED gpointer data, GldiWind
  // Utilities //
 ///////////////
 
-void gldi_dock_hide_show_if_current_window_is_on_our_way (CairoDock *pDock)
+static void gldi_dock_hide_show_if_current_window_is_on_our_way (CairoDock *pDock)
 {
 	GldiWindowActor *pCurrentAppli = gldi_windows_get_active ();
 	_hide_show_if_on_our_way (pDock, pCurrentAppli);
-}
-
-void gldi_dock_hide_if_any_window_overlap_or_show (CairoDock *pDock)
-{
-	_hide_if_any_overlap_or_show (pDock, NULL);
 }
 
 void gldi_dock_visibility_refresh (CairoDock *pDock)
@@ -305,7 +304,7 @@ static inline gboolean _window_overlaps_dock (GtkAllocation *pWindowGeometry, gb
 	}
 	return FALSE;
 }
-gboolean gldi_dock_overlaps_window (CairoDock *pDock, GldiWindowActor *actor)
+static gboolean gldi_dock_overlaps_window (CairoDock *pDock, GldiWindowActor *actor)
 {
 	return _window_overlaps_dock (&actor->windowGeometry, actor->bIsHidden || !actor->bDisplayed, pDock);
 }

--- a/src/gldit/cairo-dock-dock-visibility.h
+++ b/src/gldit/cairo-dock-dock-visibility.h
@@ -28,17 +28,8 @@ G_BEGIN_DECLS
 *@file cairo-dock-dock-visibility.h This class manages the visibility of Docks.
 */
 
-#define _gldi_window_is_on_our_way(pAppli, pDock) (pAppli != NULL && gldi_window_is_on_current_desktop (pAppli) &&  pDock->iVisibility == CAIRO_DOCK_VISI_AUTO_HIDE_ON_OVERLAP && gldi_dock_overlaps_window (pDock, pAppli))
-
-void gldi_dock_hide_show_if_current_window_is_on_our_way (CairoDock *pDock);
-
-void gldi_dock_hide_if_any_window_overlap_or_show (CairoDock *pDock);
-
 /** Re-check if the given dock should be shown given its visibility settings */
 void gldi_dock_visibility_refresh (CairoDock *pDock);
-
-gboolean gldi_dock_overlaps_window (CairoDock *pDock, GldiWindowActor *actor);
-
 
 /** Get the application whose window overlaps a dock, or NULL if none.
 *@param pDock the dock to test.


### PR DESCRIPTION
This fixes detecting overlaps with windows (on KWin) if the dock is not on the top-left monitor.