### PR TITLE
GUI: remove configuration of shortkeys on Wayland

### DIFF
--- a/src/cairo-dock-widget-shortkeys.c
+++ b/src/cairo-dock-widget-shortkeys.c
@@ -253,7 +253,20 @@ ShortkeysWidget *cairo_dock_shortkeys_widget_new (void)
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (pScrolledWindow), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 	gtk_container_add (GTK_CONTAINER (pScrolledWindow), pShortkeysWidget->pShortKeysTreeView);
 	
-	pShortkeysWidget->widget.pWidget = pScrolledWindow;
+	if (gldi_container_is_wayland_backend ())
+	{
+		GtkWidget *pBoxV = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
+		GtkWidget *pBoxH = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+		GtkWidget *pImg  = gtk_image_new_from_icon_name ("dialog-warning", GTK_ICON_SIZE_MENU);
+		GtkWidget *pLbl  = gtk_label_new (_("You are running Cairo-Dock in a Wayland session.\nSetting global keyboard shortcuts is not supported on Wayland yet."));
+		gtk_box_pack_start (GTK_BOX (pBoxH), pImg, FALSE, FALSE, 20);
+		gtk_box_pack_start (GTK_BOX (pBoxH), pLbl, FALSE, FALSE, 0);
+		gtk_container_add (GTK_CONTAINER (pBoxV), pBoxH);
+		gtk_widget_set_sensitive (pShortkeysWidget->pShortKeysTreeView, FALSE);
+		gtk_container_add (GTK_CONTAINER (pBoxV), pScrolledWindow);
+		pShortkeysWidget->widget.pWidget = pBoxV;
+	}
+	else pShortkeysWidget->widget.pWidget = pScrolledWindow;
 	
 	return pShortkeysWidget;
 }

--- a/src/cairo-dock-widget.c
+++ b/src/cairo-dock-widget.c
@@ -56,8 +56,11 @@ void cairo_dock_widget_free (CDWidget *pCdWidget)  // doesn't destroy the GTK wi
 	cairo_dock_free_generated_widget_list (pCdWidget->pWidgetList);
 	pCdWidget->pWidgetList = NULL;
 	
-	g_ptr_array_free (pCdWidget->pDataGarbage, TRUE);  /// free each element...
-	pCdWidget->pDataGarbage = NULL;
+	if (pCdWidget->pDataGarbage)
+	{
+		g_ptr_array_free (pCdWidget->pDataGarbage, TRUE);  /// free each element...
+		pCdWidget->pDataGarbage = NULL;
+	}
 	
 	g_free (pCdWidget);
 }

--- a/src/gldit/cairo-dock-core.c
+++ b/src/gldit/cairo-dock-core.c
@@ -225,7 +225,10 @@ bWAYFIRE = TRUE;
 		bWAYLAND_PROTOCOLS ? "yes" : "no",
 		bWAYFIRE ? "yes" : "no",
 		bIsWayland ? "Wayland" : "X11",
-		layer_shell_info ? layer_shell_info : "",
+		bIsWayland ? (layer_shell_info ? layer_shell_info : "") :
+			(gldi_container_use_new_positioning_code () ?
+				" * window positioning:           new\n" :
+				" * window positioning:           legacy\n"),
 		g_bUseOpenGL ? gldi_gl_get_backend_name() : "no",
 		gldi_windows_manager_get_name (),
 		gldi_desktop_manager_get_backend_names (),

--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -325,7 +325,8 @@ static gboolean _on_motion_notify (GtkWidget* pWidget,
 	{
 		//g_print ("%s (%d,%d) (%d, %.2fms, bAtBottom:%d; bIsShrinkingDown:%d)\n", __func__, (int) pMotion->x, (int) pMotion->y, pMotion->is_hint, pMotion->time - fLastTime, pDock->bAtBottom, pDock->bIsShrinkingDown);
 		//\_______________ On deplace le dock si ALT est enfoncee.
-		if ((pMotion->state & GDK_MOD1_MASK) && (pMotion->state & GDK_BUTTON1_MASK))
+		if ((pMotion->state & GDK_MOD1_MASK) && (pMotion->state & GDK_BUTTON1_MASK) &&
+			!gldi_container_is_wayland_backend ())
 		{
 			if (pDock->container.bIsHorizontal)
 			{

--- a/src/gldit/cairo-dock-gui-factory.c
+++ b/src/gldit/cairo-dock-gui-factory.c
@@ -2127,6 +2127,7 @@ GtkWidget *cairo_dock_build_group_widget (GKeyFile *pKeyFile, const gchar *cGrou
 				}
 				if (iElementType == CAIRO_DOCK_WIDGET_SIZE_INTEGER)
 					iNbElements *= 2;
+				gboolean bDisabled = gldi_container_is_wayland_backend () && !strcmp (cKeyName, "x gap");
 				length = 0;
 				iValueList = g_key_file_get_integer_list (pKeyFile, cGroupName, cKeyName, &length, NULL);
 				GtkWidget *pPrevOneWidget=NULL;
@@ -2181,6 +2182,11 @@ GtkWidget *cairo_dock_build_group_widget (GKeyFile *pKeyFile, const gchar *cGrou
 						data[0] = pOneWidget;
 						data[1] = pToggleButton;
 						g_signal_connect (G_OBJECT (pPrevOneWidget), "value-changed", G_CALLBACK(_cairo_dock_set_value_in_pair), data);
+					}
+					if (bDisabled)
+					{
+						gtk_widget_set_sensitive (pOneWidget, FALSE);
+						gtk_widget_set_tooltip_text (pOneWidget, _("You are running Cairo-Dock in a Wayland session.\nSetting a horizontal offset is not supported on Wayland yet."));
 					}
 					pPrevOneWidget = pOneWidget;
 					iPrevValue = iValue;

--- a/src/gldit/cairo-dock-gui-factory.c
+++ b/src/gldit/cairo-dock-gui-factory.c
@@ -3028,10 +3028,19 @@ GtkWidget *cairo_dock_build_group_widget (GKeyFile *pKeyFile, const gchar *cGrou
 					}
 					else
 					{
+						// shortkey
 						g_signal_connect (G_OBJECT (pGrabKeyButton),
 							"clicked",
 							G_CALLBACK (_cairo_dock_key_grab_clicked),
 							data);
+						if (gldi_container_is_wayland_backend ())
+						{
+							gtk_widget_set_sensitive (pGrabKeyButton, FALSE);
+							gtk_widget_set_sensitive (pOneWidget, FALSE);
+							const char *tmp = _("You are running Cairo-Dock in a Wayland session.\nSetting global keyboard shortcuts is not supported on Wayland yet.");
+							gtk_widget_set_tooltip_text (pGrabKeyButton, tmp);
+							gtk_widget_set_tooltip_text (pOneWidget, tmp);
+						}
 					}
 					_pack_in_widget_box (pGrabKeyButton);
 				}

--- a/src/gldit/cairo-dock-gui-factory.c
+++ b/src/gldit/cairo-dock-gui-factory.c
@@ -2186,7 +2186,7 @@ GtkWidget *cairo_dock_build_group_widget (GKeyFile *pKeyFile, const gchar *cGrou
 					if (bDisabled)
 					{
 						gtk_widget_set_sensitive (pOneWidget, FALSE);
-						gtk_widget_set_tooltip_text (pOneWidget, _("You are running Cairo-Dock in a Wayland session.\nSetting a horizontal offset is not supported on Wayland yet."));
+						gtk_widget_set_tooltip_text (pKeyBox, _("You are running Cairo-Dock in a Wayland session.\nSetting a horizontal offset is not supported on Wayland yet."));
 					}
 					pPrevOneWidget = pOneWidget;
 					iPrevValue = iValue;
@@ -3044,8 +3044,7 @@ GtkWidget *cairo_dock_build_group_widget (GKeyFile *pKeyFile, const gchar *cGrou
 							gtk_widget_set_sensitive (pGrabKeyButton, FALSE);
 							gtk_widget_set_sensitive (pOneWidget, FALSE);
 							const char *tmp = _("You are running Cairo-Dock in a Wayland session.\nSetting global keyboard shortcuts is not supported on Wayland yet.");
-							gtk_widget_set_tooltip_text (pGrabKeyButton, tmp);
-							gtk_widget_set_tooltip_text (pOneWidget, tmp);
+							gtk_widget_set_tooltip_text (pKeyBox, tmp);
 						}
 					}
 					_pack_in_widget_box (pGrabKeyButton);

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -255,30 +255,36 @@ static void _move_resize_dock (CairoDock *pDock)
 	{
 		GtkWindow* window = GTK_WINDOW (pDock->container.pWidget);
 		// Reset old anchors
-		gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
-		gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_TOP, FALSE);
-		gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_RIGHT, FALSE);
-		gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_LEFT, FALSE);
+		gtk_layer_set_anchor (window, GTK_LAYER_SHELL_EDGE_BOTTOM, FALSE);
+		gtk_layer_set_anchor (window, GTK_LAYER_SHELL_EDGE_TOP, FALSE);
+		gtk_layer_set_anchor (window, GTK_LAYER_SHELL_EDGE_RIGHT, FALSE);
+		gtk_layer_set_anchor (window, GTK_LAYER_SHELL_EDGE_LEFT, FALSE);
 		// Set new anchor
 		CairoDockPositionType iScreenBorder = gldi_wayland_get_edge_for_dock (pDock);
+		GtkLayerShellEdge anchor_edge;
 		switch (iScreenBorder)
 		{
 			case CAIRO_DOCK_BOTTOM :
-				gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_BOTTOM, TRUE);
-			break;
+				anchor_edge = GTK_LAYER_SHELL_EDGE_BOTTOM;
+				break;
 			case CAIRO_DOCK_TOP :
-				gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_TOP, TRUE);
-			break;
+				anchor_edge = GTK_LAYER_SHELL_EDGE_TOP;
+				break;
 			case CAIRO_DOCK_RIGHT :
-				gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_RIGHT, TRUE);
-			break;
+				anchor_edge = GTK_LAYER_SHELL_EDGE_RIGHT;
+				break;
 			case CAIRO_DOCK_LEFT :
-				gtk_layer_set_anchor(window, GTK_LAYER_SHELL_EDGE_LEFT, TRUE);
-			break;
+				anchor_edge = GTK_LAYER_SHELL_EDGE_LEFT;
+				break;
 			case CAIRO_DOCK_INSIDE_SCREEN :
 			case CAIRO_DOCK_NB_POSITIONS :
-			break;
+			default :
+				cd_warning ("Cannot determine which edge to anchor a dock to!");
+				return;
 		}
+		
+		gtk_layer_set_anchor (window, anchor_edge, TRUE);
+		gtk_layer_set_margin (window, anchor_edge, pDock->iGapY);
 	}
 #endif
 }


### PR DESCRIPTION
We cannot set global keyboard shortcuts, so it is better not to display them.