### PR TITLE
Improve screen selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.5.99.rc7") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.5.99.rc8") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/src/gldit/cairo-dock-dock-facility.c
+++ b/src/gldit/cairo-dock-dock-facility.c
@@ -387,11 +387,6 @@ void cairo_dock_prevent_dock_from_out_of_screen (CairoDock *pDock)
 #define CD_VISIBILITY_MARGIN 20
 void cairo_dock_get_window_position_at_balance (CairoDock *pDock, int iNewWidth, int iNewHeight, int *iNewPositionX, int *iNewPositionY)
 {
-	//!! TODO: will likely result in invalid size if there is more than one screen but pDock->iNumScreen
-	/// is invalid since in this case, these functions return the size of the whole Xscreen (i.e. combined
-	/// of all screens) -- this can happen if e.g. there were 3 screens originally and the one with the dock
-	/// has been removed --> this could be handled by first setting "fallback" screen for the dock and using that
-	/// or using gdk_display_get_monitor_at_window () to get the screen the dock is actually on (at least on Wayland)
 	int W = gldi_dock_get_screen_width (pDock), H = gldi_dock_get_screen_height (pDock);
 	int iWindowPositionX = (W - iNewWidth) * pDock->fAlign + pDock->iGapX;
 	if (pDock->iRefCount == 0 && pDock->fAlign != .5)

--- a/src/gldit/cairo-dock-dock-factory.h
+++ b/src/gldit/cairo-dock-dock-factory.h
@@ -150,8 +150,14 @@ struct _CairoDock {
 	gdouble fAlign;  // alignment, between 0 and 1, on the screen's edge.
 	/// visibility.
 	CairoDockVisibility iVisibility;
-	/// number of the screen the dock is placed on (-1 <=> all screen, >0 <=> num screen).
+	/// number of the screen the dock is actually placed on (between 0 and g_desktopGeometry.iNbScreens - 1)
+	/// might differ from iScreenReq if the requested screen is not available; filled out when updating the dock's position
 	gint iNumScreen;
+	/// number of the screen requested by the user
+	gint iScreenReq;
+	/// name of the screen requested by the user -- TODO: not used yet, should implement saving screen names !
+	gchar *cScreenReq;
+	
 	// icons
 	/// icon size, as specified in the config of the dock
 	gint iIconSize;

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -1552,42 +1552,25 @@ static void load (void)
 	if (g_pKeepingBelowBackend == NULL)  // pas d'option en config pour ca.
 		g_pKeepingBelowBackend = cairo_dock_get_hiding_effect ("Fade out");
 	
-	// the first main dock doesn't have a config file, its parameters are the global ones.
-	if (g_pMainDock)
+	// register a key binding
+	if (myDocksParam.iVisibility == CAIRO_DOCK_VISI_SHORTKEY)  // register a key binding
 	{
-		g_pMainDock->iGapX = myDocksParam.iGapX;
-		g_pMainDock->iGapY = myDocksParam.iGapY;
-		g_pMainDock->fAlign = myDocksParam.fAlign;
-//		g_pMainDock->iNumScreen = myDocksParam.iNumScreen;
-		g_pMainDock->bExtendedMode = myDocksParam.bExtendedMode;
-		
-		_set_dock_orientation (g_pMainDock, myDocksParam.iScreenBorder);
-		cairo_dock_move_resize_dock (g_pMainDock);
-		
-		g_pMainDock->fFlatDockWidth = - myIconsParam.iIconGap;  // car on ne le connaissait pas encore au moment de sa creation.
-		
-		// register a key binding
-		if (myDocksParam.iVisibility == CAIRO_DOCK_VISI_SHORTKEY)  // register a key binding
+		if (s_pPopupBinding == NULL)
 		{
-			if (s_pPopupBinding == NULL)
-			{
-				s_pPopupBinding = gldi_shortkey_new (myDocksParam.cRaiseDockShortcut,
-					"Cairo-Dock",
-					_("Pop up the main dock"),
-					GLDI_SHARE_DATA_DIR"/"CAIRO_DOCK_ICON,
-					g_cConfFile,
-					"Accessibility",
-					"raise shortcut",
-					(CDBindkeyHandler) _raise_from_shortcut,
-					NULL);
-			}
-			else
-			{
-				gldi_shortkey_rebind (s_pPopupBinding, myDocksParam.cRaiseDockShortcut, NULL);
-			}
+			s_pPopupBinding = gldi_shortkey_new (myDocksParam.cRaiseDockShortcut,
+				"Cairo-Dock",
+				_("Pop up the main dock"),
+				GLDI_SHARE_DATA_DIR"/"CAIRO_DOCK_ICON,
+				g_cConfFile,
+				"Accessibility",
+				"raise shortcut",
+				(CDBindkeyHandler) _raise_from_shortcut,
+				NULL);
 		}
-		
-		gldi_dock_set_visibility (g_pMainDock, myDocksParam.iVisibility);
+		else
+		{
+			gldi_shortkey_rebind (s_pPopupBinding, myDocksParam.cRaiseDockShortcut, NULL);
+		}
 	}
 }
 

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -132,6 +132,7 @@ static void _make_sub_dock (CairoDock *pDock, CairoDock *pParentDock, const gcha
 	pDock->container.bIsHorizontal = pParentDock->container.bIsHorizontal;
 	pDock->container.bDirectionUp = pParentDock->container.bDirectionUp;
 	pDock->iNumScreen = pParentDock->iNumScreen;
+	pDock->iScreenReq = pParentDock->iScreenReq;
 	
 	//\__________________ set a renderer
 	cairo_dock_set_renderer (pDock, cRendererName);
@@ -546,7 +547,10 @@ static gboolean _get_root_dock_config (CairoDock *pDock)
 		
 		pDock->fAlign = myDocksParam.fAlign;
 		
-		pDock->iNumScreen = myDocksParam.iNumScreen;
+		pDock->iScreenReq = myDocksParam.iScreenReq;
+		pDock->iNumScreen = pDock->iScreenReq;
+		if (pDock->iNumScreen < 0 || pDock->iNumScreen >= g_desktopGeometry.iNbScreens)
+			pDock->iNumScreen = 0;
 		
 		_set_dock_orientation (pDock, myDocksParam.iScreenBorder);  // do it after all position parameters have been set; it sets the sub-docks orientation too.
 		
@@ -591,7 +595,10 @@ static gboolean _get_root_dock_config (CairoDock *pDock)
 	
 	pDock->fAlign = cairo_dock_get_double_key_value (pKeyFile, "Behavior", "alignment", &bFlushConfFileNeeded, 0.5, "Position", NULL);
 	
-	pDock->iNumScreen = cairo_dock_get_integer_key_value (pKeyFile, "Behavior", "num_screen", &bFlushConfFileNeeded, GLDI_DEFAULT_SCREEN, "Position", NULL);
+	pDock->iScreenReq = cairo_dock_get_integer_key_value (pKeyFile, "Behavior", "num_screen", &bFlushConfFileNeeded, GLDI_DEFAULT_SCREEN, "Position", NULL);
+	pDock->iNumScreen = pDock->iScreenReq;
+	if (pDock->iNumScreen < 0 || pDock->iNumScreen >= g_desktopGeometry.iNbScreens)
+		pDock->iNumScreen = 0;
 	
 	CairoDockPositionType iScreenBorder = cairo_dock_get_integer_key_value (pKeyFile, "Behavior", "screen border", &bFlushConfFileNeeded, 0, "Position", NULL);
 	_set_dock_orientation (pDock, iScreenBorder);  // do it after all position parameters have been set; it sets the sub-docks orientation too.
@@ -684,7 +691,7 @@ void gldi_dock_add_conf_file_for_name (const gchar *cDockName)
 		G_TYPE_INT, "Behavior", "visibility",
 		g_pMainDock->iVisibility,
 		G_TYPE_INT, "Behavior", "num_screen",
-		g_pMainDock->iNumScreen,
+		g_pMainDock->iScreenReq,
 		G_TYPE_INVALID);
 	g_free (cConfFilePath);
 }
@@ -748,6 +755,7 @@ void gldi_subdock_synchronize_orientation (CairoDock *pSubDock, CairoDock *pDock
 		pSubDock->container.bIsHorizontal = pDock->container.bIsHorizontal;
 		bUpdateDockSize = TRUE;
 	}
+	pSubDock->iScreenReq = pDock->iScreenReq;
 	if (pSubDock->iNumScreen != pDock->iNumScreen)
 	{
 		pSubDock->iNumScreen = pDock->iNumScreen;
@@ -1100,6 +1108,13 @@ static unsigned int s_sidDesktopGeom = 0;
 static gboolean _reposition_root_docks_idle (void*)
 {
 	s_sidDesktopGeom = 0;
+	
+	CairoDock *pDock = g_pMainDock;
+	// update which screen the main dock should be shown since its config will not be reloaded
+	pDock->iNumScreen = pDock->iScreenReq;
+	if (pDock->iNumScreen < 0 || pDock->iNumScreen >= g_desktopGeometry.iNbScreens)
+		pDock->iNumScreen = 0;
+	
 	_reposition_root_docks (FALSE);  // FALSE <=> main dock included
 	return G_SOURCE_REMOVE;
 }
@@ -1350,14 +1365,20 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDocksParam *pDocksParam)
 
 	pPosition->fAlign = cairo_dock_get_double_key_value (pKeyFile, "Position", "alignment", &bFlushConfFileNeeded, 0.5, NULL, NULL);
 	
-	pPosition->iNumScreen = cairo_dock_get_integer_key_value (pKeyFile, "Position", "num_screen", &bFlushConfFileNeeded, GLDI_DEFAULT_SCREEN, NULL, NULL);  // Note: if this screen doesn't exist at this time, we keep this number anyway, in case it is plugged later. Until then, it will point on the X screen.
-	if (g_key_file_has_key (pKeyFile, "Position", "xinerama", NULL))  // "xinerama" and "num screen" old keys
+	pPosition->iScreenReq = GLDI_DEFAULT_SCREEN;
+	if (g_key_file_has_key (pKeyFile, "Position", "num_screen", NULL))  // "num_screen" is the new key
+		pPosition->iScreenReq = g_key_file_get_integer (pKeyFile, "Position", "num_screen", NULL);
+	else
 	{
-		if (g_key_file_get_boolean (pKeyFile," Position", "xinerama", NULL))  // xinerama was used -> set num-screen back
+		if (g_key_file_has_key (pKeyFile, "Position", "xinerama", NULL))  // "xinerama" and "num screen" old keys
 		{
-			pPosition->iNumScreen = g_key_file_get_integer (pKeyFile, "Position", "num screen", NULL); // "num screen" was the old key
-			g_key_file_set_integer (pKeyFile, "Position", "num_screen", pPosition->iNumScreen);
+			if (g_key_file_get_boolean (pKeyFile," Position", "xinerama", NULL))  // xinerama was used -> set num-screen back
+			{
+				pPosition->iScreenReq = g_key_file_get_integer (pKeyFile, "Position", "num screen", NULL); // "num screen" was the old key
+			}
 		}
+		g_key_file_set_integer (pKeyFile, "Position", "num_screen", pPosition->iScreenReq);
+		bFlushConfFileNeeded = TRUE;
 	}
 	
 	//\____________________ Visibilite
@@ -1537,7 +1558,7 @@ static void load (void)
 		g_pMainDock->iGapX = myDocksParam.iGapX;
 		g_pMainDock->iGapY = myDocksParam.iGapY;
 		g_pMainDock->fAlign = myDocksParam.fAlign;
-		g_pMainDock->iNumScreen = myDocksParam.iNumScreen;
+//		g_pMainDock->iNumScreen = myDocksParam.iNumScreen;
 		g_pMainDock->bExtendedMode = myDocksParam.bExtendedMode;
 		
 		_set_dock_orientation (g_pMainDock, myDocksParam.iScreenBorder);
@@ -1605,10 +1626,12 @@ static void reload (CairoDocksParam *pPrevDocksParam, CairoDocksParam *pDocksPar
 	gldi_docks_foreach_root ((GFunc)_reload_bg, NULL);
 	
 	// position
-	pDock->iNumScreen = pPosition->iNumScreen;
-	
-	if (pPosition->iNumScreen != pPrevPosition->iNumScreen)
+	pDock->iScreenReq = pPosition->iScreenReq;
+	if (pPosition->iScreenReq != pPrevPosition->iScreenReq)
 	{
+		pDock->iNumScreen = pDock->iScreenReq;
+		if (pDock->iNumScreen < 0 || pDock->iNumScreen >= g_desktopGeometry.iNbScreens)
+			pDock->iNumScreen = 0;
 		gldi_container_set_screen (CAIRO_CONTAINER (pDock), pDock->iNumScreen);
 		_reposition_root_docks (TRUE);  // on replace tous les docks racines sauf le main dock, puisque c'est fait apres.
 	}
@@ -1624,7 +1647,7 @@ static void reload (CairoDocksParam *pPrevDocksParam, CairoDocksParam *pDocksPar
 	pDock->iGapY = pPosition->iGapY;
 	pDock->fAlign = pPosition->fAlign;
 	
-	if (pPosition->iNumScreen != pPrevPosition->iNumScreen
+	if (pPosition->iScreenReq != pPrevPosition->iScreenReq
 	|| pPosition->iScreenBorder != pPrevPosition->iScreenBorder  // if the orientation or the screen has changed, the available size may have changed too
 	|| pPosition->iGapX != pPrevPosition->iGapX
 	|| pPosition->iGapY != pPrevPosition->iGapY)
@@ -1882,6 +1905,7 @@ static void init_object (GldiObject *obj, gpointer attr)
 		
 		pDock->container.bIsHorizontal = pParentDock->container.bIsHorizontal;
 		pDock->container.bDirectionUp = pParentDock->container.bDirectionUp;
+		pDock->iScreenReq = pParentDock->iScreenReq;
 		pDock->iNumScreen = pParentDock->iNumScreen;
 		pDock->iIconSize = pParentDock->iIconSize;
 		

--- a/src/gldit/cairo-dock-dock-manager.h
+++ b/src/gldit/cairo-dock-dock-manager.h
@@ -92,7 +92,7 @@ struct _CairoDocksParam {
 	gint iGapX, iGapY;
 	CairoDockPositionType iScreenBorder;
 	gdouble fAlign;
-	gint iNumScreen;
+	gint iScreenReq;
 	// Root dock visibility
 	CairoDockVisibility iVisibility;
 	gchar *cHideEffect;

--- a/src/gldit/cairo-dock-gui-factory.c
+++ b/src/gldit/cairo-dock-gui-factory.c
@@ -1050,7 +1050,6 @@ static GHashTable *_cairo_dock_build_screens_list (void)
 		g_str_equal,
 		g_free,
 		g_free);
-	g_hash_table_insert (pHashTable, g_strdup (_("Use all screens")), g_strdup ("-1"));
 	
 	if (g_desktopGeometry.iNbScreens > 1)
 	{
@@ -1095,7 +1094,7 @@ static GHashTable *_cairo_dock_build_screens_list (void)
 	}
 	else  // if we have only 1 screen, and the screen-number is set to 0 (default value), let's insert a row for it; it's just to not have a blank widget with no line of the combo being selected, since anyway the widget will be unsensitive.
 	{
-		g_hash_table_insert (pHashTable, g_strdup (_("Use all screens")), g_strdup ("0"));
+		g_hash_table_insert (pHashTable, g_strdup_printf ("%s %d", _("Screen"), 0), g_strdup ("0"));
 	}
 	return pHashTable;
 }

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20250720
+#define GLDI_ABI_VERSION 20250802
 
 // manager
 typedef struct _GldiModulesParam GldiModulesParam;


### PR DESCRIPTION
The screen selected in the config file might not exist. We take this explicitly into account and store separately the requested and realized screen that a dock is on.