### PR TITLE
Fixes when closing dialogs and subdocks

### DIFF
--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -792,14 +792,24 @@ void _refresh_all_dialogs (gboolean bReplace)
 			pDialog = next->data;
 			pIcon = pDialog->pIcon;
 			pContainer = cairo_dock_get_icon_container (pIcon);
+			gboolean bDelete = FALSE;
 			if (pContainer && !gldi_container_is_visible (pContainer))
 			{
-				// remove next from the list
-				ic->next = next->next;
-				next->next = to_delete;
-				to_delete = next;
+				if (pDialog->bHideOnClick)
+				{
+					if (gldi_container_is_visible (CAIRO_CONTAINER (pDialog)))
+						gtk_widget_hide (pDialog->container.pWidget);
+				}
+				else
+				{
+					// remove next from the list
+					ic->next = next->next;
+					next->next = to_delete;
+					to_delete = next;
+					bDelete = TRUE;
+				}
 			}
-			else ic = next;
+			if (!bDelete) ic = next;
 		}
 		s_pDialogList = dummy.next; // in case we removed the first element in the list
 		

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -766,7 +766,7 @@ static void _place_dialog (CairoDialog *pDialog, GldiContainer *pContainer)
 
 
 static gboolean s_bInRefreshDialogs = FALSE;
-void _refresh_all_dialogs (gboolean bReplace)
+static void _refresh_all_dialogs (gboolean bReplace)
 {
 	//g_print ("%s ()\n", __func__);
 	GSList *ic;

--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -493,6 +493,8 @@ static gboolean _hide_child_docks (CairoDock *pDock)
 	return TRUE;
 }
 
+static void _hide_parent_dock (CairoDock *pDock);
+
 static gboolean _on_leave_notify (G_GNUC_UNUSED GtkWidget* pWidget, GdkEventCrossing* pEvent, CairoDock *pDock)
 {
 	//g_print ("%s (bIsMainDock : %d; bInside:%d; iState:%d; iRefCount:%d, pEvent: %p)\n", __func__, pDock->bIsMainDock, pDock->container.bInside, pDock->iInputState, pDock->iRefCount, pEvent);
@@ -681,6 +683,13 @@ static gboolean _on_leave_notify (G_GNUC_UNUSED GtkWidget* pWidget, GdkEventCros
 		gldi_object_notify (pDock, NOTIFICATION_LEAVE_DOCK, pDock, &bStartAnimation);
 		if (bStartAnimation)
 			cairo_dock_launch_animation (CAIRO_CONTAINER (pDock));
+	}
+	else if (pDock->iRefCount > 0)
+	{
+		// if this is a child dock, we should still send a leave event
+		// to its parent (for visible docks, this would be done at the
+		// end of the animation)
+		_hide_parent_dock (pDock);
 	}
 
 	return TRUE;


### PR DESCRIPTION
On Wayland, the compositor can dismiss popups any time, we need to be a bit more careful when handling these.