### PR TITLE
Avoid a possible crash when the display scale factor changes

### DIFF
--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -1197,6 +1197,14 @@ static gboolean _on_configure (GtkWidget* pWidget, GdkEventConfigure* pEvent, Ca
 	pDock->container.iWindowPositionX = iNewX;
 	pDock->container.iWindowPositionY = iNewY;
 	
+	// it is possible that the scale factor changes without the size -- we need to resize our EGLSurface on Wayland to avoid a crash
+	gint scale = gdk_window_get_scale_factor (gldi_container_get_gdk_window (CAIRO_CONTAINER (pDock)));
+	if (scale != pDock->iScaleFactor)
+	{
+		bSizeUpdated = TRUE;
+		pDock->iScaleFactor = scale;
+	}
+	
 	if (pDock->container.iWidth == 1 && pDock->container.iHeight == 1)  // the X window has not yet reached its size.
 	{
 		return FALSE;

--- a/src/gldit/cairo-dock-dock-factory.h
+++ b/src/gldit/cairo-dock-dock-factory.h
@@ -296,6 +296,8 @@ struct _CairoDock {
 	GLuint iRedirectedTexture;
 	GLuint iFboId;
 	gboolean bNeedSizeUpdate; // set to TRUE whether we could not do size-related updated in the configure handler
+	/// last buffer scale factor set by us
+	gint iScaleFactor;
 	
 	/// any data necessary for the dock visibility backend to work -- managed by the backend
 	gpointer pVisibilityData;

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -155,7 +155,6 @@ static void _set_input_shape(GldiContainer *pContainer, cairo_region_t *pShape)
 		}
 	}
 	wl_surface_set_input_region (wls, r);
-	wl_surface_commit (wls);
 	if (r) wl_region_destroy (r);
 #endif
 }


### PR DESCRIPTION
We should handle the possibility of a scale change in our configure handler. Also, we should avoid commiting our `wl_surface` manually as that can cause unexpected problems.