### PR TITLE
Fix rendering icons in hidden subdocks with EGL on Wayland

### DIFF
--- a/src/gldit/cairo-dock-opengl.c
+++ b/src/gldit/cairo-dock-opengl.c
@@ -174,6 +174,13 @@ gboolean gldi_gl_container_make_current (GldiContainer *pContainer)
 	return FALSE;
 }
 
+gboolean gldi_gl_offscreen_context_make_current (void)
+{
+	if (s_backend.offscreen_make_current)
+		return s_backend.offscreen_make_current ();
+	return FALSE;
+}
+
 static void _apply_desktop_background (GldiContainer *pContainer)
 {
 	if (! g_pFakeTransparencyDesktopBg || g_pFakeTransparencyDesktopBg->iTexture == 0)

--- a/src/gldit/cairo-dock-opengl.h
+++ b/src/gldit/cairo-dock-opengl.h
@@ -100,9 +100,7 @@ gboolean gldi_gl_container_make_current (GldiContainer *pContainer);
 
 /** Try to make current an OpenGL context that is not associated with any
 *container, but is suitable for rendering to offscreen targets (i.e. textures).
-*The caller must attach an FBO and a texture before rendering. Note that this
-*is not supported by every backend, so it is recommended to fall back to
-*gldi_gl_container_make_current() with a suitable container if this fails.
+*The caller must attach an FBO and a texture before rendering.
 *@return TRUE if a context was successfully set up.
 */
 gboolean gldi_gl_offscreen_context_make_current (void);

--- a/src/gldit/cairo-dock-opengl.h
+++ b/src/gldit/cairo-dock-opengl.h
@@ -54,6 +54,7 @@ struct _GldiGLManagerBackend {
 	gboolean (*init) (gboolean bForceOpenGL);
 	void (*stop) (void);
 	gboolean (*container_make_current) (GldiContainer *pContainer);
+	gboolean (*offscreen_make_current) (void);
 	void (*container_end_draw) (GldiContainer *pContainer);
 	void (*container_init) (GldiContainer *pContainer);
 	void (*container_finish) (GldiContainer *pContainer);
@@ -96,6 +97,15 @@ void gldi_gl_init_opengl_context (void);
 *@return TRUE if the Container's context is now the current one.
 */
 gboolean gldi_gl_container_make_current (GldiContainer *pContainer);
+
+/** Try to make current an OpenGL context that is not associated with any
+*container, but is suitable for rendering to offscreen targets (i.e. textures).
+*The caller must attach an FBO and a texture before rendering. Note that this
+*is not supported by every backend, so it is recommended to fall back to
+*gldi_gl_container_make_current() with a suitable container if this fails.
+*@return TRUE if a context was successfully set up.
+*/
+gboolean gldi_gl_offscreen_context_make_current (void);
 
 /** Start drawing on a Container's OpenGL context.
 *@param pContainer the container

--- a/src/implementations/cairo-dock-glx.c
+++ b/src/implementations/cairo-dock-glx.c
@@ -221,6 +221,7 @@ static void _stop (void)
 	if (s_XContext != 0)
 	{
 		Display *dpy = s_XDisplay;
+		glXMakeCurrent (dpy, 0, NULL); // s_XContext might still be current
 		glXDestroyContext (dpy, s_XContext);
 		s_XContext = 0;
 	}
@@ -231,6 +232,14 @@ static gboolean _container_make_current (GldiContainer *pContainer)
 	Window Xid = _gldi_container_get_Xid (pContainer);
 	Display *dpy = s_XDisplay;
 	return glXMakeCurrent (dpy, Xid, pContainer->glContext);
+}
+
+static gboolean _offscreen_make_current (void)
+{
+	if (! (s_XContext && g_pPrimaryContainer)) return FALSE;
+	Window Xid = _gldi_container_get_Xid (g_pPrimaryContainer);
+	Display *dpy = s_XDisplay;
+	return glXMakeCurrent (dpy, Xid, s_XContext);
 }
 
 static void _container_end_draw (GldiContainer *pContainer)
@@ -294,6 +303,7 @@ void gldi_register_glx_backend (void)
 	gmb.init = _initialize_opengl_backend;
 	gmb.stop = _stop;
 	gmb.container_make_current = _container_make_current;
+	gmb.offscreen_make_current = _offscreen_make_current;
 	gmb.container_end_draw = _container_end_draw;
 	gmb.container_init = _container_init;
 	gmb.container_finish = _container_finish;


### PR DESCRIPTION
On Wayland, containers only have a valid EGLSurface if they are mapped (visible). Since we have been using the parent container's GL context when rendering icons, this would not work when the container (e.g. a subdock) is hidden (note: we require a valid EGLSurface to make current the context, since the same API is used for rendering to the surface). This can be fixed by separating the APIs used:
 - `_container_make_current()` is only used when we really want to render to the container's EGLSurface
 - a new function, `_offscreen_make_current()` will make current a default context without any surface for rendering to textures (note: this requires the EGL_KHR_surfaceless_context extension, but we already depended on it)

These changes are fully implemented for EGL, and partially on GLX, allowing some simplification of `cairo_dock_begin_draw_image_buffer_opengl()` as well.
