### PR TITLE
remove support for very old GLib versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,11 @@ list(APPEND CMAKE_INSTALL_RPATH ${libdir})
 ########### dependencies ###############
 
 # check for mandatory dependencies
-set (packages_required "glib-2.0 gthread-2.0 cairo librsvg-2.0 dbus-1 dbus-glib-1 libxml-2.0 gl glu libcurl")  # for the .pc and to have details
-STRING (REGEX REPLACE " " ";" packages_required_semicolon ${packages_required})  # replace blank space by semicolon => to have more details if a package is missing
-pkg_check_modules ("PACKAGE" REQUIRED "${packages_required_semicolon}")
+# for pkg_check_modules -- use semicolon to have more details if a package is missing
+set (packages_required_semicolon "glib-2.0 >= 2.36.0;gthread-2.0;cairo;librsvg-2.0;dbus-1;dbus-glib-1;libxml-2.0;gl;glu;libcurl")
+# for gldi.pc -- replace semicolons with spaces
+STRING (REPLACE ";" " " packages_required "${packages_required_semicolon}") # note: need to use quotes around ${packages_required_semicolon} for this to work!
+pkg_check_modules ("PACKAGE" REQUIRED ${packages_required_semicolon})
 find_library(MLIB m)
 if (MLIB)
   set (PACKAGE_LIBRARIES ${PACKAGE_LIBRARIES} ${MLIB})

--- a/Help/data/Help.conf.in
+++ b/Help/data/Help.conf.in
@@ -151,7 +151,7 @@ _Hiding the dock to use all the screen=
 
 
 
-#[@pkgdatadir@/icons/icon-desklets.png]
+#[@pkgdatadir@/icons/icon-desklets.svg]
 [Desklets]
 
 #X[Placing applets on your desktop]

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -355,14 +355,6 @@ int main (int argc, char** argv)
 	
 	
 	// init lib
-	#if !defined (GLIB_VERSION_2_36) // no longer needed now... (>= 2.35)
-	g_type_init (); // should initialise threads too on new versions of GLIB (>= 2.24)
-	#endif
-	#if (GLIB_MAJOR_VERSION == 2 && GLIB_MINOR_VERSION < 24)
-	if (!g_thread_supported ())
-		g_thread_init (NULL);
-	#endif
-
 	dbus_g_thread_init (); // it's a wrapper: it will use dbus_threads_init_default ();
 	
 	GError *erreur = NULL;

--- a/src/gldit/cairo-dock-dbus.h
+++ b/src/gldit/cairo-dock-dbus.h
@@ -31,9 +31,6 @@ G_BEGIN_DECLS
 * DBus is used to communicate and interact with other running applications.
 */ 
 
-#if (GLIB_MAJOR_VERSION == 2 && GLIB_MINOR_VERSION < 29) // not needed before => http://developer.gnome.org/gobject/unstable/gobject-Generic-values.html#G-VALUE-INIT:CAPS
-#define G_VALUE_INIT {0,{{0}}}  // bonne idee d'un dev de GTK, pour eviter les warnings de gcc.
-#endif
 
 typedef void (*CairoDockDbusNameOwnerChangedFunc) (const gchar *cName, gboolean bOwned, gpointer data);
 

--- a/src/gldit/cairo-dock-file-manager.c
+++ b/src/gldit/cairo-dock-file-manager.c
@@ -130,16 +130,12 @@ gboolean cairo_dock_fm_launch_uri (const gchar *cURI)
 		//s_pEnvBackend->launch_uri (cURI);
 		GError *erreur = NULL;
 		gchar *cThreadURI = g_strdup (cURI);
-		#if (GLIB_MAJOR_VERSION == 2 && GLIB_MINOR_VERSION < 32)
-		GThread* pThread = g_thread_create ((GThreadFunc) _cairo_dock_fm_launch_uri_threaded, (gpointer) cThreadURI, FALSE, &erreur);
-		#else
 		// The name can be useful for discriminating threads in a debugger.
 		// Some systems restrict the length of name to 16 bytes. 
 		gchar *cThreadName = g_strndup (cURI, 15);
 		GThread* pThread = g_thread_try_new (cThreadName, (GThreadFunc) _cairo_dock_fm_launch_uri_threaded, (gpointer) cThreadURI, &erreur);
 		g_thread_unref (pThread);
 		g_free (cThreadName);
-		#endif
 		if (erreur != NULL)
 		{
 			cd_warning (erreur->message);

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20250802
+#define GLDI_ABI_VERSION 20250820
 
 // manager
 typedef struct _GldiModulesParam GldiModulesParam;

--- a/src/gldit/cairo-dock-task.h
+++ b/src/gldit/cairo-dock-task.h
@@ -63,7 +63,7 @@ struct _GldiTask {
 	GldiGetDataAsyncFunc get_data;
 	// function carrying out the update of the dock. Returns TRUE to continue, FALSE to stop.
 	GldiUpdateSyncFunc update;
-	/// interval of time in seconds, 0 if the Task is to run once.
+	/// interval of time in seconds, 0 if the Task is to run once. Set when creating the task; can change >0 values later, but cannot change between 0 and >0.
 	guint iPeriod;
 	// state of the frequency of the Task.
 	GldiTaskFrequencyState iFrequencyState;
@@ -83,9 +83,9 @@ struct _GldiTask {
 	gboolean bNeedsUpdate;  // TRUE when new data are waiting to be processed.
 	gboolean bContinue;  // result of the 'update' function (TRUE -> continue, FALSE -> stop, if the task is periodic).
 	GThread *pThread;  // the thread that execute the asynchronous 'get_data' callback
-	GCond *pCond;  // condition to awake the thread (if periodic).
+	GCond cond;  // condition to awake the thread (if periodic). Only used if iPeriod > 0
 	gboolean bRunThread;  // condition value: whether to run the thread or exit.
-	GMutex *pMutex;  // mutex associated with the condition.
+	GMutex mutex;  // mutex associated with the condition. Always initialized when creating a task.
 } ;
 
 


### PR DESCRIPTION
explicitly depend on version >= 2.36 which should be available everywhere