### PR TITLE
Rework launching apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.5.99.rc9") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.5.99.rca") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/src/cairo-dock-user-menu.c
+++ b/src/cairo-dock-user-menu.c
@@ -881,7 +881,7 @@ static void _cairo_dock_launch_new (G_GNUC_UNUSED GtkMenuItem *pMenuItem, gpoint
 {
 	struct _MenuParams *params = (struct _MenuParams*) data;
 	Icon *icon = params->pIcon;
-	if (icon->pAppInfo || icon->pCustomLauncher)
+	if (icon->pAppInfo)
 	{
 		gldi_object_notify (params->pContainer, NOTIFICATION_CLICK_ICON, icon,
 			params->pContainer, GDK_SHIFT_MASK);  // on emule un shift+clic gauche .
@@ -1190,8 +1190,7 @@ gboolean cairo_dock_notification_build_container_menu (G_GNUC_UNUSED gpointer *p
 		if (cairo_dock_is_locked ())
 		{
 			gboolean bSensitive = FALSE;
-			if ( (CAIRO_DOCK_IS_APPLI (icon) || CAIRO_DOCK_ICON_TYPE_IS_CLASS_CONTAINER (pIcon))
-				&& (icon->pAppInfo || icon->pCustomLauncher))
+			if ( (CAIRO_DOCK_IS_APPLI (icon) || CAIRO_DOCK_ICON_TYPE_IS_CLASS_CONTAINER (pIcon)) && icon->pAppInfo)
 			{
 				_add_entry_in_menu (_("Launch a new (Shift+clic)"), GLDI_ICON_NAME_ADD, _cairo_dock_launch_new, pItemSubMenu, params);
 				bSensitive = TRUE;
@@ -1205,8 +1204,7 @@ gboolean cairo_dock_notification_build_container_menu (G_GNUC_UNUSED gpointer *p
 		}
 		else
 		{
-			if ( (CAIRO_DOCK_IS_APPLI (icon) || CAIRO_DOCK_ICON_TYPE_IS_CLASS_CONTAINER (pIcon))
-					&& (icon->pAppInfo || icon->pCustomLauncher))
+			if ( (CAIRO_DOCK_IS_APPLI (icon) || CAIRO_DOCK_ICON_TYPE_IS_CLASS_CONTAINER (pIcon)) && icon->pAppInfo)
 				_add_entry_in_menu (_("Launch a new (Shift+clic)"), GLDI_ICON_NAME_ADD, _cairo_dock_launch_new, pItemSubMenu, params);
 			
 			if ((CAIRO_DOCK_ICON_TYPE_IS_LAUNCHER (pIcon)
@@ -1933,7 +1931,8 @@ gboolean cairo_dock_notification_build_icon_menu (G_GNUC_UNUSED gpointer *pUserD
 	if (icon && icon->cClass != NULL && ! icon->bIgnoreQuicklist)
 	{
 		GldiAppInfo *app = icon->pAppInfo;
-		if (app && app->actions)
+		const gchar* const *actions = app ? gldi_app_info_get_desktop_actions (app) : NULL;
+		if (actions)
 		{
 			if (bAddSeparator)
 			{
@@ -1942,14 +1941,13 @@ gboolean cairo_dock_notification_build_icon_menu (G_GNUC_UNUSED gpointer *pUserD
 			}
 			bAddSeparator = TRUE;
 			
-			const gchar* const *actions = app->actions;
 			for (; *actions; ++actions)
 			{
 				struct _AppAction *pAction = g_new0 (struct _AppAction, 1);
 				gldi_object_ref (GLDI_OBJECT (app));
 				pAction->app = app;
 				pAction->action = *actions;
-				pAction->action_name = g_desktop_app_info_get_action_name (app->app, *actions);
+				pAction->action_name = gldi_app_info_get_desktop_action_name (app, *actions);
 				
 				pMenuItem = cairo_dock_add_in_menu_with_stock_and_data (pAction->action_name,
 					NULL,

--- a/src/gldit/cairo-dock-class-icon-manager.c
+++ b/src/gldit/cairo-dock-class-icon-manager.c
@@ -96,8 +96,6 @@ static void init_object (GldiObject *obj, gpointer attr)
 		pIcon->pAppInfo = pSameClassIcon->pAppInfo;
 		gldi_object_ref (GLDI_OBJECT (pIcon->pAppInfo));
 	}
-	if (pSameClassIcon->pCustomLauncher)
-		pIcon->pCustomLauncher = g_object_ref (pSameClassIcon->pCustomLauncher);
 	pIcon->cClass = g_strdup (pSameClassIcon->cClass);
 	pIcon->fOrder = pSameClassIcon->fOrder;
 	pIcon->bHasIndicator = pSameClassIcon->bHasIndicator;

--- a/src/gldit/cairo-dock-class-manager.h
+++ b/src/gldit/cairo-dock-class-manager.h
@@ -51,7 +51,7 @@ G_BEGIN_DECLS
 *@param cCmdline Command to launch in the format of the XDG Desktop Entry specification.
 *@param cName Descriptive name that is suitable to be displayed to the user.
 *@param cWorkingDir Optionally, a directory where the command should be launched.
-*@param bNeedsTerminal Whether the command should be launched in a terminal. Currently unsupported and ignored.
+*@param bNeedsTerminal Whether the command should be launched in a terminal.
 *@return the newly created GldiAppInfo or NULL if there was an error parsing cCmdline.
 */
 GldiAppInfo *gldi_app_info_new_from_commandline (const gchar *cCmdline, const gchar *cName, const gchar *cWorkingDir, gboolean bNeedsTerminal);
@@ -138,6 +138,8 @@ GldiAppInfo *gldi_app_info_from_desktop_app_info (GDesktopAppInfo *pDesktopAppIn
 */
 void gldi_launch_desktop_app_info (GDesktopAppInfo *pDesktopAppInfo, const gchar* const *uris);
 
+/** Override the setting whether this app needs to run in a terminal. */
+void gldi_app_info_set_run_in_terminal (GldiAppInfo *app, gboolean bNeedsTerminal);
 
 /*
 * Initialise le gestionnaire de classes. Ne fait rien la 2eme fois.

--- a/src/gldit/cairo-dock-class-manager.h
+++ b/src/gldit/cairo-dock-class-manager.h
@@ -71,7 +71,7 @@ GldiAppInfo *gldi_app_info_new_from_commandline (const gchar *cCmdline, const gc
 */
 void gldi_app_info_launch_action (GldiAppInfo *app, const gchar *cAction);
 
-/** Launch the application with an optional list of URIs or files to open.
+/** Launch an application with an optional list of URIs or files to open.
 *
 *@param app a GldiAppInfo corresponding to an installed app or available command.
 *@param uris a NULL-terminated list of file names or URIs to provide as parameters or NULL.
@@ -109,6 +109,35 @@ const gchar * const *gldi_app_info_get_desktop_actions (GldiAppInfo *app);
 * for freeing it.
 */
 gchar *gldi_app_info_get_desktop_action_name (GldiAppInfo *app, const gchar *cAction);
+
+/** Get the list of mime types that this app supports or NULL if unknown. */
+const gchar** gldi_app_info_get_supported_types (GldiAppInfo *app);
+
+/** Get a GldiAppInfo corresponding to the given GDesktopAppInfo. Also registers
+* this app with the class manager if this has not been done before.
+*@param pDesktopAppInfo a GDesktopAppInfo representing an app installed on the system.
+*@return a GldiAppInfo that can be used to launch this app or NULL if pAppInfo is invalid.
+* A reference is added and the caller should call gldi_object_unref () when done using it.
+*/
+GldiAppInfo *gldi_app_info_from_desktop_app_info (GDesktopAppInfo *pDesktopAppInfo);
+
+/** Launch an application given by a GDesktopAppInfo with an optional list of URIs or
+* files to open. The app will be registered with the class manager if it has not been
+* seen yet.
+*
+*@param app a GDesktopAppInfo corresponding to an installed app.
+*@param uris a NULL-terminated list of file names or URIs to provide as parameters or NULL.
+*
+* Note: if the app supports DBus activation, it will be used instead of
+* directly launching it. See here for more details:
+* https://specifications.freedesktop.org/desktop-entry-spec/latest/dbus.html
+* 
+* Apps that do not support DBus activation might be launched directly as a child
+* process of Cairo-Dock, or indirectly via the session manager if available
+* (i.e. systemd on Linux).
+*/
+void gldi_launch_desktop_app_info (GDesktopAppInfo *pDesktopAppInfo, const gchar* const *uris);
+
 
 /*
 * Initialise le gestionnaire de classes. Ne fait rien la 2eme fois.

--- a/src/gldit/cairo-dock-icon-facility.c
+++ b/src/gldit/cairo-dock-icon-facility.c
@@ -45,7 +45,6 @@
 #include "cairo-dock-draw-opengl.h"
 #include "cairo-dock-draw.h"
 #include "cairo-dock-animations.h"  // CairoDockHidingEffect
-#include "cairo-dock-utils.h"  // cairo_dock_launch_app_info
 #include "cairo-dock-icon-facility.h"
 
 extern gchar *g_cCurrentLaunchersPath;
@@ -729,12 +728,12 @@ gboolean gldi_icon_launch_command (Icon *pIcon)
 	// notify startup
 	gldi_class_startup_notify (pIcon);
 
-	GDesktopAppInfo *app = pIcon->pCustomLauncher;
-	if (!app && pIcon->pAppInfo) app = pIcon->pAppInfo->app;
+	GldiAppInfo *app = pIcon->pAppInfo;
 	if (app)
 	{
 		cd_debug ("launching app from desktop file info: %s", pIcon->cClass);
-		return cairo_dock_launch_app_info (app);
+		gldi_app_info_launch (app, NULL);
+		return TRUE;
 	}
 	cd_warning ("cannot launch icon with no app associated to it!");
 	return FALSE;

--- a/src/gldit/cairo-dock-icon-factory.h
+++ b/src/gldit/cairo-dock-icon-factory.h
@@ -117,10 +117,11 @@ struct _Icon {
 	gchar *cBaseURI; // used by shortcuts
 	gint iVolumeID;
 	gchar *cInitialName; // original name replaced by e.g. the actual app title matched to a launcher
-	// GAppInfo(s) that are used to launch the app corresponding to this icon (if it is a launcher or appli)
-	// These are only set on creation and do not change during the lifetime of the icon.
-	GldiAppInfo *pAppInfo; // app info from a .desktop file installed on the system
-	GDesktopAppInfo *pCustomLauncher; // GAppInfo with custom launch command (if set)
+	// GldiAppInfo that can be used to launch the app corresponding to this icon (if it is a launcher or appli).
+	// This typically wraps a .desktop file of an installed app, but can be custom created for launchers with
+	// custom commands. This is only set on creation and does not change during the lifetime of the icon.
+	GldiAppInfo *pAppInfo;
+	gpointer unused; // previously used for custom command
 	
 	// Appli.
 	GldiWindowActor *pAppli;

--- a/src/gldit/cairo-dock-icon-manager.c
+++ b/src/gldit/cairo-dock-icon-manager.c
@@ -1024,7 +1024,6 @@ static void reset_object (GldiObject *obj)
 	///g_free (icon->cLastAttentionDemand);
 	g_free (icon->pHiddenBgColor);
 	if (icon->pAppInfo) gldi_object_unref (GLDI_OBJECT (icon->pAppInfo));
-	if (icon->pCustomLauncher) g_object_unref (icon->pCustomLauncher);
 	
 	cairo_dock_unload_image_buffer (&icon->image);
 	

--- a/src/gldit/cairo-dock-launcher-manager.c
+++ b/src/gldit/cairo-dock-launcher-manager.c
@@ -160,6 +160,11 @@ static gboolean _get_launcher_params (Icon *icon, GKeyFile *pKeyFile)
 		}
 		g_free (cCommand);
 	}
+	else if (icon->pAppInfo)
+	{
+		if (g_key_file_get_boolean (pKeyFile, "Desktop Entry", "Terminal", NULL))
+			gldi_app_info_set_run_in_terminal (icon->pAppInfo, TRUE);
+	}
 	
 	if (bHaveOrigins && !icon->pAppInfo)
 	{

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20250821
+#define GLDI_ABI_VERSION 20250831
 
 // manager
 typedef struct _GldiModulesParam GldiModulesParam;

--- a/src/gldit/cairo-dock-user-icon-manager.c
+++ b/src/gldit/cairo-dock-user-icon-manager.c
@@ -129,7 +129,7 @@ static void _load_one_icon (gpointer pAttr, gpointer)
 	GldiUserIconAttr *attr = (GldiUserIconAttr*)pAttr;
 	
 	Icon *icon = _user_icon_create (attr);
-	if (icon == NULL || icon->reserved[0] == (gpointer)-1)  // if the icon couldn't be loaded, remove it from the theme (it's useless to try and fail to load it each time).
+	if (icon == NULL || GPOINTER_TO_INT (icon->reserved[0]) == -1)  // if the icon couldn't be loaded, remove it from the theme (it's useless to try and fail to load it each time).
 	{
 		if (icon)
 			gldi_object_unref (GLDI_OBJECT(icon));

--- a/src/gldit/cairo-dock-utils.h
+++ b/src/gldit/cairo-dock-utils.h
@@ -117,17 +117,6 @@ const gchar * cairo_dock_get_default_terminal (void);
 /** Simple "backend" for managing processes launched by us. Mainly needed to put
  * newly launched apps in their own systemd scope / cgroup. */
 struct _GldiChildProcessManagerBackend {
-	/** Handle a newly launched child process, performing any system-specific setup functions.
-	 * This should also eventually call waitpid() or similar to clean up the child process.
-	 *
-	 *@param id  a non-NULL identifier for the newly launched process, containing only "safe" characters
-	 *           (currently this means only characters valid in systemd unit names: ASCII letters, digits, ":", "-", "_", ".", and "\");
-	 * 			 does not need to be unique
-	 *@param desc  a description suitable to display to the user
-	 *@param pid  process id of the newly launched process; the caller should not use waitpid()
-	 *            or similar facility to avoid race condition
-	 */
-	void (*new_app_launched) (const char *id, const char *desc, GPid pid);
 	/** Launch a new app based on the given argument vector, performing any system-specific setup necessary.
 	 *
 	 *@param args  argument vector to use

--- a/src/gldit/cairo-dock-utils.h
+++ b/src/gldit/cairo-dock-utils.h
@@ -108,14 +108,6 @@ gboolean cairo_dock_launch_command_single_gui (const gchar *cExec);
  */
 const gchar * cairo_dock_get_default_terminal (void);
 
-
-/** Launch an app with optionally a list of URIs provided as the argument.
- * @param appinfo  app to launch
- * @param uris  list of const char* with the URIs to open or NULL
- */
-gboolean cairo_dock_launch_app_info_with_uris (GDesktopAppInfo* appinfo, GList* uris);
-#define cairo_dock_launch_app_info(appinfo) cairo_dock_launch_app_info_with_uris (appinfo, NULL)
-
 /* Like g_strcmp0, but saves a function call.
 */
 #define gldi_strings_differ(s1, s2) (!s1 ? s2 != NULL : !s2 ? s1 != NULL : strcmp(s1, s2) != 0)

--- a/src/implementations/cairo-dock-systemd-integration.c
+++ b/src/implementations/cairo-dock-systemd-integration.c
@@ -97,6 +97,99 @@ static void _create_transient_scope (const char *id, const char *desc, GPid pid)
 }
 
 
+static guint64 s_iLaunchID = 0;
+
+static void _spawn_end (GObject*, GAsyncResult *res, gpointer)
+{
+	GError *err = NULL;
+	GVariant *ret = g_dbus_proxy_call_finish (s_proxy, res, &err);
+	if (ret) g_variant_unref (ret);
+	else
+	{
+		cd_warning ("couldn't launch app: %s", err->message);
+		g_error_free (err);
+	}
+}
+
+
+static GVariantType *s_full_type = NULL;
+static GVariantType *s_props_type = NULL;
+static GVariantType *s_aux_type = NULL;
+static GVariantType *s_args_one_type = NULL;
+static GVariantType *s_string_array_type = NULL;
+
+static void _init_variant_types (void)
+{
+	/*
+	       StartTransientUnit(in  s name,
+                         in  s mode,
+                         in  a(sv) properties,
+                         in  a(sa(sv)) aux,
+                         out o job);
+	*/
+	if (!s_full_type) s_full_type = g_variant_type_new ("(ssa(sv)a(sa(sv)))");
+	if (!s_props_type) s_props_type = g_variant_type_new ("a(sv)");
+	if (!s_aux_type) s_aux_type = g_variant_type_new ("a(sa(sv))");
+	// format of args
+	if (!s_args_one_type) s_args_one_type = g_variant_type_new ("(sasb)");
+	// args and env vectors
+	if (!s_string_array_type) s_string_array_type = g_variant_type_new ("as");
+	
+	// note: all type variables are leaked -- could add a destructor that is called on exit
+}
+
+static void _spawn_app (const gchar * const *args, const gchar *id, const gchar *desc, const gchar * const *env, const gchar *working_dir)
+{
+	if (!s_proxy) return;
+	if (!(args && *args)) return;
+	
+	_init_variant_types ();
+	
+	s_iLaunchID++;
+	char *name;
+	const size_t len = strlen (id);
+	const size_t max_len =
+		255 // length allowed by systemd
+		- 24 // length of our prefix + dash + suffix + nul terminator
+		- 20; // max length of a 64-bit integer
+	if (len > max_len)
+		name = g_strdup_printf ("app-cairodock-%.*s@%"G_GUINT64_FORMAT".service", (int)max_len, id, s_iLaunchID);
+	else name = g_strdup_printf ("app-cairodock-%s@%"G_GUINT64_FORMAT".service", id, s_iLaunchID);
+	
+	GVariantBuilder var_builder;
+	g_variant_builder_init  (&var_builder, s_full_type);
+	g_variant_builder_add_value (&var_builder, g_variant_new_take_string (name));
+	g_variant_builder_add   (&var_builder, "s", "fail");
+	g_variant_builder_open  (&var_builder, s_props_type);
+	g_variant_builder_add   (&var_builder, "(sv)", "Description", g_variant_new_string (desc));
+	{
+		GVariantBuilder args_builder;
+		g_variant_builder_init  (&args_builder, s_args_one_type);
+		g_variant_builder_add   (&args_builder, "s", args[0]);
+		g_variant_builder_open  (&args_builder, s_string_array_type);
+		for(; *args; ++args) g_variant_builder_add (&args_builder, "s", *args);
+		g_variant_builder_close (&args_builder);
+		g_variant_builder_add   (&args_builder, "b", FALSE);
+		GVariant *tmp = g_variant_builder_end (&args_builder);
+		g_variant_builder_add   (&var_builder, "(sv)", "ExecStart", g_variant_new_array (NULL, &tmp, 1));
+	}
+	if (env && *env)
+	{
+		GVariantBuilder env_builder;
+		g_variant_builder_init (&env_builder, s_string_array_type);
+		if (env) for (; *env; ++env) g_variant_builder_add (&env_builder, "s", *env);
+		g_variant_builder_add (&var_builder, "(sv)", "Environment", g_variant_builder_end (&env_builder));
+	}
+	if (working_dir) g_variant_builder_add (&var_builder, "(sv)", "WorkingDirectory", working_dir);
+	g_variant_builder_add   (&var_builder, "(sv)", "CollectMode", g_variant_new_string ("inactive-or-failed"));
+	g_variant_builder_close (&var_builder);
+	g_variant_builder_open  (&var_builder, s_aux_type);
+	g_variant_builder_close (&var_builder);
+	
+	g_dbus_proxy_call (s_proxy, "StartTransientUnit", g_variant_builder_end (&var_builder), G_DBUS_CALL_FLAGS_NONE, -1, NULL, _spawn_end, NULL);
+}
+
+
 static void _proxy_connected (GObject*, GAsyncResult *res, gpointer)
 {
 	s_proxy = g_dbus_proxy_new_for_bus_finish (res, NULL);
@@ -115,6 +208,7 @@ static void _proxy_connected (GObject*, GAsyncResult *res, gpointer)
 		
 		GldiChildProcessManagerBackend backend;
 		backend.new_app_launched = _create_transient_scope;
+		backend.spawn_app = _spawn_app;
 		gldi_register_process_manager_backend (&backend);
 	}
 }

--- a/src/implementations/cairo-dock-systemd-integration.c
+++ b/src/implementations/cairo-dock-systemd-integration.c
@@ -27,76 +27,6 @@
 
 GDBusProxy *s_proxy = NULL;
 
-static void _child_watch_dummy (GPid pid, gint, gpointer)
-{
-	g_spawn_close_pid (pid); // note: this is a no-op
-}
-
-static void _create_scope_end (GObject*, GAsyncResult *res, gpointer ptr)
-{
-	GError *err = NULL;
-	GVariant *ret = g_dbus_proxy_call_finish (s_proxy, res, &err);
-	if (ret) g_variant_unref (ret);
-	else
-	{
-		cd_warning ("couldn't set scope for child process: %s", err->message);
-		g_error_free (err);
-	}
-	
-	// we only create the child watch after the DBus call to systemd finished
-	// hopefully this avoids pid reuse race conditions (i.e. until it has been
-	// waited for, the pid should become a zombie if the process exits)
-	g_child_watch_add (GPOINTER_TO_INT (ptr), _child_watch_dummy, NULL);
-}
-
-static void _create_transient_scope (const char *id, const char *desc, GPid pid)
-{
-	if (!s_proxy) return;
-	
-	GVariantBuilder var_builder;
-	/*
-	       StartTransientUnit(in  s name,
-                         in  s mode,
-                         in  a(sv) properties,
-                         in  a(sa(sv)) aux,
-                         out o job);
-	*/
-	GVariantType *full_type  = g_variant_type_new ("(ssa(sv)a(sa(sv)))");
-	GVariantType *props_type = g_variant_type_new ("a(sv)");
-	GVariantType *aux_type   = g_variant_type_new ("a(sa(sv))");
-	
-	char *name;
-	size_t len = strlen (id);
-	const size_t max_len =
-		255 // length allowed by systemd
-		- 42 // length of our prefix + dash + suffix
-		- 9; // max length of %d specifier (assuming pid_t is 32 bits)
-	if (len > max_len)
-		name = g_strdup_printf ("cairo-dock-launched-%.*s-%d.scope", (int)max_len, id, pid);
-	else name = g_strdup_printf ("cairo-dock-launched-%s-%d.scope", id, pid);
-	unsigned int tmp = (unsigned int)pid;
-	
-	g_variant_builder_init  (&var_builder, full_type);
-	g_variant_builder_add   (&var_builder, "s", name);
-	g_variant_builder_add   (&var_builder, "s", "fail");
-	g_variant_builder_open  (&var_builder, props_type);
-	g_variant_builder_add   (&var_builder, "(sv)", "Description", g_variant_new_string (desc));
-	g_variant_builder_add   (&var_builder, "(sv)", "PIDs", g_variant_new_fixed_array (G_VARIANT_TYPE_UINT32, &tmp, 1, 4));
-	g_variant_builder_close (&var_builder);
-	g_variant_builder_open  (&var_builder, aux_type);
-	g_variant_builder_close (&var_builder);
-	
-	GVariant *var = g_variant_ref_sink (g_variant_builder_end (&var_builder));
-	g_dbus_proxy_call (s_proxy, "StartTransientUnit", var, G_DBUS_CALL_FLAGS_NONE, -1, NULL, _create_scope_end, GINT_TO_POINTER (pid));
-	
-	g_variant_unref (var);
-	g_free (name);
-	g_variant_type_free (full_type);
-	g_variant_type_free (props_type);
-	g_variant_type_free (aux_type);
-}
-
-
 static guint64 s_iLaunchID = 0;
 
 static void _spawn_end (GObject*, GAsyncResult *res, gpointer)
@@ -207,7 +137,6 @@ static void _proxy_connected (GObject*, GAsyncResult *res, gpointer)
 		}
 		
 		GldiChildProcessManagerBackend backend;
-		backend.new_app_launched = _create_transient_scope;
 		backend.spawn_app = _spawn_app;
 		gldi_register_process_manager_backend (&backend);
 	}


### PR DESCRIPTION
When using systemd, instead of spawning commands ourselves, we should prefer to ask systemd to launch them for us as a transient service. This has the following benefits:
 - It avoids a race condition with putting newly launched apps in their scope, where if an app spawns a child / forks quickly, it could be missed and only the parent would be moved to a new scope.
 - On systems with systemd, this will allow us to avoid spawning processes, and thus potentially leaking our environment, fds, etc.

To achieve this, we stop using `g_app_info_launch*()` for non DBus activatable processes and instead again rely on parsing the command line ourselves.