### PR TITLE
task: fix freeing the thread

### DIFF
--- a/src/gldit/cairo-dock-task.c
+++ b/src/gldit/cairo-dock-task.c
@@ -85,7 +85,11 @@ static gboolean _check_for_update_idle (GldiTask *pTask)
 		
 		if (! pTask->iPeriod)  // one-shot thread => the thread is over
 		{
-			g_clear_object (&pTask->pThread);
+			if (pTask->pThread)
+			{
+				g_thread_unref (pTask->pThread);
+				pTask->pThread = NULL;
+			}
 		}
 		
 		pTask->iSidUpdateIdle = 0;  // set it before the unlock, as it is accessed in the thread part


### PR DESCRIPTION
Fixes #126 (not sure what was wrong with `g_clear_object()` here though, it should be OK to use even when the object is NULL)