### PR TITLE
Support smooth scrolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.5.99.rca") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.5.99.rcb") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -93,6 +93,33 @@ inline void gldi_container_update_mouse_position (GldiContainer *pContainer)
 		s_backend.update_mouse_position (pContainer);
 }
 
+void gldi_container_handle_scroll (GldiContainer *pContainer, Icon *pIcon, GdkEventScroll* pScroll)
+{
+	GdkScrollDirection dir = pScroll->direction;
+	switch (dir)
+	{
+		case GDK_SCROLL_UP:
+		case GDK_SCROLL_DOWN:
+			gldi_object_notify (pContainer, NOTIFICATION_SCROLL_ICON, pIcon, pContainer, dir, FALSE);
+			break;
+		case GDK_SCROLL_SMOOTH:
+		{
+			gdouble dx = pScroll->delta_x;
+			gdouble dy = pScroll->delta_y;
+			gldi_object_notify (pContainer, NOTIFICATION_SMOOTH_SCROLL_ICON, pIcon, pContainer, dx, dy);
+			pContainer->fSmoothScrollAccum += dy;
+			for (; pContainer->fSmoothScrollAccum > 1.0; pContainer->fSmoothScrollAccum -= 1.0)
+				gldi_object_notify (pContainer, NOTIFICATION_SCROLL_ICON, pIcon, pContainer, GDK_SCROLL_DOWN, TRUE);
+			for (; pContainer->fSmoothScrollAccum < -1.0; pContainer->fSmoothScrollAccum += 1.0)
+				gldi_object_notify (pContainer, NOTIFICATION_SCROLL_ICON, pIcon, pContainer, GDK_SCROLL_UP, TRUE);
+			break;
+		}
+		default:
+			// GDK_SCROLL_LEFT and GDK_SCROLL_RIGHT are ignored
+			break;
+	}
+}
+
 static gboolean _prevent_delete (G_GNUC_UNUSED GtkWidget *pWidget, G_GNUC_UNUSED GdkEvent *event, G_GNUC_UNUSED gpointer data)
 {
 	cd_debug ("No alt+f4");
@@ -573,9 +600,11 @@ gboolean gldi_container_can_reserve_space (int iNumScreen, gboolean bDirectionUp
 
 gboolean gldi_container_dock_handle_leave (CairoDock *pDock, GdkEventCrossing *pEvent)
 {
+	gboolean ret = TRUE; // default return value is true -- it means there is no need for further checks
 	if (s_backend.dock_handle_leave)
-		return s_backend.dock_handle_leave (pDock, pEvent);
-	return TRUE; // default return value is true -- it means there is no need for further checks
+		ret = s_backend.dock_handle_leave (pDock, pEvent);
+	if (ret) pDock->container.fSmoothScrollAccum = 0.0; // reset scroll events
+	return ret;
 }
 
 void gldi_container_dock_handle_enter (CairoDock *pDock, GdkEventCrossing *pEvent)

--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -100,10 +100,14 @@ void gldi_container_handle_scroll (GldiContainer *pContainer, Icon *pIcon, GdkEv
 	{
 		case GDK_SCROLL_UP:
 		case GDK_SCROLL_DOWN:
-			gldi_object_notify (pContainer, NOTIFICATION_SCROLL_ICON, pIcon, pContainer, dir, FALSE);
+			// filter out if the same event is delivered both as a "smooth" and "regular" event
+			// see e.g. https://bugzilla.gnome.org/show_bug.cgi?id=726878 however it might not be relevant anymore
+			if (pScroll->time != pContainer->iLastScrollTime)
+				gldi_object_notify (pContainer, NOTIFICATION_SCROLL_ICON, pIcon, pContainer, dir, FALSE);
 			break;
 		case GDK_SCROLL_SMOOTH:
 		{
+			pContainer->iLastScrollTime = pScroll->time;
 			gdouble dx = pScroll->delta_x;
 			gdouble dy = pScroll->delta_y;
 			gldi_object_notify (pContainer, NOTIFICATION_SMOOTH_SCROLL_ICON, pIcon, pContainer, dx, dy);

--- a/src/gldit/cairo-dock-container.h
+++ b/src/gldit/cairo-dock-container.h
@@ -81,8 +81,14 @@ typedef enum {
 	NOTIFICATION_DOUBLE_CLICK_ICON,
 	/// notification called when the user middle-clicks on an icon. data : {Icon, CairoDock}
 	NOTIFICATION_MIDDLE_CLICK_ICON,
-	/// notification called when the user scrolls on an icon. data : {Icon, CairoDock, int}
+	/// notification called when the user scrolls on a container. data : {Icon, CairoContainer, int iDirection, int bEmulated}
+	/// Note: Icon is the icon under the mouse or can be NULL if the mouse is not over any icon. Currently it is only emitted on docks and desklets.
+	/// iDirection is either GDK_SCROLL_UP or GDK_SCROLL_DOWN; bEmulated is TRUE if this event is synthetized based on
+	/// a series of GDK_SCROLL_SMOOTH events received earlier (so it can be ignored if those were handled)
 	NOTIFICATION_SCROLL_ICON,
+	/// notification called when the user scrolls on a container and a GDK_SCROLL_SMOOTH event was delivered
+	/// data : {Icon, CairoContainer, gdouble delta_x, gdouble delta_y}
+	NOTIFICATION_SMOOTH_SCROLL_ICON,
 	/// notification called when the mouse enters an icon. data : {Icon, CairoDock, gboolean*}
 	NOTIFICATION_ENTER_ICON,
 	/// notification called when the mouse enters a dock while dragging an object.
@@ -147,6 +153,8 @@ struct _GldiContainer {
 	gint iMouseX;
 	/// Y position of the mouse in the container's system of reference.
 	gint iMouseY;
+	/// accumulate smooth scroll events to emulate fixed steps
+	gdouble fSmoothScrollAccum;
 	/// zoom applied to the container's elements.
 	gdouble fRatio;
 	/// TRUE if the container has a reflection power.
@@ -248,6 +256,8 @@ void cairo_dock_enable_containers_opacity (void);
  * to rely on the motion notify and leave / enter events) */
 void gldi_container_update_mouse_position (GldiContainer *pContainer);
 
+/* Accumulate smooth scroll events and emit signals (should be private). */
+void gldi_container_handle_scroll (GldiContainer *pContainer, Icon *pIcon, GdkEventScroll* pScroll);
 
 /** Reserve a space on the screen for a Container; other windows won't overlap this space when maximised.
 *@param pContainer the container

--- a/src/gldit/cairo-dock-container.h
+++ b/src/gldit/cairo-dock-container.h
@@ -155,6 +155,8 @@ struct _GldiContainer {
 	gint iMouseY;
 	/// accumulate smooth scroll events to emulate fixed steps
 	gdouble fSmoothScrollAccum;
+	/// time of last smooth scroll event received (to filter potential duplicates)
+	guint iLastScrollTime;
 	/// zoom applied to the container's elements.
 	gdouble fRatio;
 	/// TRUE if the container has a reflection power.

--- a/src/gldit/cairo-dock-desklet-factory.c
+++ b/src/gldit/cairo-dock-desklet-factory.c
@@ -296,13 +296,12 @@ static gboolean on_scroll_desklet (G_GNUC_UNUSED GtkWidget* pWidget,
 	GdkEventScroll* pScroll,
 	CairoDesklet *pDesklet)
 {
-	//g_print ("scroll %d\n", pScroll->direction);
-	if (pScroll->direction != GDK_SCROLL_UP && pScroll->direction != GDK_SCROLL_DOWN)  // on degage les scrolls horizontaux.
+	GdkScrollDirection dir = pScroll->direction;
+	if (dir == GDK_SCROLL_UP || dir == GDK_SCROLL_DOWN || dir == GDK_SCROLL_SMOOTH)
 	{
-		return FALSE;
+		Icon *icon = gldi_desklet_find_clicked_icon (pDesklet);  // can be NULL
+		gldi_container_handle_scroll (CAIRO_CONTAINER (pDesklet), icon, pScroll);
 	}
-	Icon *icon = gldi_desklet_find_clicked_icon (pDesklet);  // can be NULL
-	gldi_object_notify (pDesklet, NOTIFICATION_SCROLL_ICON, icon, pDesklet, pScroll->direction);
 	return FALSE;
 }
 

--- a/src/gldit/cairo-dock-dock-factory.c
+++ b/src/gldit/cairo-dock-dock-factory.c
@@ -1145,13 +1145,12 @@ static gboolean _on_button_press (G_GNUC_UNUSED GtkWidget* pWidget, GdkEventButt
 
 static gboolean _on_scroll (G_GNUC_UNUSED GtkWidget* pWidget, GdkEventScroll* pScroll, CairoDock *pDock)
 {
-	if (pScroll->direction != GDK_SCROLL_UP && pScroll->direction != GDK_SCROLL_DOWN)  // on degage les scrolls horizontaux.
+	GdkScrollDirection dir = pScroll->direction;
+	if (dir == GDK_SCROLL_UP || dir == GDK_SCROLL_DOWN || dir == GDK_SCROLL_SMOOTH)
 	{
-		return FALSE;
+		Icon *icon = cairo_dock_get_pointed_icon (pDock->icons);  // can be NULL
+		gldi_container_handle_scroll (CAIRO_CONTAINER (pDock), icon, pScroll);
 	}
-	Icon *icon = cairo_dock_get_pointed_icon (pDock->icons);  // can be NULL
-	gldi_object_notify (pDock, NOTIFICATION_SCROLL_ICON, icon, pDock, pScroll->direction);
-	
 	return FALSE;
 }
 

--- a/src/gldit/cairo-dock-icon-factory.h
+++ b/src/gldit/cairo-dock-icon-factory.h
@@ -121,7 +121,7 @@ struct _Icon {
 	// This typically wraps a .desktop file of an installed app, but can be custom created for launchers with
 	// custom commands. This is only set on creation and does not change during the lifetime of the icon.
 	GldiAppInfo *pAppInfo;
-	gpointer unused; // previously used for custom command
+	gboolean bNotFound; // set to TRUE for launchers that could not be loaded, they will be deleted
 	
 	// Appli.
 	GldiWindowActor *pAppli;

--- a/src/gldit/cairo-dock-launcher-manager.c
+++ b/src/gldit/cairo-dock-launcher-manager.c
@@ -168,8 +168,9 @@ static gboolean _get_launcher_params (Icon *icon, GKeyFile *pKeyFile)
 	
 	if (bHaveOrigins && !icon->pAppInfo)
 	{
-		// no desktop file could be found for this launcher -> mark it as invalid
-		icon->reserved[0] = GINT_TO_POINTER(-1); // we use this as a way to tell the UserIcon manager that the icon is invalid (should add a new flag, but that would break ABI)
+		// no desktop file could be found for this launcher -> mark it as invalid, will be deleted by the UserIcon manager
+		// (note: we do not do this for custom launchers as it would be annoying to have them deleted if e.g. the user made a typo
+		icon->bNotFound = TRUE;
 	}
 	
 	gboolean bPreventFromInhibiting = g_key_file_get_boolean (pKeyFile, "Desktop Entry", "prevent inhibate", NULL);  // FALSE by default

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20250831
+#define GLDI_ABI_VERSION 20250906
 
 // manager
 typedef struct _GldiModulesParam GldiModulesParam;

--- a/src/gldit/cairo-dock-user-icon-manager.c
+++ b/src/gldit/cairo-dock-user-icon-manager.c
@@ -129,7 +129,7 @@ static void _load_one_icon (gpointer pAttr, gpointer)
 	GldiUserIconAttr *attr = (GldiUserIconAttr*)pAttr;
 	
 	Icon *icon = _user_icon_create (attr);
-	if (icon == NULL || GPOINTER_TO_INT (icon->reserved[0]) == -1)  // if the icon couldn't be loaded, remove it from the theme (it's useless to try and fail to load it each time).
+	if (icon == NULL || icon->bNotFound)  // if the icon couldn't be loaded, remove it from the theme (it's useless to try and fail to load it each time).
 	{
 		if (icon)
 			gldi_object_unref (GLDI_OBJECT(icon));


### PR DESCRIPTION
This is needed as in some cases, we don't get "regular" scroll events anymore. This also allows plugins to use smooth scroll events where it makes sense (e.g. scrolled view in subdocks)