### PR TITLE
Extra command line options for controlling how apps are launched

### DIFF
--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -485,33 +485,29 @@ int main (int argc, char** argv)
 	GOptionContext *context = g_option_context_new ("Cairo-Dock");
 	g_option_context_add_main_entries (context, pOptionsTable, NULL);
 	g_option_context_parse (context, &argc, &argv, &erreur);
-	if (erreur != NULL)
-	{
-		cd_error ("ERROR in options: %s", erreur->message);
-		return 1;
-	}
-	if (g_bForceWayland && g_bForceX11)
-	{
-		cd_error ("Both Wayland and X11 backends cannot be requested (use only one of the -L and -X options)!\n");
-		return 1;
-	}
-	if (g_bForceWayland)
-		gdk_set_allowed_backends ("wayland");
-	if (g_bForceX11)
-		gdk_set_allowed_backends ("x11");
-	if (g_bDisableDbusActivation && g_bGioLaunch)
-		cd_error ("Cannot disable DBus activation if launching apps with GIO (use only one of the --disable-dbus-activation and --force-gio-launch options)!\n");
+	if (erreur != NULL) cd_error ("ERROR in options: %s", erreur->message); // will exit
 	
 	if (bPrintVersion)
 	{
 		g_print ("%s\n", CAIRO_DOCK_VERSION);
 		return 0;
 	}
+	if (bCappuccino)
+	{
+		const gchar *cCappuccino = _("Cairo-Dock makes anything, including coffee !");
+		g_print ("%s\n", cCappuccino);
+		return 0;
+	}
+	if (g_bDisableDbusActivation && g_bGioLaunch)
+		cd_error ("Cannot disable DBus activation if launching apps with GIO (use only one of the --disable-dbus-activation and --force-gio-launch options)!\n");
+	if (g_bForceWayland && g_bForceX11)
+		cd_error ("Both Wayland and X11 backends cannot be requested (use only one of the -L and -X options)!\n");
+	if (g_bForceWayland) gdk_set_allowed_backends ("wayland");
+	if (g_bForceX11) gdk_set_allowed_backends ("x11");
 	
 	gtk_init (&argc, &argv);
 	
-	if (g_bLocked)
-		cd_warning ("Cairo-Dock will be locked.");
+	if (g_bLocked) cd_warning ("Cairo-Dock will be locked.");
 	
 	if (cVerbosity != NULL)
 	{
@@ -536,13 +532,6 @@ int main (int argc, char** argv)
 		else
 			cd_warning ("Unknown environment '%s'", cEnvironment);
 		g_free (cEnvironment);
-	}
-	
-	if (bCappuccino)
-	{
-		const gchar *cCappuccino = _("Cairo-Dock makes anything, including coffee !");
-		g_print ("%s\n", cCappuccino);
-		return 0;
 	}
 	
 	//\___________________ get global config.

--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -57,6 +57,10 @@
 extern CairoDock *g_pMainDock;
 extern CairoDockDesktopEnv g_iDesktopEnv;
 
+// global config (for debugging only)
+gboolean g_bDisableDbusActivation = FALSE;
+gboolean g_bGioLaunch = FALSE;
+
 static GldiObjectManager myAppInfoObjectMgr;
 
 /// Definition of a Class of application.
@@ -362,8 +366,10 @@ static void _init_appinfo (GldiObject *obj, gpointer attr)
 	{
 		desktop_app = G_DESKTOP_APP_INFO (info->app);
 		info->actions = g_desktop_app_info_list_actions (desktop_app);
-		bDbusActivatable = g_desktop_app_info_get_boolean (desktop_app, "DBusActivatable");
+		if (!g_bDisableDbusActivation)
+			bDbusActivatable = g_desktop_app_info_get_boolean (desktop_app, "DBusActivatable");
 	}
+	if (g_bGioLaunch) bDbusActivatable = TRUE; // this will skip parsing the command line and force using the Gio function to launch this app
 	
 	if (params->bNeedsTerminal) info->bNeedsTerminal = TRUE;
 	else if (desktop_app) info->bNeedsTerminal = g_desktop_app_info_get_boolean (desktop_app, "Terminal");

--- a/src/gldit/cairo-dock-core.c
+++ b/src/gldit/cairo-dock-core.c
@@ -66,6 +66,7 @@ int g_iMajorVersion, g_iMinorVersion, g_iMicroVersion;  // version de la lib.
 
 gboolean g_bForceWayland = FALSE;
 gboolean g_bForceX11 = FALSE;
+gboolean g_bDisableSystemd = FALSE;
 
 extern gboolean g_bDisableLayerShell;
 extern gboolean g_bUseOpenGL;
@@ -101,7 +102,7 @@ static void _gldi_register_core_managers (void)
 	gldi_register_style_manager ();  // get config before other manager that could use this manager
 	if (!g_bForceWayland) gldi_register_X_manager ();
 	if (!g_bForceX11) gldi_register_wayland_manager ();
-	cairo_dock_systemd_integration_init ();
+	if (!g_bDisableSystemd) cairo_dock_systemd_integration_init ();
 }
 
 void gldi_init (GldiRenderingMethod iRendering)


### PR DESCRIPTION
While #125 is expected to work in all cases, it can be good to add workarounds for unexpected issues. This PR adds extra command line options that can be used to disable using systemd, DBus Activation or custom command line parsing to help diagnosing any issues with starting apps.