### PR TITLE
backport: dialogs and menus: set a background if no renderer is available

### DIFF
--- a/src/gldit/cairo-dock-dialog-factory.c
+++ b/src/gldit/cairo-dock-dialog-factory.c
@@ -113,12 +113,18 @@ static gboolean on_expose_dialog (G_GNUC_UNUSED GtkWidget *pWidget, cairo_t *pCa
 	
 		cairo_dock_init_drawing_context_on_container (CAIRO_CONTAINER (pDialog), pCairoContext);
 		
+		cairo_save (pCairoContext);
 		if (pDialog->pDecorator != NULL)
-		{
-			cairo_save (pCairoContext);
 			pDialog->pDecorator->render (pCairoContext, pDialog);
-			cairo_restore (pCairoContext);
+		else
+		{
+			if (myDialogsParam.bUseDefaultColors)
+				gldi_style_colors_set_bg_color (pCairoContext);
+			else
+				gldi_color_set_cairo (pCairoContext, &myDialogsParam.fBgColor);
+			cairo_paint (pCairoContext);
 		}
+		cairo_restore (pCairoContext);
 		
 		gldi_object_notify (pDialog, NOTIFICATION_RENDER, pDialog, pCairoContext);
 	//}

--- a/src/gldit/cairo-dock-menu.c
+++ b/src/gldit/cairo-dock-menu.c
@@ -323,6 +323,14 @@ static gboolean _draw_menu (GtkWidget *pWidget,
 	CairoDialogDecorator *pDecorator = cairo_dock_get_dialog_decorator (myDialogsParam.cDecoratorName);
 	if (pDecorator)
 		pDecorator->render_menu (pWidget, pCairoContext);
+	else
+	{
+		if (myDialogsParam.bUseDefaultColors)
+			gldi_style_colors_set_bg_color_full (pCairoContext, FALSE);
+		else
+			gldi_color_set_cairo_rgb (pCairoContext, &myDialogsParam.fBgColor);
+		cairo_paint (pCairoContext);
+	}
 	
 	// draw the items
 	cairo_set_source_rgba (pCairoContext, 0.0, 0.0, 0.0, 1.0);


### PR DESCRIPTION
This improves the legibility of any text displayed. The background will be a simple rectangle that covers the whole dialog or menu window.

Note that renderers will only be unavailable if we could not load the dialog-rendering plugin -- in this case, we will very likely display a warning dialog and having a transparent background can make it very hard to read it.

This was supposed to be included in 3.6.0, but I forgot about it