### PR TITLE
Fix typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,7 @@ Fabounet :
    * proposed to see the help if it has never been done
    * message when no plug-in
    * removed some print messages
- * Config pannel :
+ * Config panel :
    * changed the agencement of many options for a better ergonomy.
    * enhancement of previews in config panels
    * correction of the icon's order bug
@@ -48,7 +48,7 @@ Fabounet :
    * added some tooltips to the menu
    * lock dock option works now for all icons
  * Themes :
-   * added versionning for distant themes
+   * added versioning for distant themes
    * Default: correction in some conf files
    * fixed 1 crash when reloading theme
    * Improved the theme selector
@@ -81,7 +81,7 @@ Matttbe :
 Fabounet :
  * Miscellaneous
    * animations and effects names are now translated
-   * fixed versionning for Dbus and Switcher
+   * fixed versioning for Dbus and Switcher
  * Rendering :
    * fixed a bug in rendering-caroussel
    * fixed a bug on Slide view (wrong placement)
@@ -91,7 +91,7 @@ Fabounet :
    * small bug-fix on MP if artist AND title is empty
    * fixed a infinite loop when a player crash
    * Fixed blank covers for Audacious
-   * modified the dowload of covers (Amazon has changed its API)
+   * modified the download of covers (Amazon has changed its API)
    * prevent empty image from Amazon 
  * Switcher :
    * fixed a bug with windows list with Metacity
@@ -174,7 +174,7 @@ Core
  * VFS backend: new methods added
  * OpenGL backend: added a cairo-like API for paths
  * Applet API: unified methods to handle icons in sub-docks and desklets
- * Added ability to have several docks with independant configurations
+ * Added ability to have several docks with independent configurations
  * Icons that demand attention are visible even when the dock is hidden
  * Icons are now loaded progressively for a faster startup
  * Desklets: added ability to click behind desklets

--- a/Help/data/Help.conf.in
+++ b/Help/data/Help.conf.in
@@ -5,8 +5,8 @@
 
 #X[Using the dock]
 Using the dock =
-#>Most icons in the dock have several actions: the primary action on left-click, a secondary action on middle-click, and additionnal actions on right-click (in the menu).
-#Some applets let you bind a shortkey to an action, and decide which action sould be on middle-click.
+#>Most icons in the dock have several actions: the primary action on left-click, a secondary action on middle-click, and additional actions on right-click (in the menu).
+#Some applets let you bind a shortkey to an action, and decide which action should be on middle-click.
 _Using the dock =
 
 #X[Adding features]
@@ -102,7 +102,7 @@ _Switching between the windows of a same application =
 
 #X[Grouping windows of a given application]
 Grouping windows of a given application =
-#>When an application has several windows, one icon for each window will appear in the dock; they will be grouped togather into a sub-dock.
+#>When an application has several windows, one icon for each window will appear in the dock; they will be grouped together into a sub-dock.
 #Clicking on the main icon will display all the windows of the application side-by-side (if your Window Manager is able to do that).
 _Grouping windows of a given application =
 
@@ -120,12 +120,12 @@ _Showing windows preview =
 #[@pkgdatadir@/icons/icon-background.svg]
 [Docks]
 
-#X[Positionning the dock on the screen]
-Positionning the dock on the screen =
+#X[Positioning the dock on the screen]
+Positioning the dock on the screen =
 #>The dock can be placed anywhere on the screen.
 #In the case of the main dock, right-click -> Cairo-Dock -> configure, and then select the position you want.
 #In the case of a 2nd or 3rd dock, right-click -> Cairo-Dock -> set up this dock, and then select the position you want.
-_Positionning the dock on the screen=
+_Positioning the dock on the screen=
 
 #X[Hiding the dock to use all the screen]
 Hiding the dock to use all the screen=
@@ -186,7 +186,7 @@ _Changing the desklets decorations =
 Having a calendar with tasks =
 #>Activate the Clock applet.
 #Clicking on it will display a calendar.
-#Double-clicking on a day will pop-up a task-editor. Here you can add/remove taks.
+#Double-clicking on a day will pop-up a task-editor. Here you can add/remove tasks.
 #When a task has been or is going to be scheduled, the applet will warn you (15mn before the event, and also 1 day before in the case of an anniversary).
 _Having a calendar with tasks =
 
@@ -287,7 +287,7 @@ _Accessing folder bookmarks =
 Having multiple instances of an applet =
 #>Some applets can have several instances running at the same time: Clock, Stack, Weather, ...
 #Right click on the applet's icon -> "launch another instance".
-#You can configure each instance independantely. This allows you, for example, to have the current time for different countries in your dock or the weather in different cities.
+#You can configure each instance independentely. This allows you, for example, to have the current time for different countries in your dock or the weather in different cities.
 _Having multiple instances of an applet =
 
 #X[Adding / removing a desktop]
@@ -297,20 +297,20 @@ Adding / removing a desktop =
 #You can even name each of them.
 _Adding / removing a desktop =
 
-#X[Controling the sound volume]
-Controling the sound volume =
+#X[Controlling the sound volume]
+Controlling the sound volume =
 #>Activate the Sound Volume applet.
 #Then scroll up/down to increase/decrease the sound.
 #Alternatively, you can click on the icon and move the scroll bar.
 #Middle-click will mute/unmute.
-_Controling the sound volume =
+_Controlling the sound volume =
 
-#X[Controling the screen brightness]
-Controling the screen brightness =
+#X[Controlling the screen brightness]
+Controlling the screen brightness =
 #>Activate the Screen Luminosity applet.
 #Then scroll up/down to increase/decrease the brightness.
 #Alternatively, you can click on the icon and move the scroll bar.
-_Controling the screen brightness =
+_Controlling the screen brightness =
 
 
 #[@pkgdatadir@/icons/icon-behavior.svg]
@@ -362,7 +362,7 @@ netspeed=
 #X [The dustbin remains empty even when I delete a file.]
 Xdustbin=
 #> if you're using KDE, you may have to specify the path to the trash folder.
-#Just edit the applet's configuration, and fill in the Trash path; it is probably «~/.locale/share/Trash/files». Be very careful when typing a path here!!! (do not insert spaces or some invisible caracters).
+#Just edit the applet's configuration, and fill in the Trash path; it is probably «~/.locale/share/Trash/files». Be very careful when typing a path here!!! (do not insert spaces or some invisible characters).
 dustbin=
 
 

--- a/Help/src/applet-config.c
+++ b/Help/src/applet-config.c
@@ -24,19 +24,19 @@
 #include "applet-config.h"
 
 
-//\_________________ Here you have to get all your parameters from the conf file. Use the macros CD_CONFIG_GET_BOOLEAN, CD_CONFIG_GET_INTEGER, CD_CONFIG_GET_STRING, etc. myConfig has been reseted to 0 at this point. This function is called at the beginning of init and reload.
+//\_________________ Here you have to get all your parameters from the conf file. Use the macros CD_CONFIG_GET_BOOLEAN, CD_CONFIG_GET_INTEGER, CD_CONFIG_GET_STRING, etc. myConfig has been reset to 0 at this point. This function is called at the beginning of init and reload.
 CD_APPLET_GET_CONFIG_BEGIN
 	
 CD_APPLET_GET_CONFIG_END
 
 
-//\_________________ Here you have to free all ressources allocated for myConfig. This one will be reseted to 0 at the end of this function. This function is called right before you get the applet's config, and when your applet is stopped, in the end.
+//\_________________ Here you have to free all resources allocated for myConfig. This one will be reset to 0 at the end of this function. This function is called right before you get the applet's config, and when your applet is stopped, in the end.
 CD_APPLET_RESET_CONFIG_BEGIN
 	
 CD_APPLET_RESET_CONFIG_END
 
 
-//\_________________ Here you have to free all ressources allocated for myData. This one will be reseted to 0 at the end of this function. This function is called when your applet is stopped, in the very end.
+//\_________________ Here you have to free all resources allocated for myData. This one will be reset to 0 at the end of this function. This function is called when your applet is stopped, in the very end.
 CD_APPLET_RESET_DATA_BEGIN
 	
 	

--- a/Help/src/applet-init.c
+++ b/Help/src/applet-init.c
@@ -56,7 +56,7 @@ CD_APPLET_INIT_BEGIN
 CD_APPLET_INIT_END
 
 
-//\___________ Here is where you stop your applet. myConfig and myData are still valid, but will be reseted to 0 at the end of the function. In the end, your applet will go back to its original state, as if it had never been activated.
+//\___________ Here is where you stop your applet. myConfig and myData are still valid, but will be reset to 0 at the end of the function. In the end, your applet will go back to its original state, as if it had never been activated.
 CD_APPLET_STOP_BEGIN
 	CD_APPLET_UNREGISTER_FOR_CLICK_EVENT;
 	CD_APPLET_UNREGISTER_FOR_MIDDLE_CLICK_EVENT;

--- a/Help/src/applet-notifications.c
+++ b/Help/src/applet-notifications.c
@@ -47,7 +47,7 @@ CD_APPLET_ON_MIDDLE_CLICK_END
 
 
 
-//\___________ Define here the entries you want to add to the menu when the user right-clicks on your icon or on its subdock or your desklet. The icon and the container that were clicked are available through the macros CD_APPLET_CLICKED_ICON and CD_APPLET_CLICKED_CONTAINER. CD_APPLET_CLICKED_ICON may be NULL if the user clicked in the container but out of icons. The menu where you can add your entries is available throught the macro CD_APPLET_MY_MENU; you can add sub-menu to it if you want.
+//\___________ Define here the entries you want to add to the menu when the user right-clicks on your icon or on its subdock or your desklet. The icon and the container that were clicked are available through the macros CD_APPLET_CLICKED_ICON and CD_APPLET_CLICKED_CONTAINER. CD_APPLET_CLICKED_ICON may be NULL if the user clicked in the container but out of icons. The menu where you can add your entries is available through the macro CD_APPLET_MY_MENU; you can add sub-menu to it if you want.
 static void _cd_show_config (G_GNUC_UNUSED GtkMenuItem *menu_item, G_GNUC_UNUSED gpointer data)
 {
 	cairo_dock_show_main_gui ();

--- a/INSTALL
+++ b/INSTALL
@@ -29,7 +29,7 @@ sudo make install
 
 For 64bits (x86_64) architectures, the libraries are installed in a 'lib64' directory by default but it seems it can be a problem for some distributions (e.g.: ArchLinux). If you have a problem by launching Cairo-Dock, you can compile it (core and its plug-ins) with the flag "FORCE_NOT_LIB64":
     $ cmake CMakeLists.txt -DCMAKE_INSTALL_PREFIX=/usr -DFORCE_NOT_LIB64=yes
-You can also force another prefix for this librairy directory with "LIB_SUFFIX" flag, e.g. for 'lib32' directory:
+You can also force another prefix for this library directory with "LIB_SUFFIX" flag, e.g. for 'lib32' directory:
     $ cmake CMakeLists.txt -DCMAKE_INSTALL_PREFIX=/usr -DLIB_SUFFIX=32
 
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Bug reports
 You can report bugs using Github [issues](https://github.com/Cairo-Dock/cairo-dock-core/issues). If possible:
 
 * Read our wiki specially the '[Troubleshooting](https://github.com/Cairo-Dock/cairo-dock-core/wiki/Troubleshooting)' section which can help you to resolve some bugs like a black background, messages at startup, etc.
-* Please include also some information like your distribution, your achitecture (32/64bits), your Desktop Manager (Gnome, KDE, XFCE,...) your Window Manager (Compiz, Metacity, Kwin, etc.) or Wayland compositor (Wayfire, Kwin, Labwc, etc.), if you use Cairo-Dock with or without OpenGL, with which theme, etc. On a recent version (>= 3.5.99), you can just copy the "Technical info" page from the About dialog (right click on the dock -> Cairo-Dock -> About) which covers the most important details.
+* Please include also some information like your distribution, your architecture (32/64bits), your Desktop Manager (Gnome, KDE, XFCE,...) your Window Manager (Compiz, Metacity, Kwin, etc.) or Wayland compositor (Wayfire, Kwin, Labwc, etc.), if you use Cairo-Dock with or without OpenGL, with which theme, etc. On a recent version (>= 3.5.99), you can just copy the "Technical info" page from the About dialog (right click on the dock -> Cairo-Dock -> About) which covers the most important details.
 * Include the method to reproduce the bug (which actions, which options activated)
 * Run the dock with the command
           cairo-dock -l debug > debug.txt

--- a/TODO
+++ b/TODO
@@ -62,7 +62,7 @@ For each new version:
 	- search in Recent-Events' dialog (seems like libzeitgeist is buggy)
 	- taskbar: separator as an option -> test
 	- taskbar, minimized windows only: when restored, an appli icon gets the "?" for a second before disappearing
-	- Twitter: when a new entry apears in the timeline, have to click on the applet to stop the animation (doesn't stop from the menu).
+	- Twitter: when a new entry appears in the timeline, have to click on the applet to stop the animation (doesn't stop from the menu).
 	- image buffer: draw the surface from the center, like the texture.
 	- Icons: use an image buffer + a request size.
 	- add a function cairo_dock_render_one_icon_in_desklet_opengl().

--- a/data/cairo-dock-simple.conf.in
+++ b/data/cairo-dock-simple.conf.in
@@ -43,7 +43,7 @@ frame_task =
 #Y-[None;0;0;Minimalistic;1;1;Integrated;1;1;Separated;1;1] Behaviour of the Taskbar:
 #{None       : Don't show opened windows in the dock.
 #Minimalistic: Mix applications with its launcher, show other windows only if they are minimized (like in MacOSX).
-#Integrated  : Mix applications with its launcher, show all others windows and group windows togather in sub-dock (default).
+#Integrated  : Mix applications with its launcher, show all others windows and group windows together in sub-dock (default).
 #Separated   : Separate the taskbar from the launchers and only show windows that are on the current desktop.}
 taskbar = 2
 

--- a/data/cairo-dock.conf.in
+++ b/data/cairo-dock.conf.in
@@ -143,7 +143,7 @@ visibility alpha = 0.35
 #a- Play a short animation of the icon when its window becomes active
 animation on active window = wobbly
 
-#i- Maximum number of caracters in application name:
+#i- Maximum number of characters in application name:
 #{"..." will be added at the end if the name is too long.}
 max name length = 25
 
@@ -157,7 +157,7 @@ action on middle click = 1
 #{This is the default behaviour of most taskbars.}
 minimize on click = true
 
-#b- Present windows preview on click when several windows are grouped togather
+#b- Present windows preview on click when several windows are grouped together
 #{Only if your Window Manager supports it.}
 present class on click = true
 

--- a/data/themes/default-theme-panel/cairo-dock.conf
+++ b/data/themes/default-theme-panel/cairo-dock.conf
@@ -143,7 +143,7 @@ visibility alpha=0.34999999999999998
 #a- Play a short animation of the icon when its window becomes active
 animation on active window=wobbly
 
-#i- Maximum number of caracters in application name:
+#i- Maximum number of characters in application name:
 #{"..." will be added at the end if the name is too long.}
 max name length=20
 
@@ -157,7 +157,7 @@ action on middle click=1
 #{This is the default behaviour of most taskbars.}
 minimize on click=true
 
-#b- Present windows preview on click when several windows are grouped togather
+#b- Present windows preview on click when several windows are grouped together
 #{Only if your Window Manager supports it.}
 present class on click=true
 

--- a/data/themes/default-theme-panel/plug-ins/shortcuts/shortcuts.conf
+++ b/data/themes/default-theme-panel/plug-ins/shortcuts/shortcuts.conf
@@ -116,7 +116,7 @@ list drives=true
 list network=false
 
 #b List bookmarks?
-#{GTK bookmarks, that are used by Nautilus for exemple.}
+#{GTK bookmarks, that are used by Nautilus for example.}
 list bookmarks=true
 
 #F[Display]

--- a/data/themes/default-theme/cairo-dock.conf
+++ b/data/themes/default-theme/cairo-dock.conf
@@ -143,7 +143,7 @@ visibility alpha=0.34999999999999998
 #a- Play a short animation of the icon when its window becomes active
 animation on active window=wobbly
 
-#i- Maximum number of caracters in application name:
+#i- Maximum number of characters in application name:
 #{"..." will be added at the end if the name is too long.}
 max name length=20
 
@@ -157,7 +157,7 @@ action on middle click=1
 #{This is the default behaviour of most taskbars.}
 minimize on click=true
 
-#b- Present windows preview on click when several windows are grouped togather
+#b- Present windows preview on click when several windows are grouped together
 #{Only if your Window Manager supports it.}
 present class on click=true
 

--- a/data/themes/default-theme/plug-ins/shortcuts/shortcuts.conf
+++ b/data/themes/default-theme/plug-ins/shortcuts/shortcuts.conf
@@ -113,7 +113,7 @@ list drives=true
 list network=false
 
 #b List bookmarks?
-#{GTK bookmarks, that are used by Nautilus for exemple.}
+#{GTK bookmarks, that are used by Nautilus for example.}
 list bookmarks=true
 
 #F[Display]

--- a/misc/apply-default-values-to-conf.sh
+++ b/misc/apply-default-values-to-conf.sh
@@ -73,7 +73,7 @@ set_current_conf_file "cairo-dock.conf"
 set_value "Position"	    "x gap" 			    0
 set_value "Position"	    "y gap" 			    0
 set_value "Position"	    "xinerama"		    false
-set_value "Accessibility"   "max autorized width"   0
+set_value "Accessibility"   "max authorized width"   0
 set_value "Accessibility"   "visibility"  	    4
 set_value "Accessibility"   "leaving delay"	    250
 set_value "Accessibility"   "show delay"  	    300
@@ -163,7 +163,7 @@ set_current_conf_file "plug-ins/drop_indicator/drop_indicator.conf"
 set_value "Drag and drop indicator"     "speed" 		    2
 
 set_current_conf_file "plug-ins/dustbin/dustbin.conf"
-set_value "Configuration"   "additionnal directories"     ""
+set_value "Configuration"   "additional directories"     ""
 set_value "Configuration"   "alternative file browser"    ""
 
 set_current_conf_file "plug-ins/GMenu/GMenu.conf"

--- a/po/misc/update-translations.sh
+++ b/po/misc/update-translations.sh
@@ -82,7 +82,7 @@ fi
 ###
 if test $UPDATE_PLUGINS -gt 0; then
 	cd ${PLUGINS_DIR}
-	echo "extracing the messages of the plug-ins ..."
+	echo "extracting the messages of the plug-ins ..."
 	for plugin in *
 	do
 		if test -d $plugin/data; then
@@ -117,7 +117,7 @@ fi
 ###
 if test $UPDATE_THIRD_PARTY -gt 0; then
 	cd ${PLUGINS_EXTRA_DIR}
-	echo "extracing the messages of third-party applets ..."
+	echo "extracting the messages of third-party applets ..."
 	for applet in `sed -n "/^\[/p" list.conf | tr -d []`; do
 		if test -d $applet; then
 			cd $applet

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable (${PROJECT_NAME}
 
 set_target_properties (${PROJECT_NAME} PROPERTIES ENABLE_EXPORTS True)
 
-# Link the executable to the librairies.
+# Link the executable to the libraries.
 target_link_libraries (${PROJECT_NAME}
 	${PACKAGE_LIBRARIES}
 	${GTK_LIBRARIES}

--- a/src/cairo-dock-widget-module.c
+++ b/src/cairo-dock-widget-module.c
@@ -36,7 +36,7 @@ static gboolean _on_module_activated (ModuleWidget *pModuleWidget, G_GNUC_UNUSED
 
 static gchar *_get_valid_module_conf_file (GldiModule *pModule)
 {
-	if (pModule->pVisitCard->cConfFileName != NULL)  // not instanciated yet, take a conf-file in the module's user dir, or the default conf-file.
+	if (pModule->pVisitCard->cConfFileName != NULL)  // not instantiated yet, take a conf-file in the module's user dir, or the default conf-file.
 	{
 		// open the module's user dir.
 		gchar *cUserDataDirPath = gldi_module_get_config_dir (pModule);

--- a/src/cairo-dock-widget-themes.c
+++ b/src/cairo-dock-widget-themes.c
@@ -242,7 +242,7 @@ static gboolean _cairo_dock_load_theme (GKeyFile* pKeyFile, ThemesWidget *pTheme
 		cd_debug ("start importation...");
 		pThemesWidget->pImportTask = cairo_dock_import_theme_async (cNewThemeName, bLoadBehavior, bLoadLaunchers, _load_theme, pThemesWidget);  // if 'pThemesWidget' is destroyed, the 'reset' callback will be called and will cancel the task.
 	}
-	else  // if the theme is already local and uptodate, there is really no need to show a progressbar, because only the download/unpacking is done asynchonously (and the copy of the files is fast enough).
+	else  // if the theme is already local and uptodate, there is really no need to show a progressbar, because only the download/unpacking is done asynchronously (and the copy of the files is fast enough).
 	{
 		bThemeImported = cairo_dock_import_theme (cNewThemeName, bLoadBehavior, bLoadLaunchers);
 		

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -217,7 +217,7 @@ static void _cairo_dock_intercept_signal (int signal)
 		g_print ("Couldn't guess if it was an applet's fault or not. It may have crashed inside the core or inside a thread\n");
 	}
 	
-	// if the crash occurs on startup, take additionnal measures; else just respawn quietly.
+	// if the crash occurs on startup, take additional measures; else just respawn quietly.
 	if (! s_bSucessfulLaunch)  // a crash on startup,
 	{
 		if (s_iNbCrashes < 2)  // the first 2 crashes, restart with a delay (in case we were launched too early on startup).
@@ -350,7 +350,7 @@ int main (int argc, char** argv)
 	 */
 	if (s_iNbCrashes > 4)
 	{
-		g_print ("Sorry, Cairo-Dock has encoutered some problems, and will quit.\n");
+		g_print ("Sorry, Cairo-Dock has encountered some problems, and will quit.\n");
 		return 1;
 	}
 
@@ -393,7 +393,7 @@ int main (int argc, char** argv)
 			_("Ask again on startup which backend to use."), NULL},
 		{"env", 'e', G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_STRING,
 			&cEnvironment,
-			_("Force the dock to consider this environnement - use it with care."), NULL},
+			_("Force the dock to consider this environment - use it with care."), NULL},
 		{"dir", 'd', G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_STRING,
 			&cUserDefinedDataDir,
 			_("Force the dock to load from this directory, instead of ~/.config/cairo-dock."), NULL},
@@ -439,7 +439,7 @@ int main (int argc, char** argv)
 			_("Cairo-Dock makes anything, including coffee !"), NULL},
 		{"modules-dir", 'M', G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_STRING,
 			&cUserDefinedModuleDir,
-			_("Ask the dock to load additionnal modules contained in this directory (though it is unsafe for your dock to load unnofficial modules)."), NULL},
+			_("Ask the dock to load additional modules contained in this directory (though it is unsafe for your dock to load unofficial modules)."), NULL},
 		{"testing", 'T', G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_NONE,
 			&bTesting,
 			_("For debugging purpose only. The crash manager will not be started to hunt down the bugs."), NULL},
@@ -674,7 +674,7 @@ int main (int argc, char** argv)
 			gldi_modules_new_from_directory (cUserDefinedModuleDir, &erreur);  // load user plug-ins
 			if (erreur != NULL)
 			{
-				cd_warning ("%s\n  no additionnal module will be available", erreur->message);
+				cd_warning ("%s\n  no additional module will be available", erreur->message);
 				g_error_free (erreur);
 				erreur = NULL;
 			}

--- a/src/gldit/CMakeLists.txt
+++ b/src/gldit/CMakeLists.txt
@@ -108,7 +108,7 @@ set_target_properties ("gldi" PROPERTIES
 	#OUTPUT_NAME ${PROJECT_NAME}
 )
 
-# Link the result to the librairies.
+# Link the result to the libraries.
 target_link_libraries("gldi"
 	${PACKAGE_LIBRARIES}
 	${GTK_LIBRARIES}

--- a/src/gldit/cairo-dock-animations.h
+++ b/src/gldit/cairo-dock-animations.h
@@ -73,9 +73,9 @@ struct _CairoDockHidingEffect {
 	void (*pre_render) (CairoDock *pDock, double fOffset, cairo_t *pCairoContext);
 	/// function called before the icons are drawn (opengl)
 	void (*pre_render_opengl) (CairoDock *pDock, double fOffset);
-	/// function called afer the icons are drawn (cairo)
+	/// function called after the icons are drawn (cairo)
 	void (*post_render) (CairoDock *pDock, double fOffset, cairo_t *pCairoContext);
-	/// function called afer the icons are drawn (opengl)
+	/// function called after the icons are drawn (opengl)
 	void (*post_render_opengl) (CairoDock *pDock, double fOffset);
 	/// function called when the animation is started.
 	void (*init) (CairoDock *pDock);
@@ -90,7 +90,7 @@ struct _CairoDockHidingEffect {
 */
 #define cairo_dock_container_is_animating(pContainer) (CAIRO_CONTAINER(pContainer)->iSidGLAnimation != 0)
 
-/** Say if it's usefull to launch an animation on a Dock (indeed, it's useless to launch it if it will be invisible).
+/** Say if it's useful to launch an animation on a Dock (indeed, it's useless to launch it if it will be invisible).
 *@param pDock the Dock to animate.
 */
 #define cairo_dock_animation_will_be_visible(pDock) ( \
@@ -200,7 +200,7 @@ void cairo_dock_stop_marking_icon_animation_as (Icon *pIcon, CairoDockAnimationS
 *@param iDuration duration if the transition, in ms. Can be 0 for an endless transition, in which case you can stop the transition with #cairo_dock_remove_transition_on_icon.
 *@param bRemoveWhenFinished TRUE to destroy and remove the transition when it is finished.
 *@param pUserData data passed to the rendering functions.
-*@param pFreeUserDataFunc function called to free the user data when the transition is destroyed (optionnal).
+*@param pFreeUserDataFunc function called to free the user data when the transition is destroyed (optional).
 */
 void cairo_dock_set_transition_on_icon (Icon *pIcon, GldiContainer *pContainer, CairoDockTransitionRenderFunc render_step_cairo, CairoDockTransitionGLRenderFunc render_step_opengl, gboolean bFastPace, gint iDuration, gboolean bRemoveWhenFinished, gpointer pUserData, GFreeFunc pFreeUserDataFunc);
 

--- a/src/gldit/cairo-dock-applet-facility.h
+++ b/src/gldit/cairo-dock-applet-facility.h
@@ -200,14 +200,14 @@ cairo_dock_get_integer_list_key_value (pKeyFile, cGroupName, cKeyName, &bFlushCo
 *@param cKeyName name of the key in the conf file.
 *@param length pointer to the number of strings that were extracted from the conf file.
 *@param cDefaultValues default value if the group/key is not found (typically if the key is new). It is a string with words separated by ';'. It can be NULL.
-*@return a table of strings, to be freeed with 'g_strfreev'.
+*@return a table of strings, to be freed with 'g_strfreev'.
 */
 #define CD_CONFIG_GET_STRING_LIST_WITH_DEFAULT(cGroupName, cKeyName, length, cDefaultValues) cairo_dock_get_string_list_key_value (pKeyFile, cGroupName, cKeyName, &bFlushConfFileNeeded, length, cDefaultValues, NULL, NULL)
 /** Get the value of a 'strings list' from the conf file, with NULL as default value.
 *@param cGroupName name of the group in the conf file.
 *@param cKeyName name of the key in the conf file.
 *@param length pointer to the number of strings that were extracted from the conf file.
-*@return a table of strings, to be freeed with 'g_strfreev'.
+*@return a table of strings, to be freed with 'g_strfreev'.
 */
 #define CD_CONFIG_GET_STRING_LIST(cGroupName, cKeyName, length) CD_CONFIG_GET_STRING_LIST_WITH_DEFAULT(cGroupName, cKeyName, length, NULL)
 
@@ -380,7 +380,7 @@ cairo_dock_get_integer_list_key_value (pKeyFile, cGroupName, cKeyName, &bFlushCo
 /** Path of the applet's instance's conf file.
 */
 #define CD_APPLET_MY_CONF_FILE myApplet->cConfFilePath
-/** Key file of the applet instance, availale during the init, config, and reload.
+/** Key file of the applet instance, available during the init, config, and reload.
 */
 #define CD_APPLET_MY_KEY_FILE pKeyFile
 
@@ -423,7 +423,7 @@ cairo_dock_get_integer_list_key_value (pKeyFile, cGroupName, cKeyName, &bFlushCo
 #define CD_APPLET_MY_MENU pAppletMenu
 
 //\______________________ drop.
-/** Data received after a drop occured (string).
+/** Data received after a drop occurred (string).
 */
 #define CD_APPLET_RECEIVED_DATA cReceivedData
 
@@ -797,7 +797,7 @@ gldi_shortkey_new (cShortKey, myApplet->pModule->pVisitCard->cTitle, cDescriptio
 
 //\_________________________________ TASKBAR
 /** Let your applet control the window of an external program, instead of the Taskbar.
- *\param cApplicationClass the class of the application you wish to control (in lower case), or NULL to stop controling any appli.
+ *\param cApplicationClass the class of the application you wish to control (in lower case), or NULL to stop controlling any appli.
 */
 #define CD_APPLET_MANAGE_APPLICATION(cApplicationClass) do {\
 	if (cairo_dock_strings_differ (myIcon->cClass, (cApplicationClass))) {\

--- a/src/gldit/cairo-dock-applet-manager.c
+++ b/src/gldit/cairo-dock-applet-manager.c
@@ -39,7 +39,7 @@
 // public (manager, config, data)
 GldiObjectManager myAppletIconObjectMgr;
 
-// dependancies
+// dependencies
 
 // private
 

--- a/src/gldit/cairo-dock-applications-manager.c
+++ b/src/gldit/cairo-dock-applications-manager.c
@@ -55,7 +55,7 @@ CairoTaskbarParam myTaskbarParam;
 GldiManager myTaskbarMgr;
 GldiObjectManager myAppliIconObjectMgr;
 
-// dependancies
+// dependencies
 extern CairoDock *g_pMainDock;
 extern gboolean g_bUseOpenGL;
 //extern int g_iDamageEvent;
@@ -867,10 +867,10 @@ static gboolean _remove_appli (G_GNUC_UNUSED GldiWindowActor *actor, Icon *pIcon
 	
 	// make it an invalid appli
 	gldi_icon_unset_appli (pIcon);  // we don't want to go into the 'unregister'
-	g_free (pIcon->cClass);  // nor the class manager, since we reseted it beforehand.
+	g_free (pIcon->cClass);  // nor the class manager, since we reset it beforehand.
 	pIcon->cClass = NULL;
 	
-	// if not inside a dock, free it, else it will be freeed with the dock.
+	// if not inside a dock, free it, else it will be freed with the dock.
 	if (cairo_dock_get_icon_container (pIcon) == NULL)  // not in a dock.
 	{
 		gldi_object_unref (GLDI_OBJECT (pIcon));

--- a/src/gldit/cairo-dock-backends-manager.c
+++ b/src/gldit/cairo-dock-backends-manager.c
@@ -37,7 +37,7 @@
 GldiManager myBackendsMgr;
 CairoBackendsParam myBackendsParam;
 
-// dependancies
+// dependencies
 extern gboolean g_bUseOpenGL;
 
 // private

--- a/src/gldit/cairo-dock-class-icon-manager.c
+++ b/src/gldit/cairo-dock-class-icon-manager.c
@@ -26,7 +26,7 @@
 // public (manager, config, data)
 GldiObjectManager myClassIconObjectMgr;
 
-// dependancies
+// dependencies
 
 // private
 

--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -67,7 +67,7 @@ static GldiObjectManager myAppInfoObjectMgr;
 struct _CairoDockClassAppli {
 	/// TRUE if the appli must use the icon provided by X instead the one from the theme.
 	gboolean bUseXIcon;
-	/// TRUE if the appli doesn't group togather with its class.
+	/// TRUE if the appli doesn't group together with its class.
 	gboolean bExpand;
 	/// List of the inhibitors of the class.
 	GList *pIconsOfClass;
@@ -1204,7 +1204,7 @@ void cairo_dock_deinhibite_class (const gchar *cClass, Icon *pInhibitorIcon)
 		cairo_dock_trigger_load_icon_buffers (pInhibitorIcon);  // in case the inhibitor was drawn with an emblem or a stack of the applis
 	}
 
-	if (pInhibitorIcon == NULL || pInhibitorIcon->pAppli != NULL)  // the launcher is controlling 1 appli icon, or we deinhibate all the inhibitors.
+	if (pInhibitorIcon == NULL || pInhibitorIcon->pAppli != NULL)  // the launcher is controlling 1 appli icon, or we deinhibit all the inhibitors.
 	{
 		const GList *pList = cairo_dock_list_existing_appli_with_class (cClass);
 		Icon *pIcon;
@@ -2552,7 +2552,7 @@ gchar *cairo_dock_guess_class (const gchar *cCommand, const gchar *cStartupWMCla
 				{
 					g_free (cDefaultClass);
 					cDefaultClass = g_strdup_printf ("%s%s", "libreoffice", str+2);
-					str = strchr (cDefaultClass, ' ');  // remove the additionnal params of the command.
+					str = strchr (cDefaultClass, ' ');  // remove the additional params of the command.
 					if (str)
 						*str = '\0';
 					cClass = cDefaultClass;  // "libreoffice-writer"

--- a/src/gldit/cairo-dock-config.h
+++ b/src/gldit/cairo-dock-config.h
@@ -31,7 +31,7 @@ G_BEGIN_DECLS
 /**
 *@file cairo-dock-config.h This class manages the configuration system of Cairo-Dock.
 * Cairo-Dock and any items (icons, root docks, modules, etc) are configured by conf files.
-* Conf files containes some information usable by the GUI manager to build a corresponding config panel and update the conf file automatically, which relieves you from this thankless task.
+* Conf files contains some information usable by the GUI manager to build a corresponding config panel and update the conf file automatically, which relieves you from this thankless task.
 */
 
 /*

--- a/src/gldit/cairo-dock-container-priv.h
+++ b/src/gldit/cairo-dock-container-priv.h
@@ -178,7 +178,7 @@ void gldi_container_move_to_rect (GldiContainer *pContainer,
 									gdouble rel_anchor_dy);
 
 /** Calculate the parameters to pass to gldi_container_move_to_rect() to
- * 	poisition a child container on the given pContainer, pointing to pPointedIcon.
+ * 	position a child container on the given pContainer, pointing to pPointedIcon.
  * 	This can be used for subdocks, dialogs and menus.
  *  The bSkipLabel parameter controls whether to leave space for an icon's label on a horizontal dock
  *  (should be TRUE for subdocks and dialogs, FALSE for menus). */
@@ -251,10 +251,10 @@ void gldi_container_disable_drop (GldiContainer *pContainer); // not used at all
 /// Get the GdkAtom used internally from dragging icons between docks
 GdkAtom gldi_container_icon_dnd_atom (void);
 
-/** Notify everybody that a drop has just occured.
+/** Notify everybody that a drop has just occurred.
 * @param cReceivedData the dropped data.
-* @param pPointedIcon the icon which was pointed when the drop occured.
-* @param fOrder the order of the icon if the drop occured on it, or LAST_ORDER if the drop occured between 2 icons.
+* @param pPointedIcon the icon which was pointed when the drop occurred.
+* @param fOrder the order of the icon if the drop occurred on it, or LAST_ORDER if the drop occurred between 2 icons.
 * @param pContainer the container of the icon
 */
 void gldi_container_notify_drop_data (GldiContainer *pContainer, gchar *cReceivedData, Icon *pPointedIcon, double fOrder);

--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -53,7 +53,7 @@ GldiObjectManager myContainerObjectMgr;
 GldiContainer *g_pPrimaryContainer = NULL;
 GldiDesktopBackground *g_pFakeTransparencyDesktopBg = NULL;
 
-// dependancies
+// dependencies
 extern CairoDockGLConfig g_openglConfig;
 extern gboolean g_bUseOpenGL;
 extern CairoDockHidingEffect *g_pHidingBackend;  // cairo_dock_is_hidden

--- a/src/gldit/cairo-dock-container.h
+++ b/src/gldit/cairo-dock-container.h
@@ -71,7 +71,7 @@ typedef enum {
 	NOTIFICATION_MIDDLE_CLICK_ICON,
 	/// notification called when the user scrolls on a container. data : {Icon, CairoContainer, int iDirection, int bEmulated}
 	/// Note: Icon is the icon under the mouse or can be NULL if the mouse is not over any icon. Currently it is only emitted on docks and desklets.
-	/// iDirection is either GDK_SCROLL_UP or GDK_SCROLL_DOWN; bEmulated is TRUE if this event is synthetized based on
+	/// iDirection is either GDK_SCROLL_UP or GDK_SCROLL_DOWN; bEmulated is TRUE if this event is synthesized based on
 	/// a series of GDK_SCROLL_SMOOTH events received earlier (so it can be ignored if those were handled)
 	NOTIFICATION_SCROLL_ICON,
 	/// notification called when the user scrolls on a container and a GDK_SCROLL_SMOOTH event was delivered

--- a/src/gldit/cairo-dock-data-renderer-manager.c
+++ b/src/gldit/cairo-dock-data-renderer-manager.c
@@ -34,7 +34,7 @@
 GldiManager myDataRenderersMgr;
 GldiObjectManager myDataRendererObjectMgr;
 
-// dependancies
+// dependencies
 extern gboolean g_bUseOpenGL;
 extern gchar *g_cExtrasDirPath;
 

--- a/src/gldit/cairo-dock-data-renderer-manager.h
+++ b/src/gldit/cairo-dock-data-renderer-manager.h
@@ -29,7 +29,7 @@
 G_BEGIN_DECLS
 
 /**
-*@file cairo-dock-data-renderer-manager.h This class manages the list of available Data Renderers and their global ressources.
+*@file cairo-dock-data-renderer-manager.h This class manages the list of available Data Renderers and their global resources.
 */
 
 // manager

--- a/src/gldit/cairo-dock-data-renderer.h
+++ b/src/gldit/cairo-dock-data-renderer.h
@@ -75,7 +75,7 @@ struct _CairoDataRendererAttribute {
 	gint iNbValues;
 	/// number of values to remember over time. For instance graphs can display as much values as the icon's width [2 by default and minimum].
 	gint iMemorySize;
-	/// an array of pairs of (min,max) values. [optionnal, input values will be considered between 0 and 1 if NULL].
+	/// an array of pairs of (min,max) values. [optional, input values will be considered between 0 and 1 if NULL].
 	gdouble *pMinMaxValues;
 	/// whether to automatically update the values' range [false by default].
 	gboolean bUpdateMinMax;
@@ -85,13 +85,13 @@ struct _CairoDataRendererAttribute {
 	RendererRotateTheme iRotateTheme;
 	/// time needed to update to the new values. The update is smooth in OpenGL mode. [0 by default]
 	gint iLatencyTime;
-	/// a function used to format the values into a string. Only useful if you make te DataRenderer write the values [optionnal, by default the values are formatted with 2 decimals].
+	/// a function used to format the values into a string. Only useful if you make te DataRenderer write the values [optional, by default the values are formatted with 2 decimals].
 	CairoDataRendererFormatValueFunc format_value;
-	/// data to be passed to the format function [optionnal].
+	/// data to be passed to the format function [optional].
 	gpointer pFormatData;
-	/// an optionnal list of emblems to draw on the overlay.
+	/// an optional list of emblems to draw on the overlay.
 	gchar **cEmblems;
-	/// an optionnal list of labels to write on the overlay.
+	/// an optional list of labels to write on the overlay.
 	gchar **cLabels;
 };
 
@@ -149,7 +149,7 @@ struct _CairoDataRenderer {
 	//\_________________ filled at init by the implementation.
 	/// interface of the Data Renderer.
 	CairoDataRendererInterface interface;
-	//\_________________ filled at loading time independantly of the renderer type.
+	//\_________________ filled at loading time independently of the renderer type.
 	/// internal data to be drawn by the renderer.
 	CairoDataToRenderer data;
 	/// size of the drawing area.
@@ -167,7 +167,7 @@ struct _CairoDataRenderer {
 	/// the time it will take to update to the new value, with a smooth animation (require openGL capacity)
 	gint iLatencyTime;
 	//\_________________ filled at load time by the implementation.
-	/// the rank of the renderer, eg the number of values it can display at once (for exemple, 1 for a bar, 2 for a dual-gauge)
+	/// the rank of the renderer, eg the number of values it can display at once (for example, 1 for a bar, 2 for a dual-gauge)
 	gint iRank;  // nbre de valeurs que peut afficher 1 unite (en general : gauge:1/2, graph:1/2, bar:1)
 	/// set to TRUE <=> the renderer can draw the values as text itself.
 	gboolean bCanRenderValueAsText;
@@ -181,11 +181,11 @@ struct _CairoDataRenderer {
 	gboolean bUseOverlay;
 	/// position of the overlay, in the case the renderer uses one.
 	CairoOverlayPosition iOverlayPosition;
-	/// an optionnal list of labels to be displayed on the Data Renderer to indicate the nature of each value. Same size as the set of values.
+	/// an optional list of labels to be displayed on the Data Renderer to indicate the nature of each value. Same size as the set of values.
 	CairoDataRendererText *pLabels;
-	/// an optionnal list of emblems to be displayed on the Data Renderer to indicate the nature of each value. Same size as the set of values.
+	/// an optional list of emblems to be displayed on the Data Renderer to indicate the nature of each value. Same size as the set of values.
 	CairoDataRendererEmblem *pEmblems;
-	/// an optionnal list of text zones to write the values. Same size as the set of values.
+	/// an optional list of text zones to write the values. Same size as the set of values.
 	CairoDataRendererTextParam *pValuesText;
 	//\_________________ dynamic.
 	/// the animation counter for the smooth movement.
@@ -220,7 +220,7 @@ void cairo_dock_add_new_data_renderer_on_icon (Icon *pIcon, GldiContainer *pCont
 *@param pNewValues a set a new values (must be of the size defined on the creation of the Renderer)*/
 void cairo_dock_render_new_data_on_icon (Icon *pIcon, GldiContainer *pContainer, cairo_t *pCairoContext, double *pNewValues);
 
-/**Remove the Data Renderer of an icon. All the allocated ressources will be freed.
+/**Remove the Data Renderer of an icon. All the allocated resources will be freed.
 *@param pIcon the icon*/
 void cairo_dock_remove_data_renderer_on_icon (Icon *pIcon);
 

--- a/src/gldit/cairo-dock-dbus.h
+++ b/src/gldit/cairo-dock-dbus.h
@@ -122,14 +122,14 @@ int cairo_dock_dbus_get_integer (DBusGProxy *pDbusProxy, const gchar *cAccessor)
 /** Get the value of a 'string' parameter on the bus.
 *@param pDbusProxy proxy to the connection.
 *@param cAccessor name of the accessor.
-*@return the value of the parameter, to be freeed with g_free.
+*@return the value of the parameter, to be freed with g_free.
 */
 gchar *cairo_dock_dbus_get_string (DBusGProxy *pDbusProxy, const gchar *cAccessor);
 
 /** Get the value of a 'string list' parameter on the bus.
 *@param pDbusProxy proxy to the connection.
 *@param cAccessor name of the accessor.
-*@return the value of the parameter, to be freeed with g_strfreev.
+*@return the value of the parameter, to be freed with g_strfreev.
 */
 gchar **cairo_dock_dbus_get_string_list (DBusGProxy *pDbusProxy, const gchar *cAccessor);
 

--- a/src/gldit/cairo-dock-desklet-factory.h
+++ b/src/gldit/cairo-dock-desklet-factory.h
@@ -36,7 +36,7 @@ G_BEGIN_DECLS
 
 /**
 *@file cairo-dock-desklet-factory.h This class defines the Desklets, that are Widgets placed directly on your desktop.
-* A Desklet is a container that holds 1 applet's icon plus an optionnal list of other icons and an optionnal GTK widget, has a decoration, suports several accessibility types (like Compiz Widget Layer), and has a renderer.
+* A Desklet is a container that holds 1 applet's icon plus an optional list of other icons and an optional GTK widget, has a decoration, supports several accessibility types (like Compiz Widget Layer), and has a renderer.
 * Desklets can be resized or moved directly with the mouse, and can be rotated in the 3 directions of space.
 * To actually create or destroy a Desklet, use the Desklet Manager's functoins in \ref cairo-dock-desklet-manager.h.
 */
@@ -124,9 +124,9 @@ struct _CairoDeskletRenderer {
 	CairoDeskletCalculateIconsFunc 			calculate_icons;
 	/// function called on each iteration of the rendering loop.
 	CairoDeskletUpdateRendererDataFunc 	update;
-	/// optionnal rendering function with OpenGL that only draws the bounding boxes of the icons (for picking).
+	/// optional rendering function with OpenGL that only draws the bounding boxes of the icons (for picking).
 	CairoDeskletGLRenderFunc 			render_bounding_box;
-	/// An optionnal list of preset configs.
+	/// An optional list of preset configs.
 	GList *pPreDefinedConfigList;
 };
 
@@ -176,7 +176,7 @@ struct _CairoDesklet {
 	gint iDesiredWidth, iDesiredHeight;  // taille a atteindre (fixee par l'utilisateur dans le.conf)
 	gint iKnownWidth, iKnownHeight;  // taille connue par l'applet associee.
 	gboolean bSpaceReserved;  // l'espace est actuellement reserve.
-	gboolean bAllowMinimize;  // TRUE to allow the desklet to be minimized once. The flag is reseted to FALSE after the desklet has minimized.
+	gboolean bAllowMinimize;  // TRUE to allow the desklet to be minimized once. The flag is reset to FALSE after the desklet has minimized.
 	gint iMouseX2d;  // X position of the pointer taking into account the 2D transformations on the desklet (for an opengl renderer, you'll have to use the picking).
 	gint iMouseY2d;  // Y position of the pointer taking into account the 2D transformations on the desklet (for an opengl renderer, you'll have to use the picking).
 	GTimer *pUnmapTimer;

--- a/src/gldit/cairo-dock-desklet-manager.c
+++ b/src/gldit/cairo-dock-desklet-manager.c
@@ -57,7 +57,7 @@ CairoDeskletsParam myDeskletsParam;
 GldiManager myDeskletsMgr;
 GldiObjectManager myDeskletObjectMgr;
 
-// dependancies
+// dependencies
 extern gboolean g_bUseOpenGL;
 extern CairoDock *g_pMainDock;  // pour savoir s'il faut afficher les boutons rattach.
 
@@ -949,12 +949,12 @@ static void init (void)
 	gldi_object_register_notification (&myDesktopMgr,
 		NOTIFICATION_DESKTOP_GEOMETRY_CHANGED,
 		(GldiNotificationFunc) _on_desktop_geometry_changed,
-		GLDI_RUN_AFTER, NULL);  // replace all desklets that are positionned relatively to the right or bottom edge
+		GLDI_RUN_AFTER, NULL);  // replace all desklets that are positioned relatively to the right or bottom edge
 	gldi_object_register_notification (&myStyleMgr,
 		NOTIFICATION_STYLE_CHANGED,
 		(GldiNotificationFunc) on_style_changed,
 		GLDI_RUN_AFTER, NULL);
-	s_iStartupTime = time (NULL);  // on startup, the WM can take a long time before it has positionned all the desklets. To avoid irrelevant configure events, we set a delay.
+	s_iStartupTime = time (NULL);  // on startup, the WM can take a long time before it has positioned all the desklets. To avoid irrelevant configure events, we set a delay.
 }
 
   ///////////////

--- a/src/gldit/cairo-dock-desklet-manager.h
+++ b/src/gldit/cairo-dock-desklet-manager.h
@@ -35,7 +35,7 @@ G_BEGIN_DECLS
 
 /**
 *@file cairo-dock-desklet-manager.h This class manages the Desklets, that are Widgets placed directly on your desktop.
-* A Desklet is a container that holds 1 applet's icon plus an optionnal list of other icons and an optionnal GTK widget, has a decoration, suports several accessibility types (like Compiz Widget Layer), and has a renderer.
+* A Desklet is a container that holds 1 applet's icon plus an optional list of other icons and an optional GTK widget, has a decoration, supports several accessibility types (like Compiz Widget Layer), and has a renderer.
 * Desklets can be resized or moved directly with the mouse, and can be rotated in the 3 directions of space.
 */
 

--- a/src/gldit/cairo-dock-desktop-file-db.h
+++ b/src/gldit/cairo-dock-desktop-file-db.h
@@ -44,7 +44,7 @@ void gldi_desktop_file_db_stop (void);
 /**
  * Try to look up an installed app. This function can block the first time it's called if the DB has not been
  * fully populated yet.
- * @param class Dektop file ID, class or app-id of an app to look up (matching is based on the basename of
+ * @param class Desktop file ID, class or app-id of an app to look up (matching is based on the basename of
  * 	its .desktop file, and the content of the StartupWMClass and Exec keys in it).
  * @param bOnlyDesktopID if TRUE, only the .desktop file name is used for matching (can be useful if looking
  * 	for a known .desktop file).

--- a/src/gldit/cairo-dock-desktop-manager.c
+++ b/src/gldit/cairo-dock-desktop-manager.c
@@ -34,7 +34,7 @@
 GldiManager myDesktopMgr;
 GldiDesktopGeometry g_desktopGeometry;
 
-// dependancies
+// dependencies
 extern GldiContainer *g_pPrimaryContainer;
 
 // private

--- a/src/gldit/cairo-dock-desktop-manager.h
+++ b/src/gldit/cairo-dock-desktop-manager.h
@@ -76,7 +76,7 @@ Old behavior: separate iNbDesktops + iNbViewportX / iNbViewportY:
       viewports to _NET_DESKTOP_GEOMETRY / _NET_DESKTOP_VIEWPORT:
       https://specifications.freedesktop.org/wm-spec/latest/ar01s03.html
 
-Typcial behavior:
+Typical behavior:
   - Compiz (+ also Gnome-shell?): iNbDesktops == 1, "workspaces" correspond to viewports only
   - other WMs: iNbDesktops >= 1, iNbViewportX == iNbViewportY == 1
 
@@ -84,7 +84,7 @@ Questions / issues:
   - Unsure if for any WM / DE, we can have both iNbDesktops > 1 and multiple viewports. In theory, on Wayland
       this will be possible with the ext-workspace protocol if there are multiple workspace groups. On X11,
       this is explicitly supported by the standards, but likely not implemented by WMs.
-  - Are there X11 WMs that provide multipe desktops and arranges them in 2D? In theory, this is possible using
+  - Are there X11 WMs that provide multiple desktops and arranges them in 2D? In theory, this is possible using
       _NET_DESKTOP_LAYOUT, however Cairo-Dock currently does not handle this. Note: according to the
       specification, this is set by the "pager", which is possibly a separate entity from the WM:
       https://specifications.freedesktop.org/wm-spec/latest/ar01s03.html
@@ -117,7 +117,7 @@ Minimal changes for Wayland:
       -> "desktops" would be interpreted as independent viewports in this case
 
 Plan for a new API:
-  - two-level structure with "desktops" and "vieports"
+  - two-level structure with "desktops" and "viewports"
   - on X11: desktop <-> _NET_NUMBER_OF_DESKTOPS / _NET_CURRENT_DESKTOP / _NET_DESKTOP_LAYOUT
             workspace <-> _NET_DESKTOP_GEOMETRY / _NET_DESKTOP_VIEWPORT
   - on Wayland: desktop <-> workspace-group, viewport <-> workspace (on KWin, only one desktop)
@@ -125,7 +125,7 @@ Plan for a new API:
   - number of viewports per desktop can be different -> dynamic storage of a new _GldiViewportGeometry for
       each desktop
   - desktops are always "independent": a window can only span one (or all for sticky windows)
-  - vieports can be overlapping (a window can span multiple), flag / setting for this that is set by the backend
+  - viewports can be overlapping (a window can span multiple), flag / setting for this that is set by the backend
 
 Next steps:
   - change API for adding and removing "workspaces", these are handled by a backend-specific way (move some of the
@@ -179,7 +179,7 @@ struct _GldiDesktopBackground {
 /////////////////////
 
 /** Register a Desktop Manager backend. NULL functions do not overwrite existing ones.
-*@param pBackend a Desktop Manager backend; can be freeed after.
+*@param pBackend a Desktop Manager backend; can be freed after.
 */
 void gldi_desktop_manager_register_backend (GldiDesktopManagerBackend *pBackend, const gchar *name);
 
@@ -230,7 +230,7 @@ gboolean gldi_desktop_set_current (int iDesktopNumber, int iViewportNumberX, int
  * Typically this can mean adding one more workspace / desktop as the "last" one.
  * On X11, this will resize the desktop geometry, and could result in adding
  * multiple viewports.
- * Might not suceed, depending on the capabilities of the backend
+ * Might not succeed, depending on the capabilities of the backend
  * (NOTIFICATION_DESKTOP_GEOMETRY_CHANGED will be emitted if successful).
  */
 void gldi_desktop_add_workspace (void);
@@ -239,7 +239,7 @@ void gldi_desktop_add_workspace (void);
  * internal ordering of workspaces. The actual number of workspaces can
  * be > 1, depending on the backend (on X11, if viewports are arranged
  * in a square).
- * Might not suceed, depending on the capabilities of the backend
+ * Might not succeed, depending on the capabilities of the backend
  * (NOTIFICATION_DESKTOP_GEOMETRY_CHANGED will be emitted if successful).
  */
 void gldi_desktop_remove_last_workspace (void);

--- a/src/gldit/cairo-dock-dialog-factory.h
+++ b/src/gldit/cairo-dock-dialog-factory.h
@@ -26,7 +26,7 @@
 G_BEGIN_DECLS
 
 /** @file cairo-dock-dialog-factory.h This class defines the Dialog container, useful to bring interaction with the user.
-* A Dialog is a container that points to an icon. It contains the following optionnal components :
+* A Dialog is a container that points to an icon. It contains the following optional components :
 * - a message
 * - an image on its left
 * - a interaction widget below it
@@ -138,7 +138,7 @@ struct _CairoDialog {
 	gint iSidTimer;// le timer pour la destruction automatique du dialog.
 	gboolean bUseMarkup;// whether markup is used to draw the text (as defined in the attributes on init)
 	gboolean bNoInput;// whether the dialog is transparent to mouse input.
-	gboolean bAllowMinimize;  // TRUE to allow the dialog to be minimized once. The flag is reseted to FALSE after the desklet has minimized.
+	gboolean bAllowMinimize;  // TRUE to allow the dialog to be minimized once. The flag is reset to FALSE after the desklet has minimized.
 	GTimer *pUnmapTimer;  // timer to filter 2 consecutive unmap events
 	cairo_region_t* pShapeBitmap;
 	gboolean bPositionForced;
@@ -175,7 +175,7 @@ struct _CairoDialog {
 */
 CairoDialog *gldi_dialog_new (CairoDialogAttr *pAttribute);
 
-/** Pop up a dialog with a message, a widget, 2 buttons ok/cancel and an icon, all optionnal.
+/** Pop up a dialog with a message, a widget, 2 buttons ok/cancel and an icon, all optional.
 *@param cText the message to display.
 *@param pIcon the icon that will hold the dialog.
 *@param pContainer the container of the icon.
@@ -283,7 +283,7 @@ CairoDialog * gldi_dialog_show_general_message (const gchar *cMessage, double fT
 *@param pContainer the container of the icon.
 *@param cIconPath path to an icon to display in the margin.
 *@param pInteractiveWidget an interactive widget.
-*@return the number of the button that was clicked : 0 or -1 for OK, 1 or -2 for CANCEL, -3 if the dialog has been destroyed before. The dialog is destroyed after the user choosed, but the interactive widget is not destroyed, which allows to retrieve the changes made by the user. Destroy it with 'gtk_widget_destroy' when you're done with it.
+*@return the number of the button that was clicked : 0 or -1 for OK, 1 or -2 for CANCEL, -3 if the dialog has been destroyed before. The dialog is destroyed after the user chose, but the interactive widget is not destroyed, which allows to retrieve the changes made by the user. Destroy it with 'gtk_widget_destroy' when you're done with it.
 */
 int gldi_dialog_show_and_wait (const gchar *cText, Icon *pIcon, GldiContainer *pContainer, const gchar *cIconPath, GtkWidget *pInteractiveWidget);
 

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -46,7 +46,7 @@ CairoDialogsParam myDialogsParam;
 GldiManager myDialogsMgr;
 GldiObjectManager myDialogObjectMgr;
 
-// dependancies
+// dependencies
 extern CairoDock *g_pMainDock;
 extern gboolean g_bUseOpenGL;
 extern CairoDockHidingEffect *g_pHidingBackend;  // cairo_dock_is_hidden
@@ -1482,7 +1482,7 @@ static void init_object (GldiObject *obj, gpointer attr)
 		if (CAIRO_DOCK_IS_DOCK (pContainer))
 		{
 			CAIRO_DOCK (pContainer)->bHasModalWindow = TRUE;
-			gldi_dock_enter_synthetic (CAIRO_DOCK (pContainer));  // to prevent the dock from hiding. We want to see it while the dialog is visible (a leave event will be emited when it disappears).
+			gldi_dock_enter_synthetic (CAIRO_DOCK (pContainer));  // to prevent the dock from hiding. We want to see it while the dialog is visible (a leave event will be emitted when it disappears).
 		}
 	}
 	else if (CAIRO_DOCK_IS_DOCK (pContainer) && gldi_container_use_new_positioning_code ())

--- a/src/gldit/cairo-dock-dock-factory.h
+++ b/src/gldit/cairo-dock-dock-factory.h
@@ -74,7 +74,7 @@ struct _CairoDockRenderer {
 	CairoDockRenderFunc render;
 	/// optimized rendering function (cairo) that only redraw a part of the dock.
 	CairoDockRenderOptimizedFunc render_optimized;
-	/// rendering function (OpenGL, optionnal).
+	/// rendering function (OpenGL, optional).
 	CairoDockGLRenderFunc render_opengl;
 	/// function that computes the position of the dock when it's a sub-dock.
 	CairoDockSetSubDockPositionFunc set_subdock_position;
@@ -254,7 +254,7 @@ struct _CairoDock {
 	gpointer pRendererData;
 	/// Set to TRUE by the renderer if one can drop between 2 icons.
 	gboolean bCanDrop;
-	/// set by the view to say if the mouse is currently on icons, on the egde, or outside of icons.
+	/// set by the view to say if the mouse is currently on icons, on the edge, or outside of icons.
 	CairoDockMousePositionType iMousePositionType;
 	/// width of the dock at rest.
 	gint iMinDockWidth;

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -69,7 +69,7 @@ CairoDock *g_pMainDock = NULL;  // pointeur sur le dock principal.
 CairoDockHidingEffect *g_pHidingBackend = NULL;
 CairoDockHidingEffect *g_pKeepingBelowBackend = NULL;
 
-// dependancies
+// dependencies
 extern gchar *g_cConfFile;
 extern gchar *g_cCurrentThemePath;
 extern gboolean g_bUseOpenGL;

--- a/src/gldit/cairo-dock-dock-manager.h
+++ b/src/gldit/cairo-dock-dock-manager.h
@@ -117,7 +117,7 @@ typedef enum {
 
 /** Get a Dock from a given name.
 * @param cDockName the name of the dock.
-* @return the dock that has been registerd under this name, or NULL if none exists.
+* @return the dock that has been registered under this name, or NULL if none exists.
 */
 CairoDock *gldi_dock_get (const gchar *cDockName);
 

--- a/src/gldit/cairo-dock-dock-priv.h
+++ b/src/gldit/cairo-dock-dock-priv.h
@@ -69,7 +69,7 @@ typedef enum {
 
 void gldi_dock_init_internals (CairoDock *pDock);
 
-/** Create a new dock of type "sub-dock", and load a given list of icons inside. The list then belongs to the dock, so it must not be freeed after that. The buffers of each icon are loaded, so they just need to have an image filename and a name.
+/** Create a new dock of type "sub-dock", and load a given list of icons inside. The list then belongs to the dock, so it must not be freed after that. The buffers of each icon are loaded, so they just need to have an image filename and a name.
 * @param cDockName the name that identifies the dock.
 * @param cRendererName name of a renderer. If NULL, the default renderer will be applied.
 * @param pParentDock the parent dock.

--- a/src/gldit/cairo-dock-draw-opengl.c
+++ b/src/gldit/cairo-dock-draw-opengl.c
@@ -535,7 +535,7 @@ void cairo_dock_render_hidden_dock_opengl (CairoDock *pDock)
 	GldiColor bg_color;
 	const double r = 4; // corner radius of the background
 	const double gap = 2;  // gap to the screen
-	double dw = (myIconsParam.iIconGap > 2 ? 2 : 0);  // 1px margin around the icons for a better readability (only if icons won't be stuck togather then).
+	double dw = (myIconsParam.iIconGap > 2 ? 2 : 0);  // 1px margin around the icons for a better readability (only if icons won't be stuck together then).
 	double w, h;
 	_cairo_dock_set_blend_alpha ();
 	do

--- a/src/gldit/cairo-dock-draw-opengl.h
+++ b/src/gldit/cairo-dock-draw-opengl.h
@@ -71,7 +71,7 @@ GLuint cairo_dock_create_texture_from_surface_full (cairo_surface_t *pImageSurfa
 /** Load a cairo surface into an OpenGL texture. The surface can be destroyed after that if you don't need it.
  *  The texture will have the same (physical) size as the surface, but potentially rounded up to the nearest
  *  power of 2 if needed. This function is the same as cairo_dock_create_texture_from_surface_full () but does
- *  not returm the size of the new texture.
+ *  not return the size of the new texture.
 *@param pImageSurface the surface, created with one of the 'cairo_dock_create_surface_xxx' functions.
 *@return the newly allocated texture, to be destroyed with _cairo_dock_delete_texture.
 */

--- a/src/gldit/cairo-dock-draw.c
+++ b/src/gldit/cairo-dock-draw.c
@@ -904,7 +904,7 @@ void cairo_dock_render_hidden_dock (cairo_t *pCairoContext, CairoDock *pDock)
 	const double r = (myDocksParam.bUseDefaultColors ? myStyleParam.iCornerRadius/2 : 4);  // corner radius of the background
 	const double gap = 2;  // gap to the screen
 	double alpha;
-	double dw = (myIconsParam.iIconGap > 2 ? 2 : 0);  // 1px margin around the icons for a better readability (only if icons won't be stuck togather then).
+	double dw = (myIconsParam.iIconGap > 2 ? 2 : 0);  // 1px margin around the icons for a better readability (only if icons won't be stuck together then).
 	double w, h;
 	do
 	{

--- a/src/gldit/cairo-dock-file-manager.c
+++ b/src/gldit/cairo-dock-file-manager.c
@@ -45,7 +45,7 @@
 // public (data)
 CairoDockDesktopEnv g_iDesktopEnv = CAIRO_DOCK_UNKNOWN_ENV;
 
-// dependancies
+// dependencies
 
 // private
 static CairoDockDesktopEnvBackend s_EnvBackend = { NULL };
@@ -642,7 +642,7 @@ static gboolean _wait_pid (gpointer *pData)
 
 		pCallback (pUserData);
 
-		// free allocated ressources just used for this function
+		// free allocated resources just used for this function
 		g_free (cProcess);
 		g_free (pData);
 

--- a/src/gldit/cairo-dock-flying-container.c
+++ b/src/gldit/cairo-dock-flying-container.c
@@ -52,7 +52,7 @@
 GldiManager myFlyingsMgr;
 GldiObjectManager myFlyingObjectMgr;
 
-// dependancies
+// dependencies
 extern GldiContainer *g_pPrimaryContainer;
 extern gchar *g_cCurrentThemePath;
 extern gboolean g_bUseOpenGL;

--- a/src/gldit/cairo-dock-gui-factory.h
+++ b/src/gldit/cairo-dock-gui-factory.h
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
 * 
 * The first character of the comment defines the type of widget. Known types are listed in the CairoDockGUIWidgetType enum.
 * 
-* A key can be a behaviour key or an appearance key. Appearance keys are keys that defines the look of the appli, they belong to the theme. Behaviour keys are keys that define some configuration parameters, that depends on the user. To mark a key as an apppearance one, suffix the widget character with a '+'. Thus, keys not marked with a '+' won't be loaded when the user loads a theme, except if he forces it.
+* A key can be a behaviour key or an appearance key. Appearance keys are keys that defines the look of the appli, they belong to the theme. Behaviour keys are keys that define some configuration parameters, that depends on the user. To mark a key as an appearance one, suffix the widget character with a '+'. Thus, keys not marked with a '+' won't be loaded when the user loads a theme, except if he forces it.
 * 
 * After the widget character and its suffix, some widget accept a list of values. For instance, a spinbutton can have a min and a max limits, a list can have pre-defined elements, etc. Such values are set between '[' and ']' brackets, and separated by ';' inside.
 * 
@@ -63,7 +63,7 @@ typedef enum {
 	CAIRO_DOCK_WIDGET_SPIN_INTEGER='i',
 	/// integer in an horizontal scale.
 	CAIRO_DOCK_WIDGET_HSCALE_INTEGER='I',
-	/// pair of integers for dimansion WidthxHeight
+	/// pair of integers for dimension WidthxHeight
 	CAIRO_DOCK_WIDGET_SIZE_INTEGER='j',
 	/// double in a spin button.
 	CAIRO_DOCK_WIDGET_SPIN_DOUBLE='f',
@@ -232,7 +232,7 @@ The widgets represent a pair (group,key) as defined in the config file.
 @param pWidgetList list of widgets built from the config file
 @param cGroupName name of the group the widget belongs to
 @param cKeyName name of the key the widget represents
-@return the widget asociated with the (group,key) , or NULL if none is found
+@return the widget associated with the (group,key) , or NULL if none is found
 */
 CairoDockGroupKeyWidget *cairo_dock_gui_find_group_key_widget_in_list (GSList *pWidgetList, const gchar *cGroupName, const gchar *cKeyName);
 

--- a/src/gldit/cairo-dock-gui-manager.h
+++ b/src/gldit/cairo-dock-gui-manager.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
 * 
 * It also defines the interface that a GUI backend should implement.
 * 
-* Note: GUIs are built from a .conf file; .conf files are normal group/key files, but with some special indications in the comments. Each key will be represented by a pre-defined widget, that is defined by the first caracter of its comment. The comment also contains a description of the key, and an optionnal tooltip. See cairo-dock-gui-factory.h for the list of pre-defined widgets and a short explanation on how to use them inside a conf file. The file 'cairo-dock.conf' can be an useful example.
+* Note: GUIs are built from a .conf file; .conf files are normal group/key files, but with some special indications in the comments. Each key will be represented by a pre-defined widget, that is defined by the first character of its comment. The comment also contains a description of the key, and an optional tooltip. See cairo-dock-gui-factory.h for the list of pre-defined widgets and a short explanation on how to use them inside a conf file. The file 'cairo-dock.conf' can be an useful example.
 */
 
 /// Definition of the callback called when the user apply the config panel.

--- a/src/gldit/cairo-dock-icon-facility.h
+++ b/src/gldit/cairo-dock-icon-facility.h
@@ -321,12 +321,12 @@ void cairo_dock_end_draw_icon_cairo (Icon *pIcon);
 /** Initiate an OpenGL drawing session on an icon's texture.
 *@param pIcon the icon on which to draw.
 *@param iRenderingMode rendering mode. 0:normal, 1:don't clear the current texture, so that the drawing will be superimposed on it, 2:keep the current icon texture unchanged for all the drawing (the drawing is made on another texture).
-*@return TRUE if you can proceed to the drawing, FALSE if an error occured.
+*@return TRUE if you can proceed to the drawing, FALSE if an error occurred.
 */
 gboolean cairo_dock_begin_draw_icon (Icon *pIcon, gint iRenderingMode);
 /** Finish an OpenGL drawing session on an icon.
 *@param pIcon the icon on which to draw.
-*@return TRUE if you can proceed to the drawing, FALSE if an error occured.
+*@return TRUE if you can proceed to the drawing, FALSE if an error occurred.
 */
 void cairo_dock_end_draw_icon (Icon *pIcon);
 

--- a/src/gldit/cairo-dock-icon-factory.c
+++ b/src/gldit/cairo-dock-icon-factory.c
@@ -233,7 +233,7 @@ void cairo_dock_load_icon_quickinfo (Icon *icon)
 void cairo_dock_load_icon_buffers (Icon *pIcon, GldiContainer *pContainer)
 {
 	gboolean bLoadText = TRUE;
-	if (pIcon->iSidLoadImage != 0)  // if a load was sheduled, cancel it and do it now (we need to load the applets' buffer before initializing the module).
+	if (pIcon->iSidLoadImage != 0)  // if a load was scheduled, cancel it and do it now (we need to load the applets' buffer before initializing the module).
 	{
 		//g_print (" load %s immediately\n", pIcon->cName);
 		g_source_remove (pIcon->iSidLoadImage);

--- a/src/gldit/cairo-dock-icon-factory.h
+++ b/src/gldit/cairo-dock-icon-factory.h
@@ -64,7 +64,7 @@ typedef enum {
 
 /// Icon's interface
 struct _IconInterface {
-	/// function that loads the icon surface (and optionnally texture).
+	/// function that loads the icon surface (and optionally texture).
 	void (*load_image) (Icon *icon);
 	/// function called when the user drag something over the icon for more than 500ms.
 	void (*action_on_drag_hover) (Icon *icon);

--- a/src/gldit/cairo-dock-icon-manager.c
+++ b/src/gldit/cairo-dock-icon-manager.c
@@ -253,7 +253,7 @@ gchar *cairo_dock_search_icon_s_path (const gchar *cFileName, gint iDesiredIconS
 		int j = 0;
 		while (cSuffixTab[j] != NULL)
 		{
-			if (strcmp(str+1, cSuffixTab[j]) == 0)  // exemple : "firefox.svg", but not "firefox-3.0" or "org.gnome.Calculator"
+			if (strcmp(str+1, cSuffixTab[j]) == 0)  // example : "firefox.svg", but not "firefox-3.0" or "org.gnome.Calculator"
 			{
 				bHasSuffix = TRUE;
 				break;
@@ -546,7 +546,7 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoIconsParam *pIcons)
 	cd_debug ("label font: %s, %d\n", pLabels->iconTextDescription.cFont, pLabels->iconTextDescription.iSize);
 	
 	//\___________________ labels text color
-	pLabels->iconTextDescription.bOutlined = cairo_dock_get_boolean_key_value (pKeyFile, "Labels", "text oulined", &bFlushConfFileNeeded, TRUE, NULL, NULL);
+	pLabels->iconTextDescription.bOutlined = cairo_dock_get_boolean_key_value (pKeyFile, "Labels", "text outlined", &bFlushConfFileNeeded, TRUE, NULL, NULL);
 	
 	GldiColor couleur_backlabel = {{0., 0., 0., 0.85}};
 	GldiColor couleur_label = {{1., 1., 1., 1.}};

--- a/src/gldit/cairo-dock-icon-manager.h
+++ b/src/gldit/cairo-dock-icon-manager.h
@@ -29,7 +29,7 @@
 G_BEGIN_DECLS
 
 /**
-*@file cairo-dock-icon-manager.h This class manages the icons parameters and their associated ressources.
+*@file cairo-dock-icon-manager.h This class manages the icons parameters and their associated resources.
 *
 * Specialized Icons are handled by the corresponding manager.
 */
@@ -124,7 +124,7 @@ void cairo_dock_set_specified_desktop_for_icon (Icon *pIcon, int iSpecificDeskto
  */
 gint cairo_dock_search_icon_size (GtkIconSize iIconSize);
 
-/** Search the path of an icon into the defined icons themes. It also handles the '~' caracter in paths.
+/** Search the path of an icon into the defined icons themes. It also handles the '~' character in paths.
  * @param cFileName name of the icon file.
  * @param iDesiredIconSize desired icon size if we use icons from user icons theme.
  * @return the complete path of the icon, or NULL if not found.

--- a/src/gldit/cairo-dock-image-buffer.h
+++ b/src/gldit/cairo-dock-image-buffer.h
@@ -111,7 +111,7 @@ gboolean cairo_dock_image_buffer_next_frame_no_loop (CairoDockImageBuffer *pImag
 
 #define cairo_dock_image_buffer_rewind(pImage) gettimeofday (&pImage->time, NULL)
 
-/** Reset an ImageBuffer's ressources. It can be used to load another image then.
+/** Reset an ImageBuffer's resources. It can be used to load another image then.
 *@param pImage an ImageBuffer.
 */
 void cairo_dock_unload_image_buffer (CairoDockImageBuffer *pImage);

--- a/src/gldit/cairo-dock-indicator-manager.c
+++ b/src/gldit/cairo-dock-indicator-manager.c
@@ -49,7 +49,7 @@
 CairoIndicatorsParam myIndicatorsParam;
 GldiManager myIndicatorsMgr;
 
-// dependancies
+// dependencies
 extern CairoDock *g_pMainDock;
 
 // private

--- a/src/gldit/cairo-dock-keybinder.c
+++ b/src/gldit/cairo-dock-keybinder.c
@@ -49,7 +49,7 @@
 // public (manager, config, data)
 GldiObjectManager myShortkeyObjectMgr;
 
-// dependancies
+// dependencies
 
 // private
 static GSList *s_pKeyBindings = NULL;
@@ -157,7 +157,7 @@ gboolean gldi_shortkey_rebind (GldiShortkey *binding,
 	g_return_val_if_fail (binding != NULL, FALSE);
 	cd_debug ("%s (%s)", __func__, binding->keystring);
 	
-	// ensure it's a registerd binding
+	// ensure it's a registered binding
 	GSList *iter = g_slist_find (s_pKeyBindings, binding);
 	g_return_val_if_fail (iter != NULL, FALSE);
 	

--- a/src/gldit/cairo-dock-keyfile-utilities.c
+++ b/src/gldit/cairo-dock-keyfile-utilities.c
@@ -239,7 +239,7 @@ static void cairo_dock_merge_key_files (GKeyFile *pOriginalKeyFile, GKeyFile *pR
 			if (! g_key_file_has_key (pReplacementKeyFile, cGroupName, cKeyName, NULL))
 			{
 				cComment = g_key_file_get_comment (pOriginalKeyFile, cGroupName, cKeyName, NULL);
-				if (cComment != NULL && cComment[0] != '\0' && cComment[1] != '0')  // not hidden nor peristent
+				if (cComment != NULL && cComment[0] != '\0' && cComment[1] != '0')  // not hidden nor persistent
 				{
 					g_key_file_remove_comment (pOriginalKeyFile, cGroupName, cKeyName, NULL);
 					g_key_file_remove_key (pOriginalKeyFile, cGroupName, cKeyName, NULL);

--- a/src/gldit/cairo-dock-keyfile-utilities.h
+++ b/src/gldit/cairo-dock-keyfile-utilities.h
@@ -91,13 +91,13 @@ void cairo_dock_remove_group_key_from_conf_file (GKeyFile *pKeyFile, const gchar
 gboolean cairo_dock_rename_group_in_conf_file (GKeyFile *pKeyFile, const gchar *cGroupName, const gchar *cNewGroupName);
 
 /* Used g_key_file_get_locale_string only if the key name exists and is not empty
- * Can be anoying to use it with an empty string because gettext mays return a non empty string (e.g. on OpenSUSE we get the .po header)
+ * Can be annoying to use it with an empty string because gettext mays return a non empty string (e.g. on OpenSUSE we get the .po header)
  */
 gchar * cairo_dock_get_locale_string_from_conf_file (GKeyFile *pKeyFile, const gchar *cGroupName, const gchar *cKeyName, const gchar *cLocale);
 
 void cairo_dock_update_keyfile_va_args (const gchar *cConfFilePath, GType iFirstDataType, va_list args);
 
-/** Update a conf file with a list of values of the form : {type, name of the groupe, name of the key, value}. Must end with G_TYPE_INVALID.
+/** Update a conf file with a list of values of the form : {type, name of the group, name of the key, value}. Must end with G_TYPE_INVALID.
 *@param cConfFilePath path to the conf file.
 *@param iFirstDataType type of the first value.
 */

--- a/src/gldit/cairo-dock-launcher-manager.c
+++ b/src/gldit/cairo-dock-launcher-manager.c
@@ -46,7 +46,7 @@
 // public (manager, config, data)
 GldiObjectManager myLauncherObjectMgr;
 
-// dependancies
+// dependencies
 extern gchar *g_cCurrentLaunchersPath;
 extern CairoDockDesktopEnv g_iDesktopEnv;
 

--- a/src/gldit/cairo-dock-log.h
+++ b/src/gldit/cairo-dock-log.h
@@ -85,7 +85,7 @@ void cd_log_force_use_color (void);
 #define cd_message(...)                                                \
   cd_log_location(G_LOG_LEVEL_MESSAGE, __FILE__, __PRETTY_FUNCTION__, __LINE__,__VA_ARGS__)
 
-/* Write a debug message on the terminal. Debug message are only useful for developpers.
+/* Write a debug message on the terminal. Debug message are only useful for developers.
 *@param ... the message format and parameters, in a 'printf' style.
 */
 #define cd_debug(...)                                                  \

--- a/src/gldit/cairo-dock-manager.c
+++ b/src/gldit/cairo-dock-manager.c
@@ -29,7 +29,7 @@
 // public (manager, config, data)
 GldiObjectManager myManagerObjectMgr;
 
-// dependancies
+// dependencies
 extern GldiContainer *g_pPrimaryContainer;
 extern gchar *g_cConfFile;
 

--- a/src/gldit/cairo-dock-module-instance-manager.c
+++ b/src/gldit/cairo-dock-module-instance-manager.c
@@ -49,7 +49,7 @@
 // public (manager, config, data)
 GldiObjectManager myModuleInstanceObjectMgr;
 
-// dependancies
+// dependencies
 extern CairoDock *g_pMainDock;
 extern gchar *g_cCurrentThemePath;
 

--- a/src/gldit/cairo-dock-module-instance-manager.h
+++ b/src/gldit/cairo-dock-module-instance-manager.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
 * @file cairo-dock-module-instance-manager.h This class defines the instances of modules.
 *
 * A module-instance represents one instance of a module; it holds a set of data: the icon and its container, the config structure and its conf file, the data structure and a slot to plug datas into containers and icons.
-* All these parameters are optionnal; a module-instance that has an icon is also called an applet.
+* All these parameters are optional; a module-instance that has an icon is also called an applet.
 */
 
 // manager
@@ -47,7 +47,7 @@ typedef enum {
 	} GldiModuleInstancesNotifications;
 
 
-/// Definition of an instance of a module. A module can be instanciated several times.
+/// Definition of an instance of a module. A module can be instantiated several times.
 struct _GldiModuleInstance {
 	/// object
 	GldiObject object;

--- a/src/gldit/cairo-dock-module-manager.c
+++ b/src/gldit/cairo-dock-module-manager.c
@@ -49,7 +49,7 @@ gboolean g_bDisableAllModules = FALSE; // fail loading any module (for debugging
 gboolean g_bNoCheckModuleVersion = FALSE; // do not check module version compatibility (similar to bEasterEggs, but only applies here)
 gchar **g_cExcludedModules = NULL; // specific modules to exclude (try loading them but fail, for debugging)
 
-// dependancies
+// dependencies
 extern gchar *g_cConfFile;
 extern gchar *g_cCurrentThemePath;
 extern int g_iMajorVersion, g_iMinorVersion, g_iMicroVersion;
@@ -623,14 +623,14 @@ void gldi_module_add_instance (GldiModule *pModule)
 	// check that the module is already active
 	if (pModule->pInstancesList == NULL)
 	{
-		cd_warning ("This module has not been instanciated yet");
+		cd_warning ("This module has not been instantiated yet");
 		return ;
 	}
 	
-	// check that the module can be multi-instanciated
+	// check that the module can be multi-instantiated
 	if (! pModule->pVisitCard->bMultiInstance)
 	{
-		cd_warning ("This module can't be instanciated more than once");
+		cd_warning ("This module can't be instantiated more than once");
 		return ;
 	}
 	

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -32,8 +32,8 @@ G_BEGIN_DECLS
 *  - the visit card allows it to define itself (name, category, default icon, etc)
 *  - the interface defines the entry points for init, stop, reload, read config, and reset data.
 *
-* Modules can be instanciated several times; each time they are, an instance \ref _GldiModuleInstance is created.
-* Each instance holds a set of data: the icon and its container, the config structure and its conf file, the data structure and a slot to plug datas into containers and icons. All these data are optionnal; a module that has an icon is also called an applet.
+* Modules can be instantiated several times; each time they are, an instance \ref _GldiModuleInstance is created.
+* Each instance holds a set of data: the icon and its container, the config structure and its conf file, the data structure and a slot to plug datas into containers and icons. All these data are optional; a module that has an icon is also called an applet.
 */
 
 /**
@@ -242,7 +242,7 @@ struct _CairoDockMinimalAppletConfig {
 
 #define gldi_module_is_auto_loaded(pModule) ((pModule->pInterface->initModule == NULL || pModule->pInterface->stopModule == NULL || pModule->pVisitCard->cInternalModule != NULL) && pModule->pVisitCard->iContainerType == CAIRO_DOCK_MODULE_IS_PLUGIN)
 
-/** Create a new module. The module takes ownership of the 2 arguments, unless an error occured.
+/** Create a new module. The module takes ownership of the 2 arguments, unless an error occurred.
 * @param pVisitCard the visit card of the module
 * @param pInterface the interface of the module
 * @return the new module, or NULL if the visit card is invalid.
@@ -251,14 +251,14 @@ GldiModule *gldi_module_new (GldiVisitCard *pVisitCard, GldiModuleInterface *pIn
 
 /** Create a new module from a .so file.
 * @param cSoFilePath path to the .so file
-* @return the new module, or NULL if an error occured.
+* @return the new module, or NULL if an error occurred.
 */
 GldiModule *gldi_module_new_from_so_file (const gchar *cSoFilePath);
 
 /** Create new modules from all the .so files contained in the given folder.
 * @param cModuleDirPath path to the folder
 * @param erreur an error
-* @return the new module, or NULL if an error occured.
+* @return the new module, or NULL if an error occurred.
 */
 void gldi_modules_new_from_directory (const gchar *cModuleDirPath, GError **erreur);
 

--- a/src/gldit/cairo-dock-object.h
+++ b/src/gldit/cairo-dock-object.h
@@ -152,7 +152,7 @@ Note: it is safe to remove the callback when it is called, but not another one.
 *@param pObject the object (Icon, Container, Manager) for which the action has been registered.
 *@param iNotifType type of the notification.
 *@param pFunction callback.
-*@param pUserData data that was registerd with the callback.
+*@param pUserData data that was registered with the callback.
 */
 void gldi_object_remove_notification (gpointer pObject, GldiNotificationType iNotifType, GldiNotificationFunc pFunction, gpointer pUserData);
 

--- a/src/gldit/cairo-dock-opengl-path.h
+++ b/src/gldit/cairo-dock-opengl-path.h
@@ -47,7 +47,7 @@ struct _CairoDockGLPath {
  */
 CairoDockGLPath *cairo_dock_new_gl_path (int iNbVertices, double x0, double y0, int iWidth, int iHeight);
 
-/** Destroy a path and free its allocated ressources.
+/** Destroy a path and free its allocated resources.
  * @param pPath the path.
  */
 void cairo_dock_free_gl_path (CairoDockGLPath *pPath);

--- a/src/gldit/cairo-dock-opengl.h
+++ b/src/gldit/cairo-dock-opengl.h
@@ -32,7 +32,7 @@ G_BEGIN_DECLS
 *@file cairo-dock-opengl.h This class manages the OpenGL backend and context.
 */
 
-/// This strucure summarizes the available OpenGL configuration on the system.
+/// This structure summarizes the available OpenGL configuration on the system.
 struct _CairoDockGLConfig {
 	gboolean bIndirectRendering;
 	gboolean bAlphaAvailable;

--- a/src/gldit/cairo-dock-overlay.c
+++ b/src/gldit/cairo-dock-overlay.c
@@ -34,7 +34,7 @@
 // public (manager, config, data)
 GldiObjectManager myOverlayObjectMgr;
 
-// dependancies
+// dependencies
 extern gboolean g_bUseOpenGL;
 
 // private
@@ -59,7 +59,7 @@ static inline void cairo_dock_add_overlay_to_icon (Icon *pIcon, CairoOverlay *pO
 	// complete the overlay
 	pOverlay->iPosition = iPosition;
 	pOverlay->data = data;
-	pOverlay->pIcon = pIcon;  // overlays are stucked to their icon.
+	pOverlay->pIcon = pIcon;  // overlays are stuck to their icon.
 	
 	// remove any overlay that matches the couple (position, data).
 	if (data != NULL)

--- a/src/gldit/cairo-dock-packages.c
+++ b/src/gldit/cairo-dock-packages.c
@@ -41,7 +41,7 @@
 CairoConnectionParam myConnectionParam;
 GldiManager myConnectionMgr;
 
-// dependancies
+// dependencies
 
 // private
 #define CAIRO_DOCK_DEFAULT_PACKAGES_LIST_FILE "list.conf"
@@ -175,7 +175,7 @@ gboolean cairo_dock_download_file (const gchar *cURL, const gchar *cLocalPath)
 	
 	// check the result
 	gboolean bOk;
-	if (r != CURLE_OK)  // an error occured
+	if (r != CURLE_OK)  // an error occurred
 	{
 		cd_warning ("Couldn't download file '%s' (%s)", cURL, curl_easy_strerror (r));
 		g_remove (cLocalPath);

--- a/src/gldit/cairo-dock-packages.h
+++ b/src/gldit/cairo-dock-packages.h
@@ -109,27 +109,27 @@ typedef void (* CairoDockGetPackagesFunc ) (GHashTable *pPackagesTable, gpointer
 gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtractTo, const gchar *cRealArchiveName);
 
 /** Download a distant file into a given location.
-*@param cURL adress of the file.
+*@param cURL address of the file.
 *@param cLocalPath a local path where to store the file.
 *@return TRUE on success, else FALSE..
 */
 gboolean cairo_dock_download_file (const gchar *cURL, const gchar *cLocalPath);
 
 /** Download a distant file as a temporary file.
-*@param cURL adress of the file.
+*@param cURL address of the file.
 *@return the local path of the file on success, else NULL. Free the string after using it.
 */
 gchar *cairo_dock_download_file_in_tmp (const gchar *cURL);
 
 /** Download an archive and extract it into a given folder.
-*@param cURL adress of the file.
+*@param cURL address of the file.
 *@param cExtractTo folder where to extract the archive (the archive is deleted then).
 *@return the local path of the file on success, else NULL. Free the string after using it.
 */
 gchar *cairo_dock_download_archive (const gchar *cURL, const gchar *cExtractTo);
 
 /** Asynchronously download a distant file into a given location. This function is non-blocking, you'll get a CairoTask that you can discard at any time, and you'll get the path of the downloaded file as the first argument of the callback (the second being the data you passed to this function).
-*@param cURL adress of the file.
+*@param cURL address of the file.
 *@param cLocalPath a local path where to store the file, or NULL for a temporary file.
 *@param pCallback function called when the download is finished. It takes the path of the downloaded file (it belongs to the task so don't free it) and the data you've set here.
 *@param data data to be passed to the callback.
@@ -148,7 +148,7 @@ GldiTask *cairo_dock_download_file_async (const gchar *cURL, const gchar *cLocal
 gchar *cairo_dock_get_url_data_with_post (const gchar *cURL, gboolean bGetOutputHeaders, GError **erreur, const gchar *cFirstProperty, ...);
 
 /** Retrieve the data of a distant URL.
-*@param cURL distant adress to get data from.
+*@param cURL distant address to get data from.
 *@param erreur an error.
 *@return the data (NULL if failed). It's an array of chars, possibly containing nul chars. Free it after using.
 */
@@ -157,7 +157,7 @@ gchar *cairo_dock_get_url_data_with_post (const gchar *cURL, gboolean bGetOutput
 gchar *cairo_dock_get_url_data_with_headers (const gchar *cURL, gboolean bGetOutputHeaders, GError **erreur, const gchar *cFirstProperty, ...);
 
 /** Asynchronously retrieve the content of a distant URL. This function is non-blocking, you'll get a CairoTask that you can discard at any time, and you'll get the content of the downloaded file as the first argument of the callback (the second being the data you passed to this function).
-*@param cURL distant adress to get data from.
+*@param cURL distant address to get data from.
 *@param pCallback function called when the download is finished. It takes the content of the downloaded file (it belongs to the task so don't free it) and the data you've set here.
 *@param data data to be passed to the callback.
 *@return the Task that is doing the job. Keep it and use \ref cairo_dock_discard_task whenever you want to discard the download (for instance if the user cancels it), or \ref cairo_dock_free_task inside your callback.
@@ -179,18 +179,18 @@ GHashTable *cairo_dock_list_local_packages (const gchar *cPackagesDir, GHashTabl
 GHashTable *cairo_dock_list_net_packages (const gchar *cServerAdress, const gchar *cDirectory, const gchar *cListFileName, GHashTable *hProvidedTable, GError **erreur);
 
 /** Get a list of packages from differente sources.
-*@param cSharePackagesDir path of a local folder containg packages or NULL.
-*@param cUserPackagesDir path of a user folder containg packages or NULL.
-*@param cDistantPackagesDir path of a distant folder containg packages or NULL.
+*@param cSharePackagesDir path of a local folder containing packages or NULL.
+*@param cUserPackagesDir path of a user folder containing packages or NULL.
+*@param cDistantPackagesDir path of a distant folder containing packages or NULL.
 *@param pTable a table of packages previously retrieved, or NULL.
 *@return a hash table of (name, #_CairoDockPackage). Free it with g_hash_table_destroy when you're done with it.
 */
 GHashTable *cairo_dock_list_packages (const gchar *cSharePackagesDir, const gchar *cUserPackagesDir, const gchar *cDistantPackagesDir, GHashTable *pTable);
 
 /** Asynchronously get a list of packages from differente sources. This function is non-blocking, you'll get a CairoTask that you can discard at any time, and you'll get a hash-table of the packages as the first argument of the callback (the second being the data you passed to this function).
-*@param cSharePackagesDir path of a local folder containg packages or NULL.
-*@param cUserPackagesDir path of a user folder containg packages or NULL.
-*@param cDistantPackagesDir path of a distant folder containg packages or NULL.
+*@param cSharePackagesDir path of a local folder containing packages or NULL.
+*@param cUserPackagesDir path of a user folder containing packages or NULL.
+*@param cDistantPackagesDir path of a distant folder containing packages or NULL.
 *@param pCallback function called when the listing is finished. It takes the hash-table of the found packages (it belongs to the task so don't free it) and the data you've set here.
 *@param data data to be passed to the callback.
 *@param pTable a table of packages previously retrieved, or NULL.
@@ -203,7 +203,7 @@ GldiTask *cairo_dock_list_packages_async (const gchar *cSharePackagesDir, const 
 *@param cPackageName name of the package.
 *@param cSharePackagesDir path of a local folder containing packages or NULL.
 *@param cUserPackagesDir path of a user folder containing packages or NULL.
-*@param cDistantPackagesDir path of a distant folder containg packages or NULL.
+*@param cDistantPackagesDir path of a distant folder containing packages or NULL.
 *@param iGivenType type of package, or CAIRO_DOCK_ANY_PACKAGE if any type of package should be considered.
 *@return a newly allocated string containing the complete local path of the package. If the package is distant, it is downloaded and extracted into this folder.
 */

--- a/src/gldit/cairo-dock-particle-system.h
+++ b/src/gldit/cairo-dock-particle-system.h
@@ -98,7 +98,7 @@ void cairo_dock_render_particles_full (CairoParticleSystem *pParticleSystem, int
 */
 CairoParticleSystem *cairo_dock_create_particle_system (int iNbParticles, GLuint iTexture, double fWidth, double fHeight);
 
-/** Destroy a particle system, freeing all the ressources it was using.
+/** Destroy a particle system, freeing all the resources it was using.
 *@param pParticleSystem the particle system.
 */
 void cairo_dock_free_particle_system (CairoParticleSystem *pParticleSystem);

--- a/src/gldit/cairo-dock-separator-manager.c
+++ b/src/gldit/cairo-dock-separator-manager.c
@@ -35,7 +35,7 @@
 // public (manager, config, data)
 GldiObjectManager mySeparatorIconObjectMgr;
 
-// dependancies
+// dependencies
 extern gchar *g_cCurrentLaunchersPath;
 
 // private

--- a/src/gldit/cairo-dock-stack-icon-manager.c
+++ b/src/gldit/cairo-dock-stack-icon-manager.c
@@ -33,7 +33,7 @@
 // public (manager, config, data)
 GldiObjectManager myStackIconObjectMgr;
 
-// dependancies
+// dependencies
 extern gchar *g_cCurrentLaunchersPath;
 
 // private

--- a/src/gldit/cairo-dock-struct.h
+++ b/src/gldit/cairo-dock-struct.h
@@ -236,11 +236,11 @@
  * 
  * In the section CD_APPLET_INIT_BEGIN/CD_APPLET_INIT_END, write the code that will run on startup.
  * 
- * In the section CD_APPLET_STOP_BEGIN/CD_APPLET_STOP_END, write the code that will run when the applet is deactivated: remove any timer, destroy any allocated ressources, unregister notifications, etc.
+ * In the section CD_APPLET_STOP_BEGIN/CD_APPLET_STOP_END, write the code that will run when the applet is deactivated: remove any timer, destroy any allocated resources, unregister notifications, etc.
  * 
  * In the section CD_APPLET_RELOAD_BEGIN/CD_APPLET_RELOAD_END section, write the code that will run when the applet is reloaded; this can happen in 2 cases:
  *   - when the configuration is changed (\ref CD_APPLET_MY_CONFIG_CHANGED is TRUE, for instance when the user edits the applet)
- *   - when something else changed (\ref CD_APPLET_MY_CONFIG_CHANGED is FALSE, for instance when the icon theme is changed, or the icon size is changed); in this case, most of the time you have nothing to do, except if you loaded some ressources yourself.
+ *   - when something else changed (\ref CD_APPLET_MY_CONFIG_CHANGED is FALSE, for instance when the icon theme is changed, or the icon size is changed); in this case, most of the time you have nothing to do, except if you loaded some resources yourself.
  * 
  * Edit the file <i>src/applet-config.c</i>;
  * In the section CD_APPLET_GET_CONFIG_BEGIN/CD_APPLET_GET_CONFIG_END, get all your config parameters (don't forget to define them in applet-struct.h). Use the CD_CONFIG_GET_* macros (defined in cairo-dock-applet-facility.h) to do so conveniently.
@@ -277,7 +277,7 @@
  * - <b>myDock</b> : if your container is a dock, myDock = myContainer, otherwise it is NULL.
  * - <b>myDesklet</b> : if your container is a desklet, myDesklet = myContainer, otherwise it is NULL.
  * - <b>myConfig</b> : the structure holding all the parameters you get in your config file. You have to define it in <i>applet-struct.h</i>.
- * - <b>myData</b> : the structure holding all the ressources loaded at run-time. You have to define it in <i>applet-struct.h</i>.
+ * - <b>myData</b> : the structure holding all the resources loaded at run-time. You have to define it in <i>applet-struct.h</i>.
  * - <b>myDrawContext</b> : a cairo context, if you need to draw on the icon with the libcairo.
  * 
  * - To get values contained inside your <b>conf file</b>, you can use the following :\n
@@ -318,7 +318,7 @@
  * 
  * But you can also make your own animation, like <i>Clock</i> of <i>Cairo-Penguin</i>. You will have to integrate yourself into the rendering loop of your container. Don't panic, here again, Cairo-Dock helps you !
  * 
- * First you will register to the "update container" notification, with a simple call to \ref CD_APPLET_REGISTER_FOR_UPDATE_ICON_SLOW_EVENT or \ref CD_APPLET_REGISTER_FOR_UPDATE_ICON_EVENT, depending on the refresh frequency you need : ~10Hz or ~33Hz. A high frequency needs of course more CPU, and most of the time the slow frequancy is enough.
+ * First you will register to the "update container" notification, with a simple call to \ref CD_APPLET_REGISTER_FOR_UPDATE_ICON_SLOW_EVENT or \ref CD_APPLET_REGISTER_FOR_UPDATE_ICON_EVENT, depending on the refresh frequency you need : ~10Hz or ~33Hz. A high frequency needs of course more CPU, and most of the time the slow frequency is enough.
  * 
  * Then you will just put all your code in a \ref CD_APPLET_ON_UPDATE_ICON_BEGIN/\ref CD_APPLET_ON_UPDATE_ICON_END section. That's all ! In this section, do what you want, like redrawing your icon, possibly incrementing a counter to know until where you went, etc. See \ref opengl "the previous paragraph" to draw on your icon.
  * Inside the rendering loop, you can skip an iteration with \ref CD_APPLET_SKIP_UPDATE_ICON, and quit the loop with \ref CD_APPLET_STOP_UPDATE_ICON or \ref CD_APPLET_PAUSE_UPDATE_ICON (don't forget to quit the loop when you're done, otherwise your container may continue to redraw itself, which means a needless CPU load).
@@ -355,7 +355,7 @@
  * 
  * 
  * \n
- * \section advanced_sec Advanced functionnalities
+ * \section advanced_sec Advanced functionalities
  * 
  * \subsection advanced_config How can I make my own widgets in the config panel ?
  * 
@@ -391,7 +391,7 @@
  * 
  * \subsection multi How can I make my applet multi-instanciable ?
  *
- * Applets can be launched several times, an instance will be created each time. To ensure your applet can be instanciated several times, you just need to pass myApplet to any function that uses one of its fields (myData, myIcon, etc). Then, to indicate Cairo-Dock that your applet is multi-instanciable, you'll have to define the macro CD_APPLET_MULTI_INSTANCE in each file. A convenient way to do that is to define it in the CMakeLists.txt by adding the following line: \code add_definitions (-DCD_APPLET_MULTI_INSTANCE="1") \endcode.
+ * Applets can be launched several times, an instance will be created each time. To ensure your applet can be instantiated several times, you just need to pass myApplet to any function that uses one of its fields (myData, myIcon, etc). Then, to indicate Cairo-Dock that your applet is multi-instanciable, you'll have to define the macro CD_APPLET_MULTI_INSTANCE in each file. A convenient way to do that is to define it in the CMakeLists.txt by adding the following line: \code add_definitions (-DCD_APPLET_MULTI_INSTANCE="1") \endcode.
  * 
  * 
  * \subsection render_container How can I draw anywhere on the dock, not only on my icon ?

--- a/src/gldit/cairo-dock-style-facility.c
+++ b/src/gldit/cairo-dock-style-facility.c
@@ -125,7 +125,7 @@ gchar *_get_default_system_font (void)
 			cd_debug ("s_cFontName: %s", s_cFontName);
 			if (s_cFontName && *s_cFontName == '\'')  // the value may be between quotes... get rid of them!
 			{
-				s_cFontName ++;  // s_cFontName is never freeed
+				s_cFontName ++;  // s_cFontName is never freed
 				s_cFontName[strlen(s_cFontName) - 1] = '\0';
 			}
 		}

--- a/src/gldit/cairo-dock-style-manager.c
+++ b/src/gldit/cairo-dock-style-manager.c
@@ -35,7 +35,7 @@
 GldiStyleParam myStyleParam;
 GldiManager myStyleMgr;
 
-// dependancies
+// dependencies
 extern gchar *g_cCurrentThemePath;
 extern gboolean g_bUseOpenGL;
 

--- a/src/gldit/cairo-dock-task.c
+++ b/src/gldit/cairo-dock-task.c
@@ -54,7 +54,7 @@ static gboolean _launch_task_timer (GldiTask *pTask)
 }
 static gboolean _check_for_update_idle (GldiTask *pTask)
 {
-	// process the data (we don't need to wait that the thread is over, so do it now, it will let more time for the thread to finish, and therfore often save a 'usleep').
+	// process the data (we don't need to wait that the thread is over, so do it now, it will let more time for the thread to finish, and therefore often save a 'usleep').
 	if (pTask->bNeedsUpdate)  // data are ready to be processed -> perform the update
 	{
 		if (! pTask->bDiscard)  // of course if the task has been discarded before, don't do anything.
@@ -110,7 +110,7 @@ static gboolean _check_for_update_idle (GldiTask *pTask)
 	}
 	
 	// if the thread is not yet over, come back in 1ms.
-	g_usleep (1);  // we don't want to block the main loop until the thread is over; so just sleep 1ms to give it a chance to terminate. so it's a kind of 'sched_yield()' wihout blocking the main loop.
+	g_usleep (1);  // we don't want to block the main loop until the thread is over; so just sleep 1ms to give it a chance to terminate. so it's a kind of 'sched_yield()' without blocking the main loop.
 	return TRUE;
 }
 static gpointer _get_data_threaded (GldiTask *pTask)

--- a/src/gldit/cairo-dock-task.h
+++ b/src/gldit/cairo-dock-task.h
@@ -71,7 +71,7 @@ struct _GldiTask {
 	GTimer *pClock;
 	// time elapsed since last update.
 	double fElapsedTime;
-	// function called when the task is destroyed to free the shared memory (optionnal).
+	// function called when the task is destroyed to free the shared memory (optional).
 	GFreeFunc free_data;
 	// below are the parameters accessed inside the thread => only between mutex lock/unlock
 	/// structure passed as parameter of the 'get_data' and 'update' functions. Must not be accessed outside of these 2 functions !
@@ -102,9 +102,9 @@ void gldi_task_launch_delayed (GldiTask *pTask, guint delay);
 
 /** Create a periodic Task.
 *@param iPeriod time between 2 iterations, possibly nul for a Task to be executed once only.
-*@param get_data asynchonous function, which carries out the heavy job parallel to the dock; stores the results in the shared memory.
-*@param update synchonous function, which carries out the update of the dock from the result of the previous function. Returns TRUE to continue, FALSE to stop.
-*@param free_data function called when the Task is destroyed, to free the shared memory (optionnal).
+*@param get_data asynchronous function, which carries out the heavy job parallel to the dock; stores the results in the shared memory.
+*@param update synchronous function, which carries out the update of the dock from the result of the previous function. Returns TRUE to continue, FALSE to stop.
+*@param free_data function called when the Task is destroyed, to free the shared memory (optional).
 *@param pSharedMemory structure passed as a parameter of the get_data and update functions. Must not be accessed outside of these functions !
 *@return the newly allocated Task, ready to be launched with \ref gldi_task_launch. Free it with \ref gldi_task_free or \ref gldi_task_discard.
 */
@@ -112,8 +112,8 @@ GldiTask *gldi_task_new_full (int iPeriod, GldiGetDataAsyncFunc get_data, GldiUp
 
 /** Create a periodic Task.
 *@param iPeriod time between 2 iterations, possibly nul for a Task to be executed once only.
-*@param get_data asynchonous function, which carries out the heavy job parallel to the dock; stores the results in the shared memory.
-*@param update synchonous function, which carries out the update of the dock from the result of the previous function. Returns TRUE to continue, FALSE to stop.
+*@param get_data asynchronous function, which carries out the heavy job parallel to the dock; stores the results in the shared memory.
+*@param update synchronous function, which carries out the update of the dock from the result of the previous function. Returns TRUE to continue, FALSE to stop.
 *@param pSharedMemory structure passed as a parameter of the get_data and update functions. Must not be accessed outside of these  functions !
 *@return the newly allocated Task, ready to be launched with \ref gldi_task_launch. Free it with \ref gldi_task_free or \ref gldi_task_discard.
 */
@@ -129,7 +129,7 @@ void gldi_task_stop (GldiTask *pTask);
 */
 void gldi_task_discard (GldiTask *pTask);
 
-/** Stop and destroy a periodic Task, freeing all the allocated ressources. Unlike \ref gldi_task_discard, the task is stopped before being freeed, so this is a blocking call. If you want to destroy the task inside the update callback, don't use this function; use \ref gldi_task_discard instead.
+/** Stop and destroy a periodic Task, freeing all the allocated resources. Unlike \ref gldi_task_discard, the task is stopped before being freed, so this is a blocking call. If you want to destroy the task inside the update callback, don't use this function; use \ref gldi_task_discard instead.
 *@param pTask the periodic Task.
 */
 void gldi_task_free (GldiTask *pTask);

--- a/src/gldit/cairo-dock-themes-manager.c
+++ b/src/gldit/cairo-dock-themes-manager.c
@@ -68,7 +68,7 @@ static gchar *s_cDistantThemeDirName = NULL;
 #define CAIRO_DOCK_LOCAL_ICONS_DIR "icons"
 #define CAIRO_DOCK_LOCAL_IMAGES_DIR "images"
 
-// dependancies
+// dependencies
 extern CairoDock *g_pMainDock;
 
 

--- a/src/gldit/cairo-dock-themes-manager.h
+++ b/src/gldit/cairo-dock-themes-manager.h
@@ -35,7 +35,7 @@ void cairo_dock_delete_conf_file (const gchar *cConfFilePath);
 
 gboolean cairo_dock_add_conf_file (const gchar *cOriginalConfFilePath, const gchar *cConfFilePath);
 
-/** Update a conf file with a list of values of the form : {type, name of the groupe, name of the key, value}. Must end with G_TYPE_INVALID.
+/** Update a conf file with a list of values of the form : {type, name of the group, name of the key, value}. Must end with G_TYPE_INVALID.
 *@param cConfFilePath path to the conf file.
 *@param iFirstDataType type of the first value.
 */
@@ -60,27 +60,27 @@ gchar *cairo_dock_write_keys_to_new_conf_file (GKeyFile *pKeyFile, const gchar *
  * @param cNewThemeName name to export the theme to.
  * @param bSaveBehavior whether to save the behavior parameters too.
  * @param bSaveLaunchers whether to save the launchers too.
- * @return TRUE if the theme could be exported succefuly.
+ * @return TRUE if the theme could be exported successfully.
  */
 gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean bSaveBehavior, gboolean bSaveLaunchers);
 
 /** Create a package of the current theme. Packages can be distributed easily, and imported into the dock by a mere drag and drop into the Theme Manager. The package is placed in the cDirPath directory (or $HOME if cDirPath is wrong).
  * @param cThemeName name of the package.
  * @param cDirPath path to the directory
- * @return TRUE if the theme could be packaged succefuly.
+ * @return TRUE if the theme could be packaged successfully.
  */
 gboolean cairo_dock_package_current_theme (const gchar *cThemeName, const gchar *cDirPath);
 
 
 /** Extract a package into the themes folder. Does not load it.
  * @param cPackagePath path of a package. If the package is distant, it is first downoladed.
- * @return the path of the theme folder, or NULL if anerror occured.
+ * @return the path of the theme folder, or NULL if anerror occurred.
  */
 gchar * cairo_dock_depackage_theme (const gchar *cPackagePath);
 
 /** Remove some exported themes from the hard-disk.
  * @param cThemesList a list of theme names, NULL-terminated.
- * @return TRUE if the themes has been succefuly deleted.
+ * @return TRUE if the themes has been successfully deleted.
  */
 gboolean cairo_dock_delete_themes (gchar **cThemesList);
 
@@ -88,7 +88,7 @@ gboolean cairo_dock_delete_themes (gchar **cThemesList);
  * @param cThemeName name of the theme to import.
  * @param bLoadBehavior whether to import the behavior parameters too.
  * @param bLoadLaunchers whether to import the launchers too.
- * @return TRUE if the theme could be imported succefuly.
+ * @return TRUE if the theme could be imported successfully.
  */
 gboolean cairo_dock_import_theme (const gchar *cThemeName, gboolean bLoadBehavior, gboolean bLoadLaunchers);
 
@@ -111,7 +111,7 @@ GldiTask *cairo_dock_import_theme_async (const gchar *cThemeName, gboolean bLoad
 *@param cCurrentThemeDirPath path to the current theme
 *@param cLocalThemeDirPath path to the installed themes (default themes)
 *@param cDistantThemeDirName folder of the themes on the server
-*@param cThemeServerAdress adress of the themes server
+*@param cThemeServerAdress address of the themes server
 */
 void cairo_dock_set_paths (gchar *cRootDataDirPath, gchar *cExtraDirPath, gchar *cThemesDirPath, gchar *cCurrentThemeDirPath, gchar *cLocalThemeDirPath, gchar *cDistantThemeDirName, gchar *cThemeServerAdress);
 

--- a/src/gldit/cairo-dock-user-icon-manager.c
+++ b/src/gldit/cairo-dock-user-icon-manager.c
@@ -34,7 +34,7 @@
 // public (manager, config, data)
 GldiObjectManager myUserIconObjectMgr;
 
-// dependancies
+// dependencies
 extern gchar *g_cCurrentLaunchersPath;
 
 // private

--- a/src/gldit/cairo-dock-utils.h
+++ b/src/gldit/cairo-dock-utils.h
@@ -49,7 +49,7 @@ void cairo_dock_remove_html_spaces (gchar *cString);
 */
 void cairo_dock_get_version_from_string (const gchar *cVersionString, int *iMajorVersion, int *iMinorVersion, int *iMicroVersion);
 
-/** Say if a string is an adress (file://xxx, http://xxx, ftp://xxx, etc).
+/** Say if a string is an address (file://xxx, http://xxx, ftp://xxx, etc).
 * @param cString a string.
 * @return TRUE if it's an address.
 */
@@ -108,7 +108,7 @@ gboolean cairo_dock_launch_command_single_gui (const gchar *cExec);
  */
 const gchar * cairo_dock_get_default_terminal (void);
 
-/* Legacy definiton used in many places */
+/* Legacy definition used in many places */
 #define cairo_dock_strings_differ g_strcmp0
 
 

--- a/src/gldit/cairo-dock-windows-manager-priv.h
+++ b/src/gldit/cairo-dock-windows-manager-priv.h
@@ -94,7 +94,7 @@ void gldi_window_set_sticky (GldiWindowActor *actor, gboolean bSticky);
 
 GldiWindowActor *gldi_window_pick (GtkWindow *pParentWindow);
 
-/** Get all currently managed windows as mebers of a GPtrArray.
+/** Get all currently managed windows as members of a GPtrArray.
  *@return a newly allocated GPtrArray with all windows (the order is unspecified); the caller should
 	free this with g_ptr_array_free()
  */

--- a/src/gldit/cairo-dock-windows-manager.c
+++ b/src/gldit/cairo-dock-windows-manager.c
@@ -26,7 +26,7 @@
 // public (manager, config, data)
 GldiObjectManager myWindowObjectMgr;
 
-// dependancies
+// dependencies
 
 // private
 GList *s_pWindowsList = NULL;  // list of all window actors
@@ -424,7 +424,7 @@ gchar* gldi_window_parse_class(const gchar* res_class, const gchar* res_name) {
 	if (res_class)
 	{
 		cd_debug ("  res_name : %s(%x); res_class : %s(%x)", res_name, res_name, res_class, res_class);
-		if (strcmp (res_class, "Wine") == 0 && res_name && (g_str_has_suffix (res_name, ".exe") || g_str_has_suffix (res_name, ".EXE")))  // wine application: use the name instead, because we don't want to group all wine apps togather
+		if (strcmp (res_class, "Wine") == 0 && res_name && (g_str_has_suffix (res_name, ".exe") || g_str_has_suffix (res_name, ".EXE")))  // wine application: use the name instead, because we don't want to group all wine apps together
 		{
 			cd_debug ("  wine application detected, changing the class '%s' to '%s'", res_class, res_name);
 			cClass = g_ascii_strdown (res_name, -1);
@@ -476,7 +476,7 @@ gchar* gldi_window_parse_class(const gchar* res_class, const gchar* res_name) {
 		// remove some suffices that can be problematic: .exe, .py (note: cClass is already lowercase here)
 		if (g_str_has_suffix (cClass, ".exe")) cClass[strlen (cClass) - 4] = 0;
 		else if (g_str_has_suffix (cClass, ".py")) cClass[strlen (cClass) - 3] = 0;
-		cairo_dock_remove_version_from_string (cClass);  // we remore number of version (e.g. Openoffice.org-3.1)
+		cairo_dock_remove_version_from_string (cClass);  // we remove number of version (e.g. Openoffice.org-3.1)
 		cd_debug ("got an application with class '%s'", cClass);
 	}
 	return cClass;

--- a/src/gldit/cairo-dock-windows-manager.h
+++ b/src/gldit/cairo-dock-windows-manager.h
@@ -140,7 +140,7 @@ gboolean gldi_window_manager_have_coordinates (void);
 gboolean gldi_window_manager_can_track_workspaces (void);
 
 /** Check how window position coordinates should be interpreted. Result is only
- *  valud if gldi_window_manager_have_coordinates () == TRUE as well.
+ *  valid if gldi_window_manager_have_coordinates () == TRUE as well.
  *@return whether window coordinates should be interpreted relative to the
  * currently active workspace / viewport; if false, coordinates are relative
  * to the workspace / viewport that the window is currently on

--- a/src/implementations/cairo-dock-X-manager.c
+++ b/src/implementations/cairo-dock-X-manager.c
@@ -605,7 +605,7 @@ static gboolean _cairo_dock_unstack_Xevents (G_GNUC_UNUSED gpointer data)
 							xactor->bIgnored = bSkipTaskbar;
 							gldi_object_notify (&myWindowObjectMgr, NOTIFICATION_WINDOW_DESTROYED, actor);
 						}
-						continue;  // actor is either freeed or ignored
+						continue;  // actor is either freed or ignored
 					}
 					
 					if (xactor->bIgnored)  // skip taskbar

--- a/src/implementations/cairo-dock-X-utilities.c
+++ b/src/implementations/cairo-dock-X-utilities.c
@@ -1595,7 +1595,7 @@ gboolean cairo_dock_get_xwindow_type (Window Xid, Window *pTransientFor)
 				bKeep = TRUE;
 				break;
 			}
-			if (pTypeBuffer[i] == s_aNetWmWindowTypeDialog)  // dialog -> skip modal dialog, because we can't act on it independantly from the parent window (it's most probably a dialog box like an open/save dialog)
+			if (pTypeBuffer[i] == s_aNetWmWindowTypeDialog)  // dialog -> skip modal dialog, because we can't act on it independently from the parent window (it's most probably a dialog box like an open/save dialog)
 			{
 				XGetTransientForHint (s_XDisplay, Xid, pTransientFor);  // maybe we should also get the _NET_WM_STATE_MODAL property, although if a dialog is set modal but not transient, that would probably be an error from the application.
 				if (*pTransientFor == None)

--- a/src/implementations/cairo-dock-egl.c
+++ b/src/implementations/cairo-dock-egl.c
@@ -237,7 +237,7 @@ static gboolean _initialize_opengl_backend (gboolean bForceOpenGL)
 	g_openglConfig.bAlphaAvailable = bAlphaAvailable;
 	s_eglConfig = config;
 	
-	// create a rendering context (All other context will share ressources with it, and it will be the default context in case no other context exist)
+	// create a rendering context (All other context will share resources with it, and it will be the default context in case no other context exist)
 	if (!eglBindAPI (EGL_OPENGL_API))  // specify the type of client API context before we create one.
 	{
 		cd_warning ("Could not bind an EGL API, OpenGL will not be available");

--- a/src/implementations/cairo-dock-gauge.c
+++ b/src/implementations/cairo-dock-gauge.c
@@ -17,7 +17,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** See the "data/gauges" folder for some exemples */
+/** See the "data/gauges" folder for some examples */
 
 #include <string.h>
 #include <math.h>

--- a/src/implementations/cairo-dock-glx.c
+++ b/src/implementations/cairo-dock-glx.c
@@ -189,7 +189,7 @@ static gboolean _initialize_opengl_backend (gboolean bForceOpenGL)
 		return FALSE;
 	}
 	
-	//\_________________ create a context for this visual. All other context will share ressources with it, and it will be the default context in case no other context exist.
+	//\_________________ create a context for this visual. All other context will share resources with it, and it will be the default context in case no other context exist.
 	Display *dpy = s_XDisplay;
 	s_XContext = glXCreateContext (dpy, pVisInfo, NULL, TRUE);
 	g_return_val_if_fail (s_XContext != 0, FALSE);

--- a/src/implementations/cairo-dock-progressbar.c
+++ b/src/implementations/cairo-dock-progressbar.c
@@ -17,7 +17,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** See the "data/gauges" folder for some exemples */
+/** See the "data/gauges" folder for some examples */
 
 #include <math.h>
 
@@ -248,7 +248,7 @@ static void render_opengl (ProgressBar *pProgressBar)
 	int iWidth = pRenderer->iWidth;
 	
 	double x, y, v, w, r = pProgressBar->iBarThickness/2.;
-	double dx = .5;  // required to not have sharp edges on the left rounded corners... although maybe it should be adressed by the Overlay...
+	double dx = .5;  // required to not have sharp edges on the left rounded corners... although maybe it should be addressed by the Overlay...
 	int i;
 	for (i = 0; i < iNbValues; i ++)
 	{

--- a/src/implementations/cairo-dock-wayfire-integration.c
+++ b/src/implementations/cairo-dock-wayfire-integration.c
@@ -79,7 +79,7 @@ static int _write_data(const char* buf, size_t n) {
  * is no open socket. The caller should free() the returned string when done.
  * The length of the message is stored in msg_len (if not NULL).
  * Note: this will block until there is a message to read.
- * TOOD: do this async by adding it to the main loop?
+ * TODO: do this async by adding it to the main loop?
  */
 static char* _read_msg(uint32_t* out_len)
 {
@@ -175,7 +175,7 @@ static gboolean _present_desktops() {
 	return _call_ipc_method_no_data ("expo/toggle");
 }
 
-/* Toggle show destop functionality (i.e. minimize / unminimize all views).
+/* Toggle show desktop functionality (i.e. minimize / unminimize all views).
  * Note: bShow argument is ignored, we don't know if the desktop is shown / hidden */
 static gboolean _show_hide_desktop(G_GNUC_UNUSED gboolean bShow) {
 	return _call_ipc_method_no_data ("wm-actions/toggle_showdesktop");

--- a/src/implementations/cairo-dock-wayland-hotspots.c
+++ b/src/implementations/cairo-dock-wayland-hotspots.c
@@ -50,7 +50,7 @@ typedef struct _hotspot_hit {
 
 typedef struct _output_hotspots_base {
 	GdkMonitor *monitor;
-	guint hotspot_width[4]; // area of hotspots needed on each egde (0: none)
+	guint hotspot_width[4]; // area of hotspots needed on each edge (0: none)
 	guint hotspot_height[4]; // order corresponds to values in the CairoDockPositionType enum
 	hotspot_hit hit[4]; // convenience structure used as parameter to the hotspot hit callback function
 } output_hotspots_base;

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -347,11 +347,11 @@ void gldi_wayland_grab_keyboard (GldiContainer *pContainer)
 	/* Note: the above will trigger a commit, but not immediately, while we should
 	 * not commit ourselves as the associated wl_surface might be in an inconsistent state.
 	 * So we set up a callback to reset to GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND,
-	 * hopefully after this change has been commited. For the complexities involved, see e.g.
+	 * hopefully after this change has been comitted. For the complexities involved, see e.g.
 	 * https://github.com/wmww/gtk-layer-shell/issues/51
 	 * https://github.com/wmww/gtk-layer-shell/issues/143
 	 * (this case is less severe as likely no "breaking" change is happening, but we still
-	 * should not commit behing the back of GTK) */
+	 * should not commit behind the back of GTK) */
 	_set_kb_mode_callback (window);
 #endif
 }

--- a/src/implementations/proto/cosmic-overlap-notify-unstable-v1.xml
+++ b/src/implementations/proto/cosmic-overlap-notify-unstable-v1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="cosmic_overlap_notify_unstable_v1">
   <copyright>
-    Copytight © 2024 Victoria Brekenfeld
+    Copyright © 2024 Victoria Brekenfeld
 
     Permission to use, copy, modify, distribute, and sell this
     software and its documentation for any purpose is hereby granted


### PR DESCRIPTION
Fixes user-facing and non-user-facing typos throughout the source.   
Found via:  codespell -S "*.po,*.pot" -L defaut,fonction,groupe,pevent