### PR TITLE
desktop-manager: update our systemd session targets

### DIFF
--- a/data/desktop-manager/gnome-session-3.36/gnome-session-x11@cairo-dock-compiz.target
+++ b/data/desktop-manager/gnome-session-3.36/gnome-session-x11@cairo-dock-compiz.target
@@ -20,4 +20,34 @@ After=gnome-flashback.target
 BindsTo=gnome-session.target
 After=gnome-session.target
 
+# Dependencies
 Wants=ayatana-indicators.target
+
+Wants=org.gnome.SettingsDaemon.A11ySettings.target
+Wants=org.gnome.SettingsDaemon.Color.target
+Wants=org.gnome.SettingsDaemon.Datetime.target
+Wants=org.gnome.SettingsDaemon.Housekeeping.target
+Wants=org.gnome.SettingsDaemon.Keyboard.target
+Wants=org.gnome.SettingsDaemon.MediaKeys.target
+Wants=org.gnome.SettingsDaemon.Power.target
+Wants=org.gnome.SettingsDaemon.PrintNotifications.target
+Wants=org.gnome.SettingsDaemon.Rfkill.target
+Wants=org.gnome.SettingsDaemon.ScreensaverProxy.target
+Wants=org.gnome.SettingsDaemon.Sharing.target
+Wants=org.gnome.SettingsDaemon.Smartcard.target
+Wants=org.gnome.SettingsDaemon.Sound.target
+Wants=org.gnome.SettingsDaemon.UsbProtection.target
+Wants=org.gnome.SettingsDaemon.Wwan.target
+Wants=org.gnome.SettingsDaemon.XSettings.target
+
+Wants=gcr-ssh-agent.socket
+Wants=gnome-disk-utility-notify.service
+
+Wants=gnome-flashback-clipboard.service
+Wants=gnome-flashback-idle-monitor.service
+Wants=gnome-flashback-media-keys.service
+Wants=gnome-flashback-polkit.service
+
+Requires=gnome-session-x11-services-ready.target
+Requires=gnome-flashback.target
+

--- a/data/desktop-manager/gnome-session-3.36/gnome-session-x11@cairo-dock-metacity.target
+++ b/data/desktop-manager/gnome-session-3.36/gnome-session-x11@cairo-dock-metacity.target
@@ -20,4 +20,34 @@ After=gnome-flashback.target
 BindsTo=gnome-session.target
 After=gnome-session.target
 
+# Dependencies
 Wants=ayatana-indicators.target
+
+Wants=org.gnome.SettingsDaemon.A11ySettings.target
+Wants=org.gnome.SettingsDaemon.Color.target
+Wants=org.gnome.SettingsDaemon.Datetime.target
+Wants=org.gnome.SettingsDaemon.Housekeeping.target
+Wants=org.gnome.SettingsDaemon.Keyboard.target
+Wants=org.gnome.SettingsDaemon.MediaKeys.target
+Wants=org.gnome.SettingsDaemon.Power.target
+Wants=org.gnome.SettingsDaemon.PrintNotifications.target
+Wants=org.gnome.SettingsDaemon.Rfkill.target
+Wants=org.gnome.SettingsDaemon.ScreensaverProxy.target
+Wants=org.gnome.SettingsDaemon.Sharing.target
+Wants=org.gnome.SettingsDaemon.Smartcard.target
+Wants=org.gnome.SettingsDaemon.Sound.target
+Wants=org.gnome.SettingsDaemon.UsbProtection.target
+Wants=org.gnome.SettingsDaemon.Wwan.target
+Wants=org.gnome.SettingsDaemon.XSettings.target
+
+Wants=gcr-ssh-agent.socket
+Wants=gnome-disk-utility-notify.service
+
+Wants=gnome-flashback-clipboard.service
+Wants=gnome-flashback-idle-monitor.service
+Wants=gnome-flashback-media-keys.service
+Wants=gnome-flashback-polkit.service
+
+Requires=gnome-session-x11-services-ready.target
+Requires=gnome-flashback.target
+


### PR DESCRIPTION
For gnome-settings-daemon version 40 and above, components will not be autostarted by gnome-session (due to the X-GNOME-HiddenUnderSystemd key in their .desktop file), but need to be started by systemd. We can achieve this by adding them to our systemd targets.