### PR TITLE
default-theme: add firefox-esr.desktop

### DIFF
--- a/data/themes/default-theme-panel/launchers/01firefox.desktop
+++ b/data/themes/default-theme-panel/launchers/01firefox.desktop
@@ -47,4 +47,4 @@ Order=3
 
 Icon Type=0
 Type=Application
-Origin=firefox.desktop;iceweasel.desktop;chromium-browser.desktop;rekonq.desktop;konqueror.desktop;org.gnome.Epiphany.desktop;konqbrowser.desktop;opera.desktop
+Origin=firefox.desktop;firefox-esr.desktop;iceweasel.desktop;chromium-browser.desktop;rekonq.desktop;konqueror.desktop;org.gnome.Epiphany.desktop;konqbrowser.desktop;opera.desktop

--- a/data/themes/default-theme/launchers/01firefox.desktop
+++ b/data/themes/default-theme/launchers/01firefox.desktop
@@ -47,4 +47,4 @@ Order=7
 
 Icon Type=0
 Type=Application
-Origin=firefox.desktop;iceweasel.desktop;chromium-browser.desktop;rekonq.desktop;konqueror.desktop;org.gnome.Epiphany.desktop;konqbrowser.desktop;opera.desktop
+Origin=firefox.desktop;firefox-esr.desktop;iceweasel.desktop;chromium-browser.desktop;rekonq.desktop;konqueror.desktop;org.gnome.Epiphany.desktop;konqbrowser.desktop;opera.desktop


### PR DESCRIPTION
This is to better support new installations on Debian.