### PR TITLE
build: link libgldi with libjson-c directly

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,8 +50,7 @@ target_link_libraries (${PROJECT_NAME}
 	${PACKAGE_LIBRARIES}
 	${GTK_LIBRARIES}
 	gldi
-	${LIBINTL_LIBRARIES}
-	${JSON_LIBRARIES})
+	${LIBINTL_LIBRARIES})
 
 # install the program once it is built.
 install(

--- a/src/gldit/CMakeLists.txt
+++ b/src/gldit/CMakeLists.txt
@@ -120,7 +120,8 @@ target_link_libraries("gldi"
 	${LIBCRYPT_LIBS}
 	implementations
 	${GTKLAYERSHELL_LIBRARIES}
-	${LIBDL_LIBRARIES})
+	${LIBDL_LIBRARIES}
+	${JSON_LIBRARIES})
 
 
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/gldi.pc.in ${CMAKE_CURRENT_BINARY_DIR}/gldi.pc)


### PR DESCRIPTION
Before, libjson-c was only linked with the cairo-dock executable, resulting in warnings from dpkg-shlibdeps when building packages.