### PR TITLE
systemd-integration: fix crash due to invalid GVariant type

### DIFF
--- a/src/implementations/cairo-dock-systemd-integration.c
+++ b/src/implementations/cairo-dock-systemd-integration.c
@@ -125,7 +125,7 @@ static void _spawn_app (const gchar * const *args, const gchar *id, const gchar 
 		if (env) for (; *env; ++env) g_variant_builder_add (&env_builder, "s", *env);
 		g_variant_builder_add (&var_builder, "(sv)", "Environment", g_variant_builder_end (&env_builder));
 	}
-	if (working_dir) g_variant_builder_add (&var_builder, "(sv)", "WorkingDirectory", working_dir);
+	if (working_dir) g_variant_builder_add (&var_builder, "(sv)", "WorkingDirectory", g_variant_new_string (working_dir));
 	// fail if systemd cannot exec the process binary
 	g_variant_builder_add   (&var_builder, "(sv)", "Type", g_variant_new_string ("exec"));
 	// clean up failed processes (otherwise, systemd service units remain in the "failed" state)


### PR DESCRIPTION
Likely fixes https://github.com/Cairo-Dock/cairo-dock-core/issues/201#issuecomment-3652070371