### PR TITLE
backport: applet-facility: apply damage after updating icons

### DIFF
--- a/src/gldit/cairo-dock-applet-facility.c
+++ b/src/gldit/cairo-dock-applet-facility.c
@@ -81,6 +81,8 @@ void cairo_dock_set_icon_surface_full (cairo_t *pIconContext, cairo_surface_t *p
 		cairo_restore (pIconContext);
 	}
 	cairo_dock_end_draw_icon_cairo (pIcon);
+	
+	if (pIcon->pContainer) gtk_widget_queue_draw (pIcon->pContainer->pWidget);
 }
 
 


### PR DESCRIPTION
Without this, sometimes a stale icon is shown (e.g. indicator, Status-Notifier)