### PR TITLE
class-manager: remove cairo_dock_register_class2 () from the public API

### DIFF
--- a/src/gldit/cairo-dock-class-manager-priv.h
+++ b/src/gldit/cairo-dock-class-manager-priv.h
@@ -116,6 +116,43 @@ void cairo_dock_reset_class_table (void);
 cairo_surface_t *cairo_dock_create_surface_from_class (const gchar *cClass, int iWidth, int ifHeight);
 
 
+/** Register an application class from apps installed on the system or find an already registered one.
+* @param cSearchTerm query to search for among installed apps (see below for details).
+* @param cWmClass StartupWMClass key from a custom launcher to add as an additional key to find this class later.
+* @param bCreateAlways if TRUE, a new class is always created with cSearchTerm as its key.
+* @return the class ID in a newly allocated string (can be used to retrieve class properties later).
+* 
+* The cSearchTerm supplied to this function should be either:
+*  - a desktop file path which is opened if it exists; if not, the file basename is searched among the
+*    desktop IDs of installed apps in a case-insensitive way, but no other heuristics is attempted
+*  - a desktop file ID (i.e. a string not starting with "/" and ending with ".desktop"); it is searched
+*    among the desktop IDs of installed apps (case-insensitive); if not found, a heuristic search is
+*    also attempted
+*  - a class name / app-id (from the StartupWMClass key of a launcher) or a command name; this is assumed
+*    to be already lowercase, and it is searched among installed apps using heuristics
+* 
+* Heuristics applied to search are the following:
+*  - search among desktop file IDs by applying common suffices (org.gnome., org.kde., org.freedesktop)
+*  - duplicating the name (e.g. "firefox" -> "firefox_firefox.desktop", required for Snap)
+*  - searching the content of the StartupWMClass or the Exec key (if StartupWMClass is not present)
+*    in the .desktop file
+* 
+* The cWmClass parameter is not used for searching among installed apps, but it is added without any
+* modification as an additional key for this class for later retrieval (so it is useful if the app
+* uses a WMClass / app-id that is not possible to find with our heuristics).
+* 
+* The bCreateAlways controls whether cSearchTerm is always used to create a class:
+*  - if bCreateAlways == FALSE, and no result is found, no class is created and NULL is returned
+*  - if bCreateAlways == TRUE, and an app is found, a class is created as normal, but it is also ensured
+*    that cSearchTerm is added as a key for retrieval (in this case, the return value will be cSearchTerm)
+*  - if bCreateAlways == TRUE, and no result is found, a "dummy" class is created and registered; this
+*    should be used as a last resort to ensure that a launcher has a class registered
+*  - if bIsDesktopFile == TRUE, cSearchTerm is assumed to be the name of a .desktop file and is processed accordingly
+*    (the .desktop suffix removed and converted to lowercase)
+*/
+gchar *cairo_dock_register_class2 (const gchar *cSearchTerm, const gchar *cWmClass, gboolean bCreateAlways, gboolean bIsDesktopFile);
+
+
 /** Run a function on each Icon that inhibites a given window.
 *@param actor the window actor
 *@param callback function to be called

--- a/src/gldit/cairo-dock-class-manager.h
+++ b/src/gldit/cairo-dock-class-manager.h
@@ -170,43 +170,6 @@ const gchar *cairo_dock_get_class_icon (const gchar *cClass);
 */
 GldiAppInfo *cairo_dock_get_class_app_info (const gchar *cClass);
 
-
-/** Register an application class from apps installed on the system or find an already registered one.
-* @param cSearchTerm query to search for among installed apps (see below for details).
-* @param cWmClass StartupWMClass key from a custom launcher to add as an additional key to find this class later.
-* @param bCreateAlways if TRUE, a new class is always created with cSearchTerm as its key.
-* @return the class ID in a newly allocated string (can be used to retrieve class properties later).
-* 
-* The cSearchTerm supplied to this function should be either:
-*  - a desktop file path which is opened if it exists; if not, the file basename is searched among the
-*    desktop IDs of installed apps in a case-insensitive way, but no other heuristics is attempted
-*  - a desktop file ID (i.e. a string not starting with "/" and ending with ".desktop"); it is searched
-*    among the desktop IDs of installed apps (case-insensitive); if not found, a heuristic search is
-*    also attempted
-*  - a class name / app-id (from the StartupWMClass key of a launcher) or a command name; this is assumed
-*    to be already lowercase, and it is searched among installed apps using heuristics
-* 
-* Heuristics applied to search are the following:
-*  - search among desktop file IDs by applying common suffices (org.gnome., org.kde., org.freedesktop)
-*  - duplicating the name (e.g. "firefox" -> "firefox_firefox.desktop", required for Snap)
-*  - searching the content of the StartupWMClass or the Exec key (if StartupWMClass is not present)
-*    in the .desktop file
-* 
-* The cWmClass parameter is not used for searching among installed apps, but it is added without any
-* modification as an additional key for this class for later retrieval (so it is useful if the app
-* uses a WMClass / app-id that is not possible to find with our heuristics).
-* 
-* The bCreateAlways controls whether cSearchTerm is always used to create a class:
-*  - if bCreateAlways == FALSE, and no result is found, no class is created and NULL is returned
-*  - if bCreateAlways == TRUE, and an app is found, a class is created as normal, but it is also ensured
-*    that cSearchTerm is added as a key for retrieval (in this case, the return value will be cSearchTerm)
-*  - if bCreateAlways == TRUE, and no result is found, a "dummy" class is created and registered; this
-*    should be used as a last resort to ensure that a launcher has a class registered
-*  - if bIsDesktopFile == TRUE, cSearchTerm is assumed to be the name of a .desktop file and is processed accordingly
-*    (the .desktop suffix removed and converted to lowercase)
-*/
-gchar *cairo_dock_register_class2 (const gchar *cSearchTerm, const gchar *cWmClass, gboolean bCreateAlways, gboolean bIsDesktopFile);
-
 /** Register an application class from apps installed on the system.
 * @param cSearchTerm query to search for among installed apps
 * @return the class ID in a newly allocated string (can be used to retrieve class properties later).


### PR DESCRIPTION
This is actually not used by the plugins so no need to expose it for now.