### PR TITLE
systemd: change unit type to "exec"

### DIFF
--- a/data/systemd/cairo-dock.service.in
+++ b/data/systemd/cairo-dock.service.in
@@ -6,6 +6,7 @@ Requisite=graphical-session.target
 
 [Service]
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/cairo-dock
+Type=exec
 BusName=org.cairodock.CairoDock
 
 [Install]


### PR DESCRIPTION
We had implicitly "Type=dbus" which would mean that systemd would terminate the Cairo-Dock process once the DBus name goes away, preventing the crash handler from restarting it. We could also rely on systemd to restart us, but then it would be more complicated to save the crashed module name.

This change means that the unit will be "ready" before the DBus name is available, but this should not be a problem (we don't have dependent units and even if we had, they should be able to handle the DBus name appearing later).