### PR TITLE
Additional UI scaling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.6.99") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.6.100") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/data/cairo-dock.conf.in
+++ b/data/cairo-dock.conf.in
@@ -186,9 +186,20 @@ animation on demands attention = rotate
 #{Enable new code paths on X11 to test for regressions.}
 X11_new_rendering_code=false
 
+#F+[Additional UI scaling;zoom-fit-best]
+frame_scale =
+
 #e+[0.5;2;smaller;bigger] UI scaling factor :
 #{Scale the UI additionally by this factor. You can use this as a workaround if the dock appears too small or too large.}
 ui scale = 1.
+
+#l+[X11;Wayland;Always] Apply scaling on display server:
+#{Select to only apply the above scaling factor when running in an environment with a specific display server.}
+ui scale backend = 2
+
+#b- Do not scale fonts in menus
+#{Select this if fonts in menus are already scaled by GTK ("Scaling factor" setting on the "Fonts" tab of GNOME Tweaks).}
+ui scale exclude menus = false
 
 #X-[Animations speed;@pkgdatadir@/icons/icon-movment.png]
 frame_mov =

--- a/data/cairo-dock.conf.in
+++ b/data/cairo-dock.conf.in
@@ -182,9 +182,13 @@ animation on demands attention = rotate
 
 [System]
 
-#B- Experimental drawing code (X11)
+#b- Experimental drawing code (X11)
 #{Enable new code paths on X11 to test for regressions.}
 X11_new_rendering_code=false
+
+#e+[0.5;2;smaller;bigger] UI scaling factor :
+#{Scale the UI additionally by this factor. You can use this as a workaround if the dock appears too small or too large.}
+ui scale = 1.
 
 #X-[Animations speed;@pkgdatadir@/icons/icon-movment.png]
 frame_mov =

--- a/src/cairo-dock-gui-advanced.c
+++ b/src/cairo-dock-gui-advanced.c
@@ -1526,9 +1526,11 @@ static void _add_main_groups_buttons (void)
 		_("System"));
 	_add_sub_group_to_group_button (pGroupDescription, "System", "icon-system.svg", _("System"));
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Docks");
+	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Dialogs");
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Connection");
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Containers");
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Backends");
+	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Icons");
 	pGroupDescription->build_widget = _build_config_group_widget;
 	
 	pGroupDescription = _add_one_main_group_button ("Style",

--- a/src/cairo-dock-gui-advanced.c
+++ b/src/cairo-dock-gui-advanced.c
@@ -1525,12 +1525,13 @@ static void _add_main_groups_buttons (void)
 		N_("All of the parameters you will never want to tweak."),
 		_("System"));
 	_add_sub_group_to_group_button (pGroupDescription, "System", "icon-system.svg", _("System"));
-	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Docks");
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Dialogs");
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Connection");
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Containers");
-	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Backends");
 	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Icons");
+	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Backends");
+	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Style");
+	pGroupDescription->pManagers = g_list_prepend (pGroupDescription->pManagers, (gchar*)"Docks"); // needs to reload before backends and icons
 	pGroupDescription->build_widget = _build_config_group_widget;
 	
 	pGroupDescription = _add_one_main_group_button ("Style",

--- a/src/cairo-dock-widget-config.c
+++ b/src/cairo-dock-widget-config.c
@@ -285,7 +285,7 @@ static GKeyFile *_make_simple_conf_file (ConfigWidget *pConfigWidget)
 	
 	g_key_file_set_string (pSimpleKeyFile, "Appearance", "default icon directory", myIconsParam.cIconTheme);
 	
-	int iIconSize = cairo_dock_convert_icon_size_to_enum (myIconsParam.iIconWidth);
+	int iIconSize = cairo_dock_convert_icon_size_to_enum (myIconsParam.iIconWidth / myDocksParam.fUIScale);
 	iIconSize --;  // skip the "default" enum
 	
 	g_key_file_set_integer (pSimpleKeyFile, "Appearance", "icon size", iIconSize);

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -514,6 +514,9 @@ int main (int argc, char** argv)
 	 * https://gitlab.gnome.org/GNOME/glib/-/issues/541
 	 */
 	g_vfs_get_default ();
+	/* Recently, I saw another deadlock with specifically this type,
+	 * let's try harder to ensure that it is initialized. */
+	g_object_unref (g_volume_monitor_get ());
 	
 	gtk_init (&argc, &argv);
 	

--- a/src/gldit/cairo-dock-container-priv.h
+++ b/src/gldit/cairo-dock-container-priv.h
@@ -276,6 +276,13 @@ void gldi_container_set_input_shape(GldiContainer *pContainer, cairo_region_t *p
 void gldi_register_containers_manager (void);
 
 
+  //////////
+ // MISC //
+//////////
+
+// Get the scale factor set in the config
+gboolean gldi_container_get_scale_setting (GKeyFile *pKeyFile, double *fScale, gboolean *bFlushConfFileNeeded);
+
 G_END_DECLS
 #endif
 

--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -758,6 +758,28 @@ static gboolean get_config (GKeyFile *pKeyFile, GldiContainersParam *pContainers
 	return bFlushConfFileNeeded;
 }
 
+gboolean gldi_container_get_scale_setting (GKeyFile *pKeyFile, double *fScale, gboolean *bFlushConfFileNeeded)
+{
+	int iUIScaleBackend = cairo_dock_get_integer_key_value (pKeyFile, "System", "ui scale backend", bFlushConfFileNeeded, 2, NULL, NULL);
+	gboolean bScale = FALSE;
+	switch (iUIScaleBackend)
+	{
+		case 2: // both
+			bScale = TRUE;
+			break;
+		case 1: // Wayland
+			bScale = gldi_container_is_wayland_backend ();
+			break;
+		case 0: // X11
+			bScale = !gldi_container_is_wayland_backend ();
+			break;
+	}
+	if (bScale)
+		*fScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", bFlushConfFileNeeded, 1., NULL, NULL);
+	
+	return bScale;
+}
+
   ////////////
  /// LOAD ///
 ////////////

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -1005,7 +1005,28 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDialogsParam *pDialogs)
 {
 	gboolean bFlushConfFileNeeded = FALSE;
 	
-	pDialogs->fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+	pDialogs->fMenuFontScale = 1.0;
+	pDialogs->fUIScale = 1.0;
+	int iUIScaleBackend = cairo_dock_get_integer_key_value (pKeyFile, "System", "ui scale backend", &bFlushConfFileNeeded, 2, NULL, NULL);
+	gboolean bScale = FALSE;
+	switch (iUIScaleBackend)
+	{
+		case 2: // both
+			bScale = TRUE;
+			break;
+		case 1: // Wayland
+			bScale = gldi_container_is_wayland_backend ();
+			break;
+		case 0: // X11
+			bScale = !gldi_container_is_wayland_backend ();
+			break;
+	}
+	if (bScale)
+	{
+		pDialogs->fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+		gboolean bDontScaleMenus = cairo_dock_get_boolean_key_value (pKeyFile, "System", "ui scale exclude menus", &bFlushConfFileNeeded, FALSE, NULL, NULL);
+		if (!bDontScaleMenus) pDialogs->fMenuFontScale = pDialogs->fUIScale;
+	}
 	
 	pDialogs->cButtonOkImage = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "button_ok image", &bFlushConfFileNeeded, NULL, NULL, NULL);
 	pDialogs->cButtonCancelImage = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "button_cancel image", &bFlushConfFileNeeded, NULL, NULL, NULL);
@@ -1163,7 +1184,9 @@ static void _init_menu_style (void)
 		}
 		else
 		{
-			gchar *cFontSize = (myDialogsParam.fUIScale != 1.0) ? g_strdup_printf ("font-size: %f %%;\n", myDialogsParam.fUIScale * 100.0) : NULL;
+			gchar *cFontSize = (myDialogsParam.fMenuFontScale != 1.0) ?
+				g_strdup_printf (".gldimenuitem label { font-size: %f%%; }\n", myDialogsParam.fMenuFontScale * 100.0)
+				: NULL;
 			
 			css = g_strconcat (cssheader,
 			".gldimenuitem * { \
@@ -1171,11 +1194,10 @@ static void _init_menu_style (void)
 				-unico-focus-border-color: alpha (@menuitem_child_bg_color, .6); \
 				-unico-focus-fill-color: alpha (@menuitem_child_bg_color, .2); \
 			} \
-			.gldimenuitem { \
+			.gldimenuitem label { \
 				text-shadow: none; \
-				border-image: none; \n",
-				cFontSize ? cFontSize : "",
-			"	box-shadow: none; \
+				border-image: none; \
+				box-shadow: none; \
 				background: transparent; \
 				color: @menuitem_text_color; \
 				border-color: transparent; \
@@ -1336,6 +1358,7 @@ static void _init_menu_style (void)
 			.window-frame { \
 				box-shadow: none; \
 			}",
+			cFontSize,
 			NULL);  // we also define ".menu", so that custom widgets (like in the SoundMenu) can get our colors. Note that we don't redefine Gtk's menuitem, because we want to keep normal menus for GUI
 			// for "entry", using "background-color" will not affect entries inside another widget (like a box), we actually have to use "background" ... (TBC with gtk > 3.6)
 			// for ".window-frame": remove shadow added by some WMs (Marco/Metacity) to the menu (LP #1407880)
@@ -1390,7 +1413,7 @@ static void reload (CairoDialogsParam *pPrevDialogs, CairoDialogsParam *pDialogs
 	
 	if (pPrevDialogs->bUseDefaultColors != pDialogs->bUseDefaultColors
 	|| ! pDialogs->bUseDefaultColors
-	|| pPrevDialogs->fUIScale != pDialogs->fUIScale)
+	|| pPrevDialogs->fMenuFontScale != pDialogs->fMenuFontScale)
 		on_style_changed (NULL);
 }
 

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -1194,7 +1194,7 @@ static void _init_menu_style (void)
 				-unico-focus-border-color: alpha (@menuitem_child_bg_color, .6); \
 				-unico-focus-fill-color: alpha (@menuitem_child_bg_color, .2); \
 			} \
-			.gldimenuitem label { \
+			.gldimenuitem { \
 				text-shadow: none; \
 				border-image: none; \
 				box-shadow: none; \

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -1006,14 +1006,19 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDialogsParam *pDialogs)
 {
 	gboolean bFlushConfFileNeeded = FALSE;
 	
+	pDialogs->fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+	
 	pDialogs->cButtonOkImage = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "button_ok image", &bFlushConfFileNeeded, NULL, NULL, NULL);
 	pDialogs->cButtonCancelImage = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "button_cancel image", &bFlushConfFileNeeded, NULL, NULL, NULL);
 	
 	cairo_dock_get_size_key_value_helper (pKeyFile, "Dialogs", "button ", bFlushConfFileNeeded, pDialogs->iDialogButtonWidth, pDialogs->iDialogButtonHeight);
+	pDialogs->iDialogButtonWidth *= pDialogs->fUIScale;
+	pDialogs->iDialogButtonHeight *= pDialogs->fUIScale;
 	
 	GldiColor couleur_bulle = {{1.0, 1.0, 1.0, 0.7}};
 	cairo_dock_get_color_key_value (pKeyFile, "Dialogs", "bg color", &bFlushConfFileNeeded, &pDialogs->fBgColor, &couleur_bulle, NULL, "background color");
 	pDialogs->iDialogIconSize = MAX (16, cairo_dock_get_integer_key_value (pKeyFile, "Dialogs", "icon size", &bFlushConfFileNeeded, 48, NULL, NULL));
+	pDialogs->iDialogIconSize *= pDialogs->fUIScale;
 	
 	pDialogs->cDecoratorName = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "decorator", &bFlushConfFileNeeded, "comics", NULL, NULL);
 	
@@ -1056,6 +1061,7 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDialogsParam *pDialogs)
 	gboolean bCustomFont = cairo_dock_get_boolean_key_value (pKeyFile, "Dialogs", "custom", &bFlushConfFileNeeded, TRUE, NULL, NULL);
 	gchar *cFont = (bCustomFont ? cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "message police", &bFlushConfFileNeeded, NULL, "Icons", NULL) : NULL);
 	gldi_text_description_set_font (&pDialogs->dialogTextDescription, cFont);
+	pDialogs->dialogTextDescription.iSize *= pDialogs->fUIScale;
 	
 	pDialogs->dialogTextDescription.fMaxRelativeWidth = .5;  // limit to half of the screen (the dialog is not placed on a given screen, it can overlap 2 screens, so it's half of the mean screen width)
 	

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -36,7 +36,6 @@
 #include "cairo-dock-animations.h"  // for cairo_dock_is_hidden
 #include "cairo-dock-desktop-manager.h"
 #include "cairo-dock-dialog-factory.h"
-#include "cairo-dock-menu.h"  // _init_menu_style
 #include "cairo-dock-style-manager.h"
 #define _MANAGER_DEF_
 #include "cairo-dock-dialog-priv.h"
@@ -1100,6 +1099,7 @@ static void _init_menu_style (void)
 			gldi_style_colors_freeze ();
 			g_object_unref (cssProvider);
 			cssProvider = NULL;
+			//!! TODO: might still need a minimal provider to adjust font size !!
 		}
 	}
 	else
@@ -1153,14 +1153,18 @@ static void _init_menu_style (void)
 				&length,
 				NULL);
 		}
+		g_free (cCustomCssFile);
 		
 		gchar *css;
 		if (cCustomCss != NULL)
 		{
 			css = g_strconcat (cssheader, cCustomCss, NULL);
+			g_free (cCustomCss);
 		}
 		else
 		{
+			gchar *cFontSize = (myDialogsParam.fUIScale != 1.0) ? g_strdup_printf ("font-size: %f %%;\n", myDialogsParam.fUIScale * 100.0) : NULL;
+			
 			css = g_strconcat (cssheader,
 			".gldimenuitem * { \
 				/*engine: none;*/ \
@@ -1169,8 +1173,9 @@ static void _init_menu_style (void)
 			} \
 			.gldimenuitem { \
 				text-shadow: none; \
-				border-image: none; \
-				box-shadow: none; \
+				border-image: none; \n",
+				cFontSize ? cFontSize : "",
+			"	box-shadow: none; \
 				background: transparent; \
 				color: @menuitem_text_color; \
 				border-color: transparent; \
@@ -1334,12 +1339,15 @@ static void _init_menu_style (void)
 			NULL);  // we also define ".menu", so that custom widgets (like in the SoundMenu) can get our colors. Note that we don't redefine Gtk's menuitem, because we want to keep normal menus for GUI
 			// for "entry", using "background-color" will not affect entries inside another widget (like a box), we actually have to use "background" ... (TBC with gtk > 3.6)
 			// for ".window-frame": remove shadow added by some WMs (Marco/Metacity) to the menu (LP #1407880)
+			
+			g_free (cFontSize);
 		}
 		
 		gldi_style_colors_freeze ();
 		gtk_css_provider_load_from_data (cssProvider,
 			css, -1, NULL);  // (should) clear any previously loaded information
 		gldi_style_colors_freeze ();
+		g_free (cssheader);
 		g_free (css);
 	}
 }
@@ -1381,7 +1389,8 @@ static void reload (CairoDialogsParam *pPrevDialogs, CairoDialogsParam *pDialogs
 	}
 	
 	if (pPrevDialogs->bUseDefaultColors != pDialogs->bUseDefaultColors
-	|| ! pDialogs->bUseDefaultColors)
+	|| ! pDialogs->bUseDefaultColors
+	|| pPrevDialogs->fUIScale != pDialogs->fUIScale)
 		on_style_changed (NULL);
 }
 

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -1005,27 +1005,17 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDialogsParam *pDialogs)
 {
 	gboolean bFlushConfFileNeeded = FALSE;
 	
-	pDialogs->fMenuFontScale = 1.0;
-	pDialogs->fUIScale = 1.0;
-	int iUIScaleBackend = cairo_dock_get_integer_key_value (pKeyFile, "System", "ui scale backend", &bFlushConfFileNeeded, 2, NULL, NULL);
-	gboolean bScale = FALSE;
-	switch (iUIScaleBackend)
+	double fScale = 1.0;
+	if (gldi_container_get_scale_setting (pKeyFile, &fScale, &bFlushConfFileNeeded))
 	{
-		case 2: // both
-			bScale = TRUE;
-			break;
-		case 1: // Wayland
-			bScale = gldi_container_is_wayland_backend ();
-			break;
-		case 0: // X11
-			bScale = !gldi_container_is_wayland_backend ();
-			break;
-	}
-	if (bScale)
-	{
-		pDialogs->fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+		pDialogs->fUIScale = fScale;
 		gboolean bDontScaleMenus = cairo_dock_get_boolean_key_value (pKeyFile, "System", "ui scale exclude menus", &bFlushConfFileNeeded, FALSE, NULL, NULL);
-		if (!bDontScaleMenus) pDialogs->fMenuFontScale = pDialogs->fUIScale;
+		if (!bDontScaleMenus) pDialogs->fMenuFontScale = fScale;
+	}
+	else
+	{
+		pDialogs->fMenuFontScale = 1.0;
+		pDialogs->fUIScale = 1.0;
 	}
 	
 	pDialogs->cButtonOkImage = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "button_ok image", &bFlushConfFileNeeded, NULL, NULL, NULL);

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -1005,7 +1005,28 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDialogsParam *pDialogs)
 {
 	gboolean bFlushConfFileNeeded = FALSE;
 	
-	pDialogs->fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+	pDialogs->fMenuFontScale = 1.0;
+	pDialogs->fUIScale = 1.0;
+	int iUIScaleBackend = cairo_dock_get_integer_key_value (pKeyFile, "System", "ui scale backend", &bFlushConfFileNeeded, 2, NULL, NULL);
+	gboolean bScale = FALSE;
+	switch (iUIScaleBackend)
+	{
+		case 2: // both
+			bScale = TRUE;
+			break;
+		case 1: // Wayland
+			bScale = gldi_container_is_wayland_backend ();
+			break;
+		case 0: // X11
+			bScale = !gldi_container_is_wayland_backend ();
+			break;
+	}
+	if (bScale)
+	{
+		pDialogs->fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+		gboolean bDontScaleMenus = cairo_dock_get_boolean_key_value (pKeyFile, "System", "ui scale exclude menus", &bFlushConfFileNeeded, FALSE, NULL, NULL);
+		if (!bDontScaleMenus) pDialogs->fMenuFontScale = pDialogs->fUIScale;
+	}
 	
 	pDialogs->cButtonOkImage = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "button_ok image", &bFlushConfFileNeeded, NULL, NULL, NULL);
 	pDialogs->cButtonCancelImage = cairo_dock_get_string_key_value (pKeyFile, "Dialogs", "button_cancel image", &bFlushConfFileNeeded, NULL, NULL, NULL);
@@ -1163,7 +1184,9 @@ static void _init_menu_style (void)
 		}
 		else
 		{
-			gchar *cFontSize = (myDialogsParam.fUIScale != 1.0) ? g_strdup_printf ("font-size: %f %%;\n", myDialogsParam.fUIScale * 100.0) : NULL;
+			gchar *cFontSize = (myDialogsParam.fMenuFontScale != 1.0) ?
+				g_strdup_printf (".gldimenuitem label { font-size: %f%%; }\n", myDialogsParam.fMenuFontScale * 100.0)
+				: NULL;
 			
 			css = g_strconcat (cssheader,
 			".gldimenuitem * { \
@@ -1173,9 +1196,8 @@ static void _init_menu_style (void)
 			} \
 			.gldimenuitem { \
 				text-shadow: none; \
-				border-image: none; \n",
-				cFontSize ? cFontSize : "",
-			"	box-shadow: none; \
+				border-image: none; \
+				box-shadow: none; \
 				background: transparent; \
 				color: @menuitem_text_color; \
 				border-color: transparent; \
@@ -1335,7 +1357,8 @@ static void _init_menu_style (void)
 			} \
 			.window-frame { \
 				box-shadow: none; \
-			}",
+			}\n",
+			cFontSize,
 			NULL);  // we also define ".menu", so that custom widgets (like in the SoundMenu) can get our colors. Note that we don't redefine Gtk's menuitem, because we want to keep normal menus for GUI
 			// for "entry", using "background-color" will not affect entries inside another widget (like a box), we actually have to use "background" ... (TBC with gtk > 3.6)
 			// for ".window-frame": remove shadow added by some WMs (Marco/Metacity) to the menu (LP #1407880)
@@ -1390,7 +1413,7 @@ static void reload (CairoDialogsParam *pPrevDialogs, CairoDialogsParam *pDialogs
 	
 	if (pPrevDialogs->bUseDefaultColors != pDialogs->bUseDefaultColors
 	|| ! pDialogs->bUseDefaultColors
-	|| pPrevDialogs->fUIScale != pDialogs->fUIScale)
+	|| pPrevDialogs->fMenuFontScale != pDialogs->fMenuFontScale)
 		on_style_changed (NULL);
 }
 

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -1010,7 +1010,8 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDialogsParam *pDialogs)
 	{
 		pDialogs->fUIScale = fScale;
 		gboolean bDontScaleMenus = cairo_dock_get_boolean_key_value (pKeyFile, "System", "ui scale exclude menus", &bFlushConfFileNeeded, FALSE, NULL, NULL);
-		if (!bDontScaleMenus) pDialogs->fMenuFontScale = fScale;
+		if (bDontScaleMenus) pDialogs->fMenuFontScale = 1.0;
+		else pDialogs->fMenuFontScale = fScale;
 	}
 	else
 	{

--- a/src/gldit/cairo-dock-dialog-manager.h
+++ b/src/gldit/cairo-dock-dialog-manager.h
@@ -61,6 +61,7 @@ struct _CairoDialogsParam {
 	gint iCornerRadius;
 	GldiTextDescription dialogTextDescription;
 	gdouble fUIScale;
+	gdouble fMenuFontScale;
 };
 
 

--- a/src/gldit/cairo-dock-dialog-manager.h
+++ b/src/gldit/cairo-dock-dialog-manager.h
@@ -60,6 +60,7 @@ struct _CairoDialogsParam {
 	gint iLineWidth;
 	gint iCornerRadius;
 	GldiTextDescription dialogTextDescription;
+	gdouble fUIScale;
 };
 
 

--- a/src/gldit/cairo-dock-dock-factory.h
+++ b/src/gldit/cairo-dock-dock-factory.h
@@ -152,6 +152,10 @@ struct _CairoDock {
 	// icons
 	/// icon size, as specified in the config of the dock
 	gint iIconSize;
+	/// original (unscaled) icon size
+	/// iIconSize is this multiplied by myDocksParam.fUIScale
+	gint iIconSizeOrig;
+	
 	/// whether the dock should use the global icons size parameters.
 	gboolean bGlobalIconSize;
 	// background

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -1498,6 +1498,8 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDocksParam *pDocksParam)
 			pAccessibility->iZoneWidth = 20;
 		if (pAccessibility->iZoneHeight < 2)
 			pAccessibility->iZoneHeight = 2;
+		pAccessibility->iZoneWidth *= pDocksParam->fUIScale;
+		pAccessibility->iZoneHeight *= pDocksParam->fUIScale;
 		pAccessibility->cZoneImage = cairo_dock_get_string_key_value (pKeyFile, "Accessibility", "callback image", &bFlushConfFileNeeded, 0, "Background", NULL);
 		pAccessibility->fZoneAlpha = 1.;  // on laisse l'utilisateur definir la transparence qu'il souhaite directement dans l'image.
 	}

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -1312,6 +1312,9 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDocksParam *pDocksParam)
 	
 	// frame
 	pBackground->iDockRadius = cairo_dock_get_integer_key_value (pKeyFile, "Background", "corner radius", &bFlushConfFileNeeded, 12, NULL, NULL);
+	pDocksParam->fUIScale = 1.0;
+	if (gldi_container_get_scale_setting (pKeyFile, &pDocksParam->fUIScale, &bFlushConfFileNeeded))
+		pBackground->iDockRadius *= pDocksParam->fUIScale;
 
 	pBackground->iDockLineWidth = cairo_dock_get_integer_key_value (pKeyFile, "Background", "line width", &bFlushConfFileNeeded, 2, NULL, NULL);
 

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -385,8 +385,12 @@ void gldi_icons_foreach_in_docks (GldiIconFunc pFunction, gpointer pUserData)
 static void _reload_buffers_in_dock (CairoDock *pDock, gboolean bRecursive, gboolean bUpdateIconSize)
 {
 	//g_print ("************%s (%d, %d)\n", __func__, pDock->bIsMainDock, bRecursive);
-	if (bUpdateIconSize && pDock->bGlobalIconSize)
-		pDock->iIconSize = myIconsParam.iIconWidth;
+	if (bUpdateIconSize)
+	{
+		if (pDock->bGlobalIconSize)
+			pDock->iIconSize = myIconsParam.iIconWidth;
+		else pDock->iIconSize = pDock->iIconSizeOrig * myDocksParam.fUIScale;
+	}
 	
 	// for each icon, reload its buffer (size may change).
 	Icon* icon;
@@ -638,8 +642,9 @@ static gboolean _get_root_dock_config (CairoDock *pDock)
 	int s = cairo_dock_get_integer_key_value (pKeyFile, "Appearance", "icon size", &bFlushConfFileNeeded, ICON_DEFAULT, NULL, NULL);  // ICON_DEFAULT <=> same as main dock
 	double fMaxScale, fReflectSize;
 	int iIconGap;
-	pDock->iIconSize = cairo_dock_convert_icon_size_to_pixels (s, &fMaxScale, &fReflectSize, &iIconGap);
+	pDock->iIconSizeOrig = cairo_dock_convert_icon_size_to_pixels (s, &fMaxScale, &fReflectSize, &iIconGap);
 	pDock->bGlobalIconSize = (s == ICON_DEFAULT);
+	pDock->iIconSize = pDock->iIconSizeOrig * myDocksParam.fUIScale;
 	
 	//\______________ View.
 	g_free (pDock->cRendererName);

--- a/src/gldit/cairo-dock-dock-manager.h
+++ b/src/gldit/cairo-dock-dock-manager.h
@@ -91,6 +91,8 @@ struct _CairoDocksParam {
 	gboolean bLockIcons;
 	gboolean bLockAll;
 	gboolean bUseDefaultColors;
+	// additional UI scaling (all dimensions should be scaled by this)
+	gdouble fUIScale;
 	};
 
 /// signals

--- a/src/gldit/cairo-dock-icon-manager.c
+++ b/src/gldit/cairo-dock-icon-manager.c
@@ -481,14 +481,19 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoIconsParam *pIcons)
 		pIcons->iIconWidth = 48;
 	if (pIcons->iIconHeight == 0)
 		pIcons->iIconHeight = 48;
+	double fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+	pIcons->iIconWidth *= fUIScale;
+	pIcons->iIconHeight *= fUIScale;
 	pIcons->fExtraScale = cairo_dock_get_double_key_value (pKeyFile, "Icons", "extra scale", &bFlushConfFileNeeded, 1., NULL, NULL);
 	
 	//\___________________ Parametres des separateurs.
 	cairo_dock_get_size_key_value_helper (pKeyFile, "Icons", "separator ", bFlushConfFileNeeded, pIcons->iSeparatorWidth, pIcons->iSeparatorHeight);
 	if (pIcons->iSeparatorWidth == 0)
 		pIcons->iSeparatorWidth = pIcons->iIconWidth;
+	else pIcons->iSeparatorWidth *= fUIScale;
 	if (pIcons->iSeparatorHeight == 0)
 		pIcons->iSeparatorHeight = pIcons->iIconHeight;
+	else pIcons->iSeparatorHeight *= fUIScale;
 	if (pIcons->iSeparatorHeight > pIcons->iIconHeight)
 		pIcons->iSeparatorHeight = pIcons->iIconHeight;
 	
@@ -543,6 +548,7 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoIconsParam *pIcons)
 	
 	gchar *cFont = (bCustomFont ? cairo_dock_get_string_key_value (pKeyFile, "Labels", "police", &bFlushConfFileNeeded, NULL, "Icons", NULL) : NULL);
 	gldi_text_description_set_font (&pLabels->iconTextDescription, cFont);
+	pLabels->iconTextDescription.iSize *= fUIScale;
 	
 	cd_debug ("label font: %s, %d\n", pLabels->iconTextDescription.cFont, pLabels->iconTextDescription.iSize);
 	
@@ -581,7 +587,7 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoIconsParam *pIcons)
 	//\___________________ quick-info
 	gldi_text_description_copy (&pLabels->quickInfoTextDescription, &pLabels->iconTextDescription);
 	pLabels->quickInfoTextDescription.iMargin = 1;  // to minimize the surface of the quick-info (0 would be too much).
-	pLabels->quickInfoTextDescription.iSize = 12;  // no need to update the fd, it will be done when loading the text buffer
+	pLabels->quickInfoTextDescription.iSize = 12 * fUIScale;  // no need to update the fd, it will be done when loading the text buffer
 	
 	gboolean bQuickInfoSameLook = cairo_dock_get_boolean_key_value (pKeyFile, "Labels", "qi same", &bFlushConfFileNeeded, TRUE, NULL, NULL);
 	if ( !bQuickInfoSameLook)

--- a/src/gldit/cairo-dock-icon-manager.c
+++ b/src/gldit/cairo-dock-icon-manager.c
@@ -481,7 +481,24 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoIconsParam *pIcons)
 		pIcons->iIconWidth = 48;
 	if (pIcons->iIconHeight == 0)
 		pIcons->iIconHeight = 48;
-	double fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+	
+	double fUIScale = 1.0;
+	int iUIScaleBackend = cairo_dock_get_integer_key_value (pKeyFile, "System", "ui scale backend", &bFlushConfFileNeeded, 2, NULL, NULL);
+	gboolean bScale = FALSE;
+	switch (iUIScaleBackend)
+	{
+		case 2: // both
+			bScale = TRUE;
+			break;
+		case 1: // Wayland
+			bScale = gldi_container_is_wayland_backend ();
+			break;
+		case 0: // X11
+			bScale = !gldi_container_is_wayland_backend ();
+			break;
+	}
+	if (bScale) fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
+	
 	pIcons->iIconWidth *= fUIScale;
 	pIcons->iIconHeight *= fUIScale;
 	pIcons->fExtraScale = cairo_dock_get_double_key_value (pKeyFile, "Icons", "extra scale", &bFlushConfFileNeeded, 1., NULL, NULL);

--- a/src/gldit/cairo-dock-icon-manager.c
+++ b/src/gldit/cairo-dock-icon-manager.c
@@ -483,24 +483,11 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoIconsParam *pIcons)
 		pIcons->iIconHeight = 48;
 	
 	double fUIScale = 1.0;
-	int iUIScaleBackend = cairo_dock_get_integer_key_value (pKeyFile, "System", "ui scale backend", &bFlushConfFileNeeded, 2, NULL, NULL);
-	gboolean bScale = FALSE;
-	switch (iUIScaleBackend)
+	if (gldi_container_get_scale_setting (pKeyFile, &fUIScale, &bFlushConfFileNeeded))
 	{
-		case 2: // both
-			bScale = TRUE;
-			break;
-		case 1: // Wayland
-			bScale = gldi_container_is_wayland_backend ();
-			break;
-		case 0: // X11
-			bScale = !gldi_container_is_wayland_backend ();
-			break;
+		pIcons->iIconWidth *= fUIScale;
+		pIcons->iIconHeight *= fUIScale;
 	}
-	if (bScale) fUIScale = cairo_dock_get_double_key_value (pKeyFile, "System", "ui scale", &bFlushConfFileNeeded, 1., NULL, NULL);
-	
-	pIcons->iIconWidth *= fUIScale;
-	pIcons->iIconHeight *= fUIScale;
 	pIcons->fExtraScale = cairo_dock_get_double_key_value (pKeyFile, "Icons", "extra scale", &bFlushConfFileNeeded, 1., NULL, NULL);
 	
 	//\___________________ Parametres des separateurs.

--- a/src/gldit/cairo-dock-icon-manager.c
+++ b/src/gldit/cairo-dock-icon-manager.c
@@ -765,8 +765,6 @@ static void _reload_separators (G_GNUC_UNUSED const gchar *cDockName, CairoDock 
 	}
 	if (bHasSeparator)
 	{
-		if (bSeparatorsNeedReload)
-			cairo_dock_update_dock_size (pDock);  // either to trigger the loading of the separator rendering, or to take into account the change in the separators size
 		gtk_widget_queue_draw (pDock->container.pWidget);  // in any case, refresh the drawing
 	}
 }
@@ -833,7 +831,8 @@ static void reload (CairoIconsParam *pPrevIcons, CairoIconsParam *pIcons)
 		(!g_bUseOpenGL && pPrevIcons->fReflectHeightRatio != pIcons->fReflectHeightRatio) ||
 		(!g_bUseOpenGL && pPrevIcons->fAlbedo != pIcons->fAlbedo) ||
 		bThemeChanged ||
-		bIconBackgroundImagesChanged)  // oui on ne fait pas dans la finesse.
+		bIconBackgroundImagesChanged ||
+		bSeparatorsNeedReload)  // oui on ne fait pas dans la finesse.
 	{
 		cairo_dock_reload_buffers_in_all_docks (TRUE);
 	}

--- a/src/gldit/cairo-dock-menu.c
+++ b/src/gldit/cairo-dock-menu.c
@@ -717,6 +717,7 @@ GtkWidget *gldi_menu_item_new_full2 (const gchar *cLabel, const gchar *cImage, g
 			GtkWidget *image = NULL;
 			int size;
 			gtk_icon_size_lookup (iSize, &size, NULL);
+			size *= myDialogsParam.fUIScale;
 			
 			// note: this takes care to load the icon with the correct scale factor
 			cairo_surface_t *surface = cairo_dock_create_surface_from_icon (cImage, size, size);

--- a/src/gldit/cairo-dock-module-instance-manager.c
+++ b/src/gldit/cairo-dock-module-instance-manager.c
@@ -140,6 +140,8 @@ static GKeyFile *_open_conf_file (GldiModuleInstance *pInstance, CairoDockMinima
 	{
 		gboolean bUnused;
 		cairo_dock_get_size_key_value_helper (pKeyFile, "Icon", "icon ", bUnused, pMinimalConfig->iDesiredIconWidth, pMinimalConfig->iDesiredIconHeight);  // for a dock, if 0, will just get the default size; for a desklet, unused.
+		pMinimalConfig->iDesiredIconWidth *= myDocksParam.fUIScale;
+		pMinimalConfig->iDesiredIconHeight *= myDocksParam.fUIScale;
 		
 		pMinimalConfig->cLabel = cairo_dock_get_string_key_value (pKeyFile, "Icon", "name", NULL, NULL, NULL, NULL);
 		if (pMinimalConfig->cLabel == NULL && !pInstance->pModule->pVisitCard->bAllowEmptyTitle)
@@ -227,6 +229,8 @@ static GKeyFile *_open_conf_file (GldiModuleInstance *pInstance, CairoDockMinima
 			pDeskletAttribute->iDeskletWidth = 96;
 		if (pDeskletAttribute->iDeskletHeight == 0)
 			pDeskletAttribute->iDeskletHeight = 96;
+		pDeskletAttribute->iDeskletWidth *= myDocksParam.fUIScale;
+		pDeskletAttribute->iDeskletHeight *= myDocksParam.fUIScale;
 		
 		pDeskletAttribute->iDeskletPositionX = cairo_dock_get_integer_key_value (pKeyFile, "Desklet", "x position", NULL, 0, NULL, NULL);
 		pDeskletAttribute->iDeskletPositionY = cairo_dock_get_integer_key_value (pKeyFile, "Desklet", "y position", NULL, 0, NULL, NULL);

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20260419
+#define GLDI_ABI_VERSION 20260702
 
 // manager
 #ifndef _MANAGER_DEF_

--- a/src/gldit/cairo-dock-style-manager.c
+++ b/src/gldit/cairo-dock-style-manager.c
@@ -25,6 +25,7 @@
 
 #include "cairo-dock-config.h"
 #include "cairo-dock-log.h"
+#include "cairo-dock-container-priv.h"
 #include "cairo-dock-draw-opengl.h"
 #include "cairo-dock-surface-factory.h"  // cairo_dock_create_blank_surface
 #include "cairo-dock-keyfile-utilities.h"  // cairo_dock_open_key_file
@@ -461,6 +462,10 @@ static gboolean get_config (GKeyFile *pKeyFile, GldiStyleParam *pStyleParam)
 		pStyleParam->iLineWidth = g_key_file_get_integer (pKeyFile, "Style", "linewidth", NULL);
 		cairo_dock_get_color_key_value (pKeyFile, "Style", "line color", &bFlushConfFileNeeded, &pStyleParam->fLineColor, NULL, NULL, NULL);
 	}
+	
+	double fScale = 1.0;
+	if (gldi_container_get_scale_setting (pKeyFile, &fScale, &bFlushConfFileNeeded))
+		pStyleParam->iCornerRadius *= fScale;
 	
 	GldiColor bg_color = {{1.0, 1.0, 1.0, 0.7}};
 	cairo_dock_get_color_key_value (pKeyFile, "Style", "bg color", &bFlushConfFileNeeded, &pStyleParam->fBgColor, &bg_color, "Dialogs", "background color");


### PR DESCRIPTION
See #245 
This allows scaling the main UI (the dock, menus, dialogs) by a custom factor optionally either on Wayland or X11. This is mainly intended as a workaround when the display scale factor is not taken into account properly (mainly fractional scaling cases).

TODO: scale additional elements, mainly in dock and dialog / menu renderers