### PR TITLE
cairo-dock-config: avoid struct member access within nullptr

### DIFF
--- a/src/gldit/cairo-dock-config.c
+++ b/src/gldit/cairo-dock-config.c
@@ -373,7 +373,7 @@ void cairo_dock_get_double_list_key_value (GKeyFile *pKeyFile, const gchar *cGro
 void cairo_dock_get_color_key_value (GKeyFile *pKeyFile, const gchar *cGroupName, const gchar *cKeyName, gboolean *bFlushConfFileNeeded, GldiColor *fValueBuffer, GldiColor *fDefaultValues, const gchar *cDefaultGroupName, const gchar *cDefaultKeyName)
 {
 	fValueBuffer->rgba.alpha = 1.;  // in case it's an RGB color in conf
-	cairo_dock_get_double_list_key_value (pKeyFile, cGroupName, cKeyName, bFlushConfFileNeeded, (double*)&fValueBuffer->rgba, 4, (double*)&fDefaultValues->rgba, cDefaultGroupName, cDefaultKeyName);
+	cairo_dock_get_double_list_key_value (pKeyFile, cGroupName, cKeyName, bFlushConfFileNeeded, (double*)&fValueBuffer->rgba, 4, (fDefaultValues ? (double*)&fDefaultValues->rgba : NULL), cDefaultGroupName, cDefaultKeyName);
 }
 
 gchar **cairo_dock_get_string_list_key_value (GKeyFile *pKeyFile, const gchar *cGroupName, const gchar *cKeyName, gboolean *bFlushConfFileNeeded, gsize *length, const gchar *cDefaultValues, const gchar *cDefaultGroupName, const gchar *cDefaultKeyName)


### PR DESCRIPTION
cairo_dock_get_color_key_value() can be called with fDefaultValues argument NULL. In that case, member access fDefaultValues->rgba invokes nullptr access, avoid this.

Currently, compiled with `-fsanitize=address -fsanitize=undefined` , launching `$ cairo-dock -c` causes sanitizer complaint:
```
/builddir/cairo-dock-freeworld-3.6.98_20260307gitb3265bd-build/src/gldit/cairo-dock-config.c:376:136: runtime error: member access within null pointer of type 'struct GldiColor'
```

https://github.com/Cairo-Dock/cairo-dock-core/blob/b3265bd38f4aeb3b09daac0322d53d7ce242fd22/src/gldit/cairo-dock-config.c#L376