### PR TITLE
main: ensure GVolumeMonitor class is loaded early

### DIFF
--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -514,6 +514,9 @@ int main (int argc, char** argv)
 	 * https://gitlab.gnome.org/GNOME/glib/-/issues/541
 	 */
 	g_vfs_get_default ();
+	// needs to be created explicitly for loading extensions such as libgioremote-volume-monitor.so
+	GVolumeMonitor *tmp_vol = g_volume_monitor_get ();
+	g_object_unref (tmp_vol);
 	
 	gtk_init (&argc, &argv);
 	


### PR DESCRIPTION
Further workaround for #247 

This is apparently not fully initialized with `g_vfs_get_default()` and can cause deadlocks later if called first from another thread (which can happen due to plugins using a task to list directories or volumes).