### PR TITLE
Fix compile error when no wayland exists

### DIFF
--- a/src/implementations/cairo-dock-wayland-wm.h
+++ b/src/implementations/cairo-dock-wayland-wm.h
@@ -22,7 +22,9 @@
 #ifndef CAIRO_DOCK_WAYLAND_WM_H
 #define CAIRO_DOCK_WAYLAND_WM_H
 
+#ifdef HAVE_WAYLAND
 #include <wayland-client.h>
+#endif
 #include <stdint.h>
 #include "cairo-dock-struct.h"
 #include "cairo-dock-windows-manager.h"


### PR DESCRIPTION
Do not try to include non-existent header file on systems that do not support wayland at all.

This allows the project to be compiled on such systems.