### PR TITLE
Do not use external commands to manipulate files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ list(APPEND CMAKE_INSTALL_RPATH ${libdir})
 
 # check for mandatory dependencies
 # for pkg_check_modules -- use semicolon to have more details if a package is missing
-set (packages_required_semicolon "glib-2.0 >= 2.40.0;gthread-2.0;cairo;librsvg-2.0;libxml-2.0;gl;glu;libcurl")
+set (packages_required_semicolon "glib-2.0 >= 2.40.0;gthread-2.0;cairo;librsvg-2.0;libxml-2.0;gl;glu;libcurl;libarchive")
 # for gldi.pc -- replace semicolons with spaces
 STRING (REPLACE ";" " " packages_required "${packages_required_semicolon}") # note: need to use quotes around ${packages_required_semicolon} for this to work!
 pkg_check_modules ("PACKAGE" REQUIRED ${packages_required_semicolon})

--- a/src/cairo-dock-user-menu.c
+++ b/src/cairo-dock-user-menu.c
@@ -365,31 +365,10 @@ static void _cairo_dock_about (G_GNUC_UNUSED GtkMenuItem *pMenuItem, GldiContain
 	//don't use gtk_dialog_run(), as we don't want to block the dock
 }
 
-static void _launch_url (const gchar *cURL)
-{
-	if  (! cairo_dock_fm_launch_uri (cURL))
-	{
-		gchar *cCommand = g_strdup_printf ("\
-which xdg-open > /dev/null && xdg-open %s || \
-which firefox > /dev/null && firefox %s || \
-which konqueror > /dev/null && konqueror %s || \
-which iceweasel > /dev/null && konqueror %s || \
-which opera > /dev/null && opera %s ",
-			cURL,
-			cURL,
-			cURL,
-			cURL,
-			cURL);  // pas super beau mais efficace ^_^
-		int r = system (cCommand);
-		if (r < 0)
-			cd_warning ("Not able to launch this command: %s", cCommand);
-		g_free (cCommand);
-	}
-}
 static void _cairo_dock_show_third_party_applets (G_GNUC_UNUSED GtkMenuItem *pMenuItem, G_GNUC_UNUSED gpointer data)
 {
 	gchar *cLink = cairo_dock_get_third_party_applets_link ();
-	_launch_url (cLink);
+	cairo_dock_fm_launch_uri (cLink);
 	g_free (cLink);
 }
 

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -854,12 +854,9 @@ int main (int argc, char** argv)
 		}
 		else
 			cThemeName = "Default-Single";
-		gchar *cCommand = g_strdup_printf ("cp -r \"%s/%s\"/* \"%s\"", CAIRO_DOCK_SHARE_DATA_DIR"/themes", cThemeName, g_cCurrentThemePath);
-		cd_message (cCommand);
-		int r = system (cCommand);
-		if (r < 0)
-			cd_warning ("Not able to launch this command: %s", cCommand);
-		g_free (cCommand);
+		gchar *cThemePath = g_strdup_printf ("%s/%s", CAIRO_DOCK_SHARE_DATA_DIR"/themes", cThemeName);
+		cairo_dock_fm_recursive_copy (cThemePath, g_cCurrentThemePath, NULL, NULL);
+		g_free (cThemePath);
 	}
 	/* The first time the Cairo-Dock session is used but not the first time the
 	 *  dock is launched: propose to use the Default-Panel theme if a second

--- a/src/gldit/cairo-dock-file-manager.c
+++ b/src/gldit/cairo-dock-file-manager.c
@@ -718,7 +718,7 @@ gboolean _recursive_copy_internal (const gchar *cSourceDir, const gchar *cDestDi
 	GFile *pFile = g_file_new_for_path (cSourceDir);
 	GError *erreur = NULL;
 	const gchar *cAttributes = G_FILE_ATTRIBUTE_STANDARD_TYPE","
-		G_FILE_ATTRIBUTE_STANDARD_NAME;
+		G_FILE_ATTRIBUTE_STANDARD_NAME","G_FILE_ATTRIBUTE_STANDARD_SYMLINK_TARGET;
 	GFileEnumerator *pFileEnum = g_file_enumerate_children (pFile, cAttributes,
 		G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, NULL, &erreur);
 	if (erreur != NULL)
@@ -780,9 +780,32 @@ gboolean _recursive_copy_internal (const gchar *cSourceDir, const gchar *cDestDi
 		}
 		else
 		{
-			// copy a normal file
 			if (bExists) cairo_dock_fm_delete_file (sDestUri->str, TRUE); // delete if it already exists
-			ret = cairo_dock_copy_file (sFileUri->str, sDestUri->str);
+			if (iFileType == G_FILE_TYPE_SYMBOLIC_LINK)
+			{
+				// handle symlinks specially, keeping the link
+				const char *cTarget = g_file_info_get_symlink_target (pFileInfo);
+				
+				// check if the target actually exists (some themes might contain broken links)
+				g_string_printf (sFileUri, "%s/%s", cSourceDir, cTarget);
+				if (g_file_test (sFileUri->str, G_FILE_TEST_EXISTS))
+				{
+					GFile *tmp = g_file_new_for_path (sDestUri->str);
+					// note: this assumes the link will work in the new location
+					// (which it should as we expect a relative link to files in
+					// the same directory)
+					g_file_make_symbolic_link (tmp, cTarget, NULL, &erreur);
+					g_object_unref (tmp);
+					if (erreur)
+					{
+						cd_warning ("%s", erreur->message);
+						g_error_free (erreur);
+						ret = FALSE;
+					}
+				}
+			}
+			// copy a normal file
+			else ret = cairo_dock_copy_file (sFileUri->str, sDestUri->str);
 		}
 		
 		g_object_unref (pFileInfo);

--- a/src/gldit/cairo-dock-file-manager.c
+++ b/src/gldit/cairo-dock-file-manager.c
@@ -228,6 +228,120 @@ gboolean cairo_dock_fm_eject_drive (const gchar *cURI)
 }
 
 
+static gboolean _empty_dir (const gchar *cBaseURI, CairoDockFMDirectoryFilterFunc pFilter, gconstpointer data, gboolean bRecurse, gboolean *bRemain)
+{
+	GFile *pFile = (*cBaseURI == '/' ? g_file_new_for_path (cBaseURI) : g_file_new_for_uri (cBaseURI));
+	GError *erreur = NULL;
+	const gchar *cAttributes = G_FILE_ATTRIBUTE_STANDARD_TYPE","
+		G_FILE_ATTRIBUTE_STANDARD_NAME;
+	GFileEnumerator *pFileEnum = g_file_enumerate_children (pFile,
+		cAttributes,
+		G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+		NULL,
+		&erreur);
+	if (erreur != NULL)
+	{
+		cd_warning ("%s", erreur->message);
+		g_object_unref (pFile);
+		g_error_free (erreur);
+		return FALSE;
+	}
+	
+	gboolean ret = TRUE;
+	*bRemain = FALSE;
+	GString *sFileUri = g_string_new ("");
+	GFileInfo *pFileInfo;
+	do
+	{
+		pFileInfo = g_file_enumerator_next_file (pFileEnum, NULL, &erreur);
+		if (erreur != NULL)
+		{
+			cd_warning ("%s", erreur->message);
+			g_error_free (erreur);
+			ret = FALSE; // no point in continuing, we cannot empty the directory in this case
+			break;
+		}
+		if (pFileInfo == NULL) break; // we are at the end
+		
+		GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+		const gchar *cFileName = g_file_info_get_name (pFileInfo);
+		if (iFileType != G_FILE_TYPE_DIRECTORY && pFilter && !pFilter (cFileName, data))
+		{
+			// skip this file
+			*bRemain = TRUE;
+			g_object_unref (pFileInfo);
+			continue;
+		}
+		
+		g_string_printf (sFileUri, "%s/%s", cBaseURI, cFileName);
+		
+		gboolean bKeep = FALSE;
+		if (iFileType == G_FILE_TYPE_DIRECTORY)
+		{
+			if (bRecurse) ret = _empty_dir (sFileUri->str, pFilter, data, bRecurse, &bKeep);
+			else bKeep = TRUE;
+			if (ret && bKeep) *bRemain = TRUE;
+		}
+		
+		if (ret && !bKeep)
+		{
+			GFile *file = (*cBaseURI == '/' ? g_file_new_for_path (sFileUri->str) : g_file_new_for_uri (sFileUri->str));
+			g_file_delete (file, NULL, &erreur);
+			if (erreur != NULL)
+			{
+				cd_warning ("%s", erreur->message);
+				g_error_free (erreur);
+				erreur = NULL;
+				ret = FALSE;
+			}
+			g_object_unref (file);
+		}
+		
+		g_object_unref (pFileInfo);
+	} while (ret);
+	
+	g_string_free (sFileUri, TRUE);
+	g_object_unref (pFileEnum);
+	g_object_unref (pFile);
+	return ret;
+}
+
+gboolean cairo_dock_fm_empty_directory (const gchar *cURI, gboolean bRecurse, CairoDockFMDirectoryFilterFunc pFilter, gconstpointer data)
+{
+	g_return_val_if_fail (cURI != NULL, FALSE);
+	GFile *pFile = (*cURI == '/' ? g_file_new_for_path (cURI) : g_file_new_for_uri (cURI));
+	
+	GError *erreur = NULL;
+	
+	const gchar *cQuery = G_FILE_ATTRIBUTE_STANDARD_TYPE;
+	GFileInfo *pFileInfo = g_file_query_info (pFile,
+		cQuery,
+		G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+		NULL,
+		&erreur);
+	if (erreur != NULL)
+	{
+		cd_warning ("%s", erreur->message);
+		g_error_free (erreur);
+		g_object_unref (pFile);
+		return FALSE;
+	}
+	
+	gboolean ret;
+	gboolean dummy;
+	GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+	if (iFileType == G_FILE_TYPE_DIRECTORY)
+		ret = _empty_dir (cURI, pFilter, data, bRecurse, &dummy);
+	else
+	{
+		cd_warning ("Path is not a directory: %s\n", cURI);
+		ret = FALSE;
+	}
+	
+	g_object_unref (pFile);
+	return ret;
+}
+
 gboolean cairo_dock_fm_delete_file (const gchar *cURI, gboolean bNoTrash)
 {
 	if (s_EnvBackend.delete_file != NULL)

--- a/src/gldit/cairo-dock-file-manager.c
+++ b/src/gldit/cairo-dock-file-manager.c
@@ -345,6 +345,49 @@ gboolean cairo_dock_fm_empty_directory (const gchar *cURI, gboolean bRecurse, Ca
 
 gboolean cairo_dock_fm_delete_file (const gchar *cURI, gboolean bNoTrash)
 {
+	g_return_val_if_fail (cURI != NULL, FALSE);
+	
+	if (bNoTrash)
+	{
+		GFile *pFile = (*cURI == '/' ? g_file_new_for_path (cURI) : g_file_new_for_uri (cURI));
+		
+		GError *erreur = NULL;
+		const gchar *cQuery = G_FILE_ATTRIBUTE_STANDARD_TYPE;
+		GFileInfo *pFileInfo = g_file_query_info (pFile,
+			cQuery,
+			G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+			NULL,
+			&erreur);
+		if (erreur != NULL)
+		{
+			cd_warning ("%s", erreur->message);
+			g_error_free (erreur);
+			g_object_unref (pFile);
+			return FALSE;
+		}
+		
+		GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+		
+		gboolean bSuccess = TRUE;
+		if (iFileType == G_FILE_TYPE_DIRECTORY)
+			bSuccess = cairo_dock_fm_empty_directory (cURI, TRUE, NULL, NULL);
+		
+		if (bSuccess)
+		{
+			bSuccess = g_file_delete (pFile, NULL, &erreur);
+			if (erreur != NULL)
+			{
+				cd_warning ("gvfs-integration : %s", erreur->message);
+				g_error_free (erreur);
+			}
+		}
+		
+		g_object_unref (pFileInfo);
+		g_object_unref (pFile);
+		return bSuccess;
+	}
+	
+	// bNoTrash == FALSE here, i.e. we want to move the file to trash
 	if (s_EnvBackend.delete_file != NULL)
 	{
 		return s_EnvBackend.delete_file (cURI, bNoTrash);

--- a/src/gldit/cairo-dock-file-manager.c
+++ b/src/gldit/cairo-dock-file-manager.c
@@ -20,8 +20,9 @@
 #define _POSIX_C_SOURCE 200809L // needed for O_CLOEXEC
 #include <stdlib.h>      // atoi
 #include <string.h>      // memset
-#include <sys/stat.h>    // stat
+#include <sys/stat.h>    // stat, mkdir
 #include <fcntl.h>  // open
+#include <unistd.h> // unlink
 #include <sys/sendfile.h>  // sendfile
 #include <errno.h>  // errno
 
@@ -708,6 +709,141 @@ gboolean cairo_dock_copy_file (const gchar *cFilePath, const gchar *cDestPath)
 	}
 	close (dest_fd);
 	close (src_fd);
+	return ret;
+}
+
+
+gboolean _recursive_copy_internal (const gchar *cSourceDir, const gchar *cDestDir, CairoDockFMCopyFilterFunc pFilter, unsigned int depth, gpointer data)
+{
+	GFile *pFile = g_file_new_for_path (cSourceDir);
+	GError *erreur = NULL;
+	const gchar *cAttributes = G_FILE_ATTRIBUTE_STANDARD_TYPE","
+		G_FILE_ATTRIBUTE_STANDARD_NAME;
+	GFileEnumerator *pFileEnum = g_file_enumerate_children (pFile, cAttributes,
+		G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, NULL, &erreur);
+	if (erreur != NULL)
+	{
+		cd_warning ("%s", erreur->message);
+		g_object_unref (pFile);
+		g_error_free (erreur);
+		return FALSE;
+	}
+	
+	gboolean ret = TRUE;
+	GString *sFileUri = g_string_new (NULL);
+	GString *sDestUri = g_string_new (NULL);
+	GFileInfo *pFileInfo;
+	do
+	{
+		pFileInfo = g_file_enumerator_next_file (pFileEnum, NULL, &erreur);
+		if (erreur != NULL)
+		{
+			cd_warning ("%s", erreur->message);
+			g_error_free (erreur);
+			ret = FALSE; // no point in continuing, just signal an error
+			break;
+		}
+		if (pFileInfo == NULL) break; // we are at the end
+		
+		if (pFilter && !pFilter (pFileInfo, depth, data))
+		{
+			g_object_unref (pFileInfo);
+			continue;
+		}
+		
+		GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+		const gchar *cFileName = g_file_info_get_name (pFileInfo);
+		
+		g_string_printf (sFileUri, "%s/%s", cSourceDir, cFileName);
+		g_string_printf (sDestUri, "%s/%s", cDestDir, cFileName);
+		
+		gboolean bExists = g_file_test (sDestUri->str, G_FILE_TEST_EXISTS);
+		gboolean bIsDir = bExists && g_file_test (sDestUri->str, G_FILE_TEST_IS_DIR);
+		
+		if (iFileType == G_FILE_TYPE_DIRECTORY)
+		{
+			// we should try to create it
+			if (bExists)
+			{
+				if (!bIsDir) unlink (sDestUri->str); // just overwrite it
+			}
+			else
+			{
+				if (mkdir (sDestUri->str, 7*8*8+7*8+5) != 0)
+				{
+					cd_warning ("couldn't create directory %s", sDestUri->str);
+					ret = FALSE;
+				}
+			}
+			
+			if (ret) ret = _recursive_copy_internal (sFileUri->str, sDestUri->str, pFilter, depth + 1, data);
+		}
+		else
+		{
+			// copy a normal file
+			if (bExists) cairo_dock_fm_delete_file (sDestUri->str, TRUE); // delete if it already exists
+			ret = cairo_dock_copy_file (sFileUri->str, sDestUri->str);
+		}
+		
+		g_object_unref (pFileInfo);
+	} while (ret);
+	
+	g_object_unref (pFileEnum);
+	g_object_unref (pFile);
+	return ret;
+}
+
+gboolean cairo_dock_fm_recursive_copy (const gchar *cSourceDir, const gchar *cDestDir, CairoDockFMCopyFilterFunc pFilter, gpointer data)
+{
+	g_return_val_if_fail (cSourceDir && cDestDir, FALSE);
+	
+	// check that both source and destination are directories
+	GFile *pFile1 = g_file_new_for_path (cSourceDir);
+	GFile *pFile2 = g_file_new_for_path (cDestDir);
+	
+	GError *erreur = NULL;
+	gboolean ret = FALSE;
+	
+	const gchar *cQuery = G_FILE_ATTRIBUTE_STANDARD_TYPE;
+	GFileInfo *pFileInfo = g_file_query_info (pFile1, cQuery,
+		G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, NULL, &erreur);
+	if (erreur != NULL)
+	{
+		cd_warning ("%s", erreur->message);
+		g_error_free (erreur);
+		goto copy_end;
+	}
+	
+	GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+	if (iFileType != G_FILE_TYPE_DIRECTORY)
+	{
+		cd_warning ("Source is not a directory or does not exist: %s", cSourceDir);
+		g_object_unref (pFileInfo);
+		goto copy_end;
+	}
+	
+	pFileInfo = g_file_query_info (pFile2, cQuery,
+		G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, NULL, &erreur);
+	if (erreur != NULL)
+	{
+		cd_warning ("%s", erreur->message);
+		g_error_free (erreur);
+		goto copy_end;
+	}
+	
+	iFileType = g_file_info_get_file_type (pFileInfo);
+	g_object_unref (pFileInfo);
+	if (iFileType != G_FILE_TYPE_DIRECTORY)
+	{
+		cd_warning ("Destination is not a directory or does not exist: %s", cDestDir);
+		goto copy_end;
+	}
+	
+	ret = _recursive_copy_internal (cSourceDir, cDestDir, pFilter, 0, data);
+	
+copy_end:
+	g_object_unref (pFile1);
+	g_object_unref (pFile2);
 	return ret;
 }
 

--- a/src/gldit/cairo-dock-file-manager.h
+++ b/src/gldit/cairo-dock-file-manager.h
@@ -315,6 +315,11 @@ gboolean cairo_dock_fm_toggle_wifi (void);
 */
 int cairo_dock_get_file_size (const gchar *cFilePath);
 
+/** Copy the contents of a single file.
+*@param cFilePath File to copy. Cannot be a directory. For symlinks, the content of the linked file will be copied (not the link).
+*@param cDestPath Destination. Can be a directory (in which case a file with the same name as the source is created there).
+*@return whether the file was successfully copied.
+*/
 gboolean cairo_dock_copy_file (const gchar *cFilePath, const gchar *cDestPath);
 
 /** Recursively copy files matching a criteria from one directory to another.

--- a/src/gldit/cairo-dock-file-manager.h
+++ b/src/gldit/cairo-dock-file-manager.h
@@ -81,7 +81,7 @@ typedef void (*CairoDockFMMonitorCallback) (CairoDockFMEventType iEventType, con
 typedef void (*CairoDockFMAddMonitorFunc) (const gchar *cURI, gboolean bDirectory, CairoDockFMMonitorCallback pCallback, gpointer data);
 typedef void (*CairoDockFMRemoveMonitorFunc) (const gchar *cURI);
 
-typedef gboolean (*CairoDockFMDeleteFileFunc) (const gchar *cURI, gboolean bNoTrash);
+typedef gboolean (*CairoDockFMDeleteFileFunc) (const gchar *cURI, gboolean bNoTrash); // note: only called with bNoTrash == FALSE
 typedef gboolean (*CairoDockFMRenameFileFunc) (const gchar *cOldURI, const gchar *cNewName);
 typedef gboolean (*CairoDockFMMoveFileFunc) (const gchar *cURI, const gchar *cDirectoryURI);
 typedef gboolean (*CairoDockFMCreateFileFunc) (const gchar *cURI, gboolean bDirectory);

--- a/src/gldit/cairo-dock-file-manager.h
+++ b/src/gldit/cairo-dock-file-manager.h
@@ -109,12 +109,12 @@ struct _CairoDockDesktopEnvBackend {
 	CairoDockFMUnmountFunc 			unmount;
 	CairoDockFMAddMonitorFunc 		add_monitor;
 	CairoDockFMRemoveMonitorFunc 	remove_monitor;
-	CairoDockFMDeleteFileFunc 		delete_file;
-	CairoDockFMRenameFileFunc 		rename;
-	CairoDockFMMoveFileFunc 		move;
+	CairoDockFMDeleteFileFunc 		delete_file; // implemented in kde-integration
+	CairoDockFMRenameFileFunc 		rename; // implemented in kde-integration
+	CairoDockFMMoveFileFunc 		move; // implemented in kde-integration
 	CairoDockFMCreateFileFunc 		create;
 	CairoDockFMListAppsForFileFunc 	list_apps_for_file;
-	CairoDockFMEmptyTrashFunc		empty_trash;
+	CairoDockFMEmptyTrashFunc		empty_trash; // implemented in kde-integration
 	CairoDockFMGetTrashFunc 		get_trash_path;
 	CairoDockFMGetDesktopFunc 		get_desktop_path;
 	CairoDockFMActionWithConfirmationFunc logout;
@@ -192,6 +192,18 @@ gboolean cairo_dock_fm_eject_drive (const gchar *cURI);
 /** Delete a file.
 */
 gboolean cairo_dock_fm_delete_file (const gchar *cURI, gboolean bNoTrash);
+
+/** Empty a directory by deleting all files in it that match a criterion.
+*@param cURI the directory to empty
+*@param bRecurse whether to recursively delete subdirectories
+*@param pFilter optional filter function; only files matching the filter
+    are deleted (i.e. where the function returns TRUE). Empty directories
+    are always deleted if bRecurse == TRUE.
+*@param data parameter to pass to pFilter
+*@returns FALSE if any errors occured (warnings already printed on the console), TRUE otherwise
+*/
+typedef gboolean (*CairoDockFMDirectoryFilterFunc) (const gchar *cFileName, gconstpointer data);
+gboolean cairo_dock_fm_empty_directory (const gchar *cURI, gboolean bRecurse, CairoDockFMDirectoryFilterFunc pFilter, gconstpointer data);
 
 /** Rename a file.
 */

--- a/src/gldit/cairo-dock-file-manager.h
+++ b/src/gldit/cairo-dock-file-manager.h
@@ -317,6 +317,14 @@ int cairo_dock_get_file_size (const gchar *cFilePath);
 
 gboolean cairo_dock_copy_file (const gchar *cFilePath, const gchar *cDestPath);
 
+/** Recursively copy files matching a criteria from one directory to another.
+*@param cSourceDir source directory (files in this directory are considered, but the directory itself is not copied)
+*@param cDestDir destination directory
+*@param pFilter filter function, only files where this returns TRUE are copied (if it returns FALSE for a directory, it is skipped entirely)
+*@param data user data to pass to pFilter
+*/
+typedef gboolean (*CairoDockFMCopyFilterFunc) (GFileInfo *pFileInfo, unsigned int depth, gconstpointer data);
+gboolean cairo_dock_fm_recursive_copy (const gchar *cSourceDir, const gchar *cDestDir, CairoDockFMCopyFilterFunc pFilter, gpointer data);
 
 /** Get process ID given its name
  * @param cProcessName name of the process

--- a/src/gldit/cairo-dock-module-manager.c
+++ b/src/gldit/cairo-dock-module-manager.c
@@ -337,9 +337,7 @@ gchar *gldi_module_get_config_dir (GldiModule *pModule)
 	{
 		cd_message ("directory %s doesn't exist, it will be added.", cUserDataDirPath);
 		
-		gchar *command = g_strdup_printf ("mkdir -p \"%s\"", cUserDataDirPath);
-		int r = system (command);
-		g_free (command);
+		int r = g_mkdir_with_parents (cUserDataDirPath, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 		
 		if (r != 0)
 		{

--- a/src/gldit/cairo-dock-packages.c
+++ b/src/gldit/cairo-dock-packages.c
@@ -60,7 +60,7 @@ static gchar *s_cPackageServerAdress = NULL;
 /* Simple function to uncompress a tar archive. Taken from the examples here:
  * https://github.com/libarchive/libarchive/wiki/Examples (in the public domain)
  */
-static gboolean _uncompress_archive (const gchar *cArchivePath, const gchar *cExtractTo)
+static gboolean _uncompress_archive (const gchar *cArchivePath, const gchar *cExtractTo, const gchar *cPrefix)
 {
 	struct archive *a;
 	struct archive *ext;
@@ -69,6 +69,7 @@ static gboolean _uncompress_archive (const gchar *cArchivePath, const gchar *cEx
 	int r;
 	gboolean ret = TRUE;
 	GString *str = g_string_new (NULL);
+	size_t uPrefixLen = strlen(cPrefix);
 
 	flags = 0;
 
@@ -88,8 +89,16 @@ static gboolean _uncompress_archive (const gchar *cArchivePath, const gchar *cEx
 		if (r < ARCHIVE_OK) cd_warning ("%s", archive_error_string (a));
 		if (r < ARCHIVE_WARN) { ret = FALSE; break; }
 		
+		const char *fn = archive_entry_pathname (entry);
+		if (!fn || strncmp (fn, cPrefix, uPrefixLen) || // we want to match the prefix and
+			!(fn[uPrefixLen] == 0 || fn[uPrefixLen] == '/')) // be a directory
+		{
+			cd_warning ("Unexpected content in archive (%s): %s!", cPrefix, fn);
+			ret = FALSE;
+			break;
+		}
 		
-		g_string_printf (str, "%s/%s", cExtractTo, archive_entry_pathname (entry));
+		g_string_printf (str, "%s/%s", cExtractTo, fn);
 		archive_entry_set_pathname (entry, str->str);
 
 		r = archive_write_header(ext, entry);
@@ -129,6 +138,8 @@ static gboolean _uncompress_archive (const gchar *cArchivePath, const gchar *cEx
 
 gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtractTo, const gchar *cRealArchiveName)
 {
+	g_return_val_if_fail (cArchivePath != NULL, NULL);
+	
 	//\_______________ on cree le repertoire d'extraction.
 	if (!g_file_test (cExtractTo, G_FILE_TEST_EXISTS))
 	{
@@ -145,7 +156,14 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 		cRealArchiveName = cArchivePath;
 	gchar *str = strrchr (cRealArchiveName, '/');
 	if (str != NULL)
+	{
+		if (str[1] == '\0') // sanity check
+		{
+			cd_warning ("Invalid archive file name: %s\n", cRealArchiveName);
+			return NULL;
+		}
 		cLocalFileName = g_strdup (str+1);
+	}
 	else
 		cLocalFileName = g_strdup (cRealArchiveName);
 	
@@ -157,10 +175,14 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 		cLocalFileName[strlen(cLocalFileName)-4] = '\0';
 	else if (g_str_has_suffix (cLocalFileName, ".zip"))
 		cLocalFileName[strlen(cLocalFileName)-4] = '\0';
-	g_return_val_if_fail (cLocalFileName != NULL && *cLocalFileName != '\0', NULL);
+	if (*cLocalFileName == '\0')
+	{
+		cd_warning ("Invalid archive file name: %s\n", cRealArchiveName);
+		g_free (cLocalFileName);
+		return NULL;
+	}
 	
 	gchar *cResultPath = g_strdup_printf ("%s/%s", cExtractTo, cLocalFileName);
-	g_free (cLocalFileName);
 	
 	//\_______________ on deplace un dossier identique prealable.
 	gchar *cTempBackup = NULL;
@@ -171,7 +193,7 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 	}
 	
 	//\_______________ on decompresse l'archive.
-	gboolean r = _uncompress_archive (cArchivePath, cExtractTo);
+	gboolean r = _uncompress_archive (cArchivePath, cExtractTo, cLocalFileName);
 	
 	//\_______________ on verifie le resultat, en remettant l'original en cas d'echec.
 	gboolean bExists = g_file_test (cResultPath, G_FILE_TEST_EXISTS);
@@ -194,6 +216,7 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 	}
 	
 	g_free (cTempBackup);
+	g_free (cLocalFileName);
 	return cResultPath;
 }
 

--- a/src/gldit/cairo-dock-packages.c
+++ b/src/gldit/cairo-dock-packages.c
@@ -34,6 +34,7 @@
 #include "cairo-dock-task.h"
 #include "cairo-dock-config.h"
 #include "cairo-dock-log.h"
+#include "cairo-dock-file-manager.h"
 #define _MANAGER_DEF_
 #include "cairo-dock-packages.h"
 
@@ -111,11 +112,8 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 	}
 	else if (cTempBackup != NULL)
 	{
-		gchar *cCommand = g_strdup_printf ("rm -rf \"%s\"", cTempBackup);
-		int r = system (cCommand);
-		if (r < 0)
+		if (!cairo_dock_fm_delete_file (cTempBackup, TRUE))
 			cd_warning ("Couldn't remove temporary folder (%s)", cCommand);
-		g_free (cCommand);
 	}
 	
 	g_free (cCommand);

--- a/src/gldit/cairo-dock-packages.c
+++ b/src/gldit/cairo-dock-packages.c
@@ -28,6 +28,9 @@
 #include <glib/gi18n.h>
 #include <curl/curl.h>
 
+#include <archive.h>
+#include <archive_entry.h>
+
 #include "gldi-config.h"
 #include "cairo-dock-manager.h"
 #include "cairo-dock-keyfile-utilities.h"
@@ -53,12 +56,83 @@ static gchar *s_cPackageServerAdress = NULL;
  /// DOWNLOAD API ///
 ////////////////////
 
+
+/* Simple function to uncompress a tar archive. Taken from the examples here:
+ * https://github.com/libarchive/libarchive/wiki/Examples (in the public domain)
+ */
+static gboolean _uncompress_archive (const gchar *cArchivePath, const gchar *cExtractTo)
+{
+	struct archive *a;
+	struct archive *ext;
+	struct archive_entry *entry;
+	int flags;
+	int r;
+	gboolean ret = TRUE;
+	GString *str = g_string_new (NULL);
+
+	flags = 0;
+
+	a = archive_read_new();
+	archive_read_support_format_all(a);
+	archive_read_support_filter_all(a);
+	ext = archive_write_disk_new();
+	archive_write_disk_set_options(ext, flags);
+	// archive_write_disk_set_standard_lookup(ext);
+	
+	r = archive_read_open_filename (a, cArchivePath, 10240);
+	if (r != ARCHIVE_OK) ret = FALSE;
+	else while (1) {
+		r = archive_read_next_header (a, &entry);
+		if (r == ARCHIVE_EOF) break;
+		
+		if (r < ARCHIVE_OK) cd_warning ("%s", archive_error_string (a));
+		if (r < ARCHIVE_WARN) { ret = FALSE; break; }
+		
+		
+		g_string_printf (str, "%s/%s", cExtractTo, archive_entry_pathname (entry));
+		archive_entry_set_pathname (entry, str->str);
+
+		r = archive_write_header(ext, entry);
+		if (r < ARCHIVE_OK) cd_warning ("%s", archive_error_string (ext));
+		
+		else if (archive_entry_size(entry) > 0) {
+			const void *buff;
+			size_t size;
+			la_int64_t offset;
+
+			while (1) {
+				r = archive_read_data_block(a, &buff, &size, &offset);
+				if (r == ARCHIVE_EOF) break;
+				if (r < ARCHIVE_OK) cd_warning ("%s", archive_error_string (a));
+				else
+				{
+					r = archive_write_data_block(ext, buff, size, offset);
+					if (r < ARCHIVE_OK) cd_warning ("%s", archive_error_string (ext));
+				}
+				
+				if (r < ARCHIVE_WARN) break;
+			}
+		}
+		
+		if (r == ARCHIVE_EOF || r == ARCHIVE_OK) r = archive_write_finish_entry (ext);
+		if (r < ARCHIVE_OK) cd_warning ("%s", archive_error_string(ext));
+		if (r < ARCHIVE_WARN) { ret = FALSE; break; }
+	}
+	archive_read_close (a);
+	archive_read_free (a);
+	archive_write_close (ext);
+	archive_write_free (ext);
+	g_string_free (str, TRUE);
+	
+	return ret;
+}
+
 gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtractTo, const gchar *cRealArchiveName)
 {
 	//\_______________ on cree le repertoire d'extraction.
 	if (!g_file_test (cExtractTo, G_FILE_TEST_EXISTS))
 	{
-		if (g_mkdir (cExtractTo, 7*8*8+7*8+5) != 0)
+		if (g_mkdir_with_parents (cExtractTo, 7*8*8+7*8+5) != 0)
 		{
 			cd_warning ("couldn't create directory %s", cExtractTo);
 			return NULL;
@@ -81,6 +155,8 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 		cLocalFileName[strlen(cLocalFileName)-8] = '\0';
 	else if (g_str_has_suffix (cLocalFileName, ".tgz"))
 		cLocalFileName[strlen(cLocalFileName)-4] = '\0';
+	else if (g_str_has_suffix (cLocalFileName, ".zip"))
+		cLocalFileName[strlen(cLocalFileName)-4] = '\0';
 	g_return_val_if_fail (cLocalFileName != NULL && *cLocalFileName != '\0', NULL);
 	
 	gchar *cResultPath = g_strdup_printf ("%s/%s", cExtractTo, cLocalFileName);
@@ -95,14 +171,15 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 	}
 	
 	//\_______________ on decompresse l'archive.
-	gchar *cCommand = g_strdup_printf ("tar xf%c \"%s\" -C \"%s\"", (g_str_has_suffix (cArchivePath, "bz2") ? 'j' : 'z'), cArchivePath, cExtractTo);
-	cd_debug ("tar : %s", cCommand);
-	int r = system (cCommand);
+	gboolean r = _uncompress_archive (cArchivePath, cExtractTo);
 	
 	//\_______________ on verifie le resultat, en remettant l'original en cas d'echec.
-	if (r != 0 || !g_file_test (cResultPath, G_FILE_TEST_EXISTS))
+	gboolean bExists = g_file_test (cResultPath, G_FILE_TEST_EXISTS);
+	if (!r) if (bExists) cairo_dock_fm_delete_file (cResultPath, TRUE); // if extraction did not work, clean up
+	
+	if (!(r && bExists))
 	{
-		cd_warning ("Invalid archive file (%s)", cCommand);
+		cd_warning ("Invalid archive file (%s)", cArchivePath);
 		if (cTempBackup != NULL)
 		{
 			g_rename (cTempBackup, cResultPath);
@@ -113,10 +190,9 @@ gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtr
 	else if (cTempBackup != NULL)
 	{
 		if (!cairo_dock_fm_delete_file (cTempBackup, TRUE))
-			cd_warning ("Couldn't remove temporary folder (%s)", cCommand);
+			cd_warning ("Couldn't remove temporary folder (%s)", cTempBackup);
 	}
 	
-	g_free (cCommand);
 	g_free (cTempBackup);
 	return cResultPath;
 }

--- a/src/gldit/cairo-dock-packages.h
+++ b/src/gldit/cairo-dock-packages.h
@@ -115,9 +115,8 @@ typedef void (* CairoDockGetPackagesFunc ) (GHashTable *pPackagesTable, gpointer
 Notes:
  - This function will block during the extraction. Use a GldiTask to keep the UI responsive.
  - This is not intended as a general extractor as a specific format is assumed: the archive
-   should contain a single subdirectory with the same equal to the basename of cRealArchiveName
-   (with the extension removed). The return value will thus be the combination of this with
-   cExtractTo.
+   should contain a single subdirectory whose name is equal to the basename of cRealArchiveName
+   (with the extension removed). Extraction will fail if this condition is not satisfied.
 */
 gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtractTo, const gchar *cRealArchiveName);
 

--- a/src/gldit/cairo-dock-packages.h
+++ b/src/gldit/cairo-dock-packages.h
@@ -106,6 +106,19 @@ struct _CairoDockPackage {
 /// Prototype of the function called when the list of packages is available. Use g_hash_table_ref if you want to keep the table outside of this function.
 typedef void (* CairoDockGetPackagesFunc ) (GHashTable *pPackagesTable, gpointer data);
 
+/** Uncompress an already downloaded package archive to the given directory.
+*@param cArchivePath path of the downloaded archive file
+*@param cExtractTo path to extract to (root of archive is extracted here)
+*@param cRealArchiveName true archive name (if e.g. cArchivePath is a temporary file name), or NULL
+*@return path to the successfully extracted package or NULL on failure
+
+Notes:
+ - This function will block during the extraction. Use a GldiTask to keep the UI responsive.
+ - This is not intended as a general extractor as a specific format is assumed: the archive
+   should contain a single subdirectory with the same equal to the basename of cRealArchiveName
+   (with the extension removed). The return value will thus be the combination of this with
+   cExtractTo.
+*/
 gchar *cairo_dock_uncompress_file (const gchar *cArchivePath, const gchar *cExtractTo, const gchar *cRealArchiveName);
 
 /** Download a distant file into a given location.

--- a/src/gldit/cairo-dock-themes-manager.c
+++ b/src/gldit/cairo-dock-themes-manager.c
@@ -441,17 +441,6 @@ static gchar *_cairo_dock_get_theme_path (const gchar *cThemeName)  // a theme n
 	return cNewThemePath;
 }
 
-static gboolean _check_has_suffix_inv (const gchar *cFileName, gconstpointer data)
-{
-	return ! g_str_has_suffix (cFileName, (const char*)data);
-}
-
-static gboolean _copy_filter_conf (GFileInfo *pFileInfo, G_GNUC_UNUSED unsigned int depth, G_GNUC_UNUSED gconstpointer data)
-{
-	const gchar *cFileName = g_file_info_get_name (pFileInfo);
-	return g_str_has_suffix (cFileName, ".conf");
-}
-
 static gboolean _copy_filter_no_launchers (GFileInfo *pFileInfo, G_GNUC_UNUSED unsigned int depth, G_GNUC_UNUSED gconstpointer data)
 {
 	GFileType iFileType = g_file_info_get_file_type (pFileInfo);
@@ -477,22 +466,47 @@ static gboolean _copy_filter_no_launchers_conf (GFileInfo *pFileInfo, unsigned i
 	else return !g_str_has_suffix (cFileName, ".conf");
 }
 
+static gboolean _copy_filter_no_launcher_dir (GFileInfo *pFileInfo, unsigned int depth, G_GNUC_UNUSED gconstpointer data)
+{
+	GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+	const gchar *cFileName = g_file_info_get_name (pFileInfo);
+	
+	if (iFileType == G_FILE_TYPE_DIRECTORY && depth == 0)
+		return !!strcmp (cFileName, CAIRO_DOCK_LAUNCHERS_DIR); // exclude launcher directory only
+	return TRUE; // otherwise, copy everything
+}
+
 
 static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboolean bLoadBehavior, gboolean bLoadLaunchers)
 {
 	g_return_val_if_fail (cNewThemePath != NULL && g_file_test (cNewThemePath, G_FILE_TEST_EXISTS), FALSE);
 	
-	//\___________________ We load global behaviour parameters for each dock.
+	// Cleanup
+	// We always remove previous icons, otherwise we could end up with a mixed theme
+	cairo_dock_fm_empty_directory (g_cCurrentIconsPath, FALSE, NULL, NULL);
+	cairo_dock_fm_empty_directory (g_cCurrentImagesPath, FALSE, NULL, NULL);
+	
+	
+	//\___________________ We load behaviour parameters for each dock and plug-in.
 	GString *sCommand = g_string_new ("");
 	cd_message ("Applying changes ...");
 	if (g_pMainDock == NULL || bLoadBehavior)
 	{
-		cairo_dock_fm_empty_directory (g_cCurrentThemePath, FALSE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".conf");
-		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_conf, NULL); // only copy from main directory (no recursion)
+		// Simple case: we delete all config files (since there could be multiple docks / multiple plugin instances),
+		// and then copy everything (except launchers), overwriting any existing files
+		cairo_dock_fm_empty_directory (g_cCurrentThemePath, TRUE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".conf");
+		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_no_launcher_dir, NULL);
 	}
 	else
 	{
+		// More complicated case: we only merge .conf files, leaving the current configuration in place
+		
 		//!! TODO: we want to copy the style properties even in this case !!
+		
+		// We copy all files of the new theme except launchers and .conf files (dock and plug-ins).
+		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_no_launchers_conf, GINT_TO_POINTER(1));
+		
+		// We update docks' configuration
 		GDir *dir = g_dir_open (cNewThemePath, 0, NULL);
 		const gchar* cDockConfFile;
 		gchar *cThemeDockConfFile, *cUserDockConfFile;
@@ -515,61 +529,15 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 			}
 		}
 		g_dir_close (dir);
-	}
-	
-	//\___________________ We load icons
-	// We always remove previous icons, otherwise we could end up with a mixed theme
-	cairo_dock_fm_empty_directory (g_cCurrentIconsPath, FALSE, NULL, NULL);
-	cairo_dock_fm_empty_directory (g_cCurrentImagesPath, FALSE, NULL, NULL);
-	
-	gchar *cNewLocalIconsPath = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_ICONS_DIR);
-	if (! g_file_test (cNewLocalIconsPath, G_FILE_TEST_IS_DIR))  // it's an old theme: move icons to a new dir 'icons'.
-	{
-		g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
-		cairo_dock_fm_recursive_copy (sCommand->str, g_cCurrentIconsPath, _copy_filter_no_launchers, NULL);
-	}
-	else cairo_dock_fm_recursive_copy (cNewLocalIconsPath, g_cCurrentIconsPath, NULL, NULL);
-	
-	g_free (cNewLocalIconsPath);
-	
-	//\___________________ We load extras.
-	g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_EXTRAS_DIR);
-	if (g_file_test (sCommand->str, G_FILE_TEST_IS_DIR))
-		cairo_dock_fm_recursive_copy (sCommand->str, g_cExtrasDirPath, NULL, NULL);
-	
-	//\___________________ We load launcher if needed after having removed old ones.
-	if (! g_file_test (g_cCurrentLaunchersPath, G_FILE_TEST_EXISTS))
-		g_mkdir (g_cCurrentLaunchersPath, 7*8*8+7*8+5); //!! TODO: error checking?
-	
-	if (g_pMainDock == NULL || bLoadLaunchers)
-	{
-		cairo_dock_fm_empty_directory (g_cCurrentLaunchersPath, TRUE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".desktop");
-
-		g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
-		cairo_dock_fm_recursive_copy (sCommand->str, g_cCurrentLaunchersPath, _copy_filter_launchers, NULL);
-	}
-	
-	//\___________________ We replace all files by the new ones.
-	cairo_dock_fm_empty_directory (g_cCurrentThemePath, FALSE, _check_has_suffix_inv, ".conf");
-
-	if (g_pMainDock == NULL || bLoadBehavior)
-	{
-		// copy everything except conf files in the main dir (which were copied before) and launchers
-		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_no_launchers_conf, GINT_TO_POINTER(0));
-	}
-	else
-	{
-		// We copy all files of the new theme except launchers and .conf files (dock and plug-ins).
-		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_no_launchers_conf, GINT_TO_POINTER(1));
 		
 		// iterate all .conf files of all plug-ins, then update them and merge them with the current theme.
 		gchar *cNewPlugInsDir = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_PLUG_INS_DIR);  // dir of plug-ins of the new theme.
-		GDir *dir = g_dir_open (cNewPlugInsDir, 0, NULL);  // NULL if this theme doesn't have any 'plug-ins' dir.
+		dir = g_dir_open (cNewPlugInsDir, 0, NULL);  // NULL if this theme doesn't have any 'plug-ins' dir.
 		const gchar* cModuleDirName;
 		gchar *cConfFilePath, *cNewConfFilePath, *cUserDataDirPath, *cConfFileName;
 		do
 		{
-			cModuleDirName = g_dir_read_name (dir);  // name of the dir of the theme (maybe != of theme's name)
+			cModuleDirName = g_dir_read_name (dir);
 			if (cModuleDirName == NULL)
 				break ;
 			
@@ -618,6 +586,28 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 		while (1);
 		g_dir_close (dir);
 		g_free (cNewPlugInsDir);
+	}
+	
+	// Old themes: icons were part of launchers, move them to the icons dir
+	gchar *cNewLocalIconsPath = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_ICONS_DIR);
+	if (! g_file_test (cNewLocalIconsPath, G_FILE_TEST_IS_DIR))
+	{
+		g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
+		cairo_dock_fm_recursive_copy (sCommand->str, g_cCurrentIconsPath, _copy_filter_no_launchers, NULL);
+	}
+	g_free (cNewLocalIconsPath);
+	
+	
+	//\___________________ We load launcher if needed after having removed old ones.
+	if (! g_file_test (g_cCurrentLaunchersPath, G_FILE_TEST_EXISTS))
+		g_mkdir (g_cCurrentLaunchersPath, 7*8*8+7*8+5);
+	
+	if (g_pMainDock == NULL || bLoadLaunchers)
+	{
+		cairo_dock_fm_empty_directory (g_cCurrentLaunchersPath, TRUE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".desktop");
+
+		g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
+		cairo_dock_fm_recursive_copy (sCommand->str, g_cCurrentLaunchersPath, _copy_filter_launchers, NULL);
 	}
 	
 	g_string_printf (sCommand, "%s/last-modif", g_cCurrentThemePath);

--- a/src/gldit/cairo-dock-themes-manager.c
+++ b/src/gldit/cairo-dock-themes-manager.c
@@ -173,6 +173,16 @@ gchar *cairo_dock_write_keys_to_new_conf_file (GKeyFile *pKeyFile, const gchar *
 	return ret;
 }
 
+static gboolean _copy_exclude_launchers_config (GFileInfo *pFileInfo, unsigned int depth, G_GNUC_UNUSED gconstpointer data)
+{
+	GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+	const gchar *cFileName = g_file_info_get_name (pFileInfo);
+	
+	if (depth) return TRUE; // if we are not in the main directory, copy everything
+	if (iFileType == G_FILE_TYPE_DIRECTORY)
+		return !!strcmp (cFileName, CAIRO_DOCK_LAUNCHERS_DIR); // exclude launcher directory only
+	else return !!strcmp (cFileName, CAIRO_DOCK_CONF_FILE);
+}
 
 gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean bSaveBehavior, gboolean bSaveLaunchers)
 {
@@ -182,14 +192,10 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 	
 	cairo_dock_extract_package_type_from_name (cNewThemeNameWithoutSlashes);
 
-	gchar *cNewThemeNameEscaped = g_strescape (cNewThemeNameWithoutSlashes, NULL);
-
 	cd_message ("we save in %s", cNewThemeNameWithoutSlashes);
-	GString *sCommand = g_string_new ("");
+	GString *sTmpPath = g_string_new (NULL);
 	gboolean bThemeSaved = FALSE;
-	int r;
 	gchar *cNewThemePath = g_strdup_printf ("%s/%s", g_cThemesDirPath, cNewThemeNameWithoutSlashes);
-	gchar *cNewThemePathEscaped = g_strdup_printf ("%s/%s", g_cThemesDirPath, cNewThemeNameEscaped);
 	if (g_file_test (cNewThemePath, G_FILE_TEST_EXISTS))  // on ecrase un theme existant.
 	{
 		cd_debug ("  This theme will be updated");
@@ -219,29 +225,17 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 			//\___________________ On traite les lanceurs.
 			if (bSaveLaunchers)
 			{
-				g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
-				cairo_dock_fm_empty_directory (sCommand->str, TRUE, NULL, NULL); // TRUE <-> recursive, although there should not be subdirectories
+				g_string_printf (sTmpPath, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
+				cairo_dock_fm_empty_directory (sTmpPath->str, TRUE, NULL, NULL); // TRUE <-> recursive, although there should not be subdirectories
 
-/*				cd_message ("%s", sCommand->str);
-				r = system (sCommand->str);
-				if (r < 0)
-					cd_warning ("Not able to launch this command: %s", sCommand->str); */
-				
-				g_string_printf (sCommand, "cp \"%s\"/* \"%s/%s\"", g_cCurrentLaunchersPath, cNewThemePathEscaped, CAIRO_DOCK_LAUNCHERS_DIR);
-				cd_message ("%s", sCommand->str);
-				r = system (sCommand->str);
-				if (r < 0)
-					cd_warning ("Not able to launch this command: %s", sCommand->str);
+				g_string_printf (sTmpPath, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
+				cairo_dock_fm_recursive_copy (g_cCurrentLaunchersPath, sTmpPath->str, NULL, NULL);
 			}
 			
 			//\___________________ On traite tous le reste.
 			/// TODO : traiter les .conf des applets comme celui du dock...
-			g_string_printf (sCommand, "find \"%s\" -mindepth 1 -maxdepth 1  ! -name '%s' ! -name \"%s\" -exec cp -r '{}' \"%s\" \\;", g_cCurrentThemePath, CAIRO_DOCK_CONF_FILE, CAIRO_DOCK_LAUNCHERS_DIR, cNewThemePathEscaped);
-			cd_message ("%s", sCommand->str);
-			r = system (sCommand->str);
-			if (r < 0)
-				cd_warning ("Not able to launch this command: %s", sCommand->str);
-
+			cairo_dock_fm_recursive_copy (g_cCurrentThemePath, cNewThemePath, _copy_exclude_launchers_config, NULL);
+			
 			bThemeSaved = TRUE;
 		}
 	}
@@ -251,19 +245,14 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 
 		if (g_mkdir (cNewThemePath, 7*8*8+7*8+5) == 0)
 		{
-			g_string_printf (sCommand, "cp -r \"%s\"/* \"%s\"", g_cCurrentThemePath, cNewThemePathEscaped);
-			cd_message ("%s", sCommand->str);
-			r = system (sCommand->str);
-			if (r < 0)
-				cd_warning ("Not able to launch this command: %s", sCommand->str);
-
+			cairo_dock_fm_recursive_copy (g_cCurrentThemePath, cNewThemePath, NULL, NULL);
+			
 			bThemeSaved = TRUE;
 		}
 		else
 			cd_warning ("couldn't create %s", cNewThemePath);
 	}
 
-	g_free (cNewThemeNameEscaped);
 	g_free (cNewThemeNameWithoutSlashes);
 
 	//\___________________ On conserve la date de derniere modif.
@@ -281,8 +270,8 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 	g_free (cReadmeFile);
 	g_free (cMessage);
 	
-	g_string_printf (sCommand, "%s/last-modif", cNewThemePath);
-	cairo_dock_fm_delete_file (sCommand->str, TRUE);
+	g_string_printf (sTmpPath, "%s/last-modif", cNewThemePath);
+	cairo_dock_fm_delete_file (sTmpPath->str, TRUE);
 	
 	//\___________________ make a preview of the current main dock.
 	gchar *cPreviewPath = g_strdup_printf ("%s/preview", cNewThemePath);
@@ -291,13 +280,12 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 	
 	//\___________________ Le theme n'est plus en etat 'modifie'.
 	g_free (cNewThemePath);
-	g_free (cNewThemePathEscaped);
 	if (bThemeSaved)
 	{
 		cairo_dock_mark_current_theme_as_modified (FALSE);
 	}
 	
-	g_string_free (sCommand, TRUE);
+	g_string_free (sTmpPath, TRUE);
 	
 	return bThemeSaved;
 }
@@ -466,6 +454,38 @@ static gboolean _check_has_suffix_inv (const gchar *cFileName, gconstpointer dat
 	return ! g_str_has_suffix (cFileName, (const char*)data);
 }
 
+static gboolean _copy_filter_conf (GFileInfo *pFileInfo, G_GNUC_UNUSED unsigned int depth, G_GNUC_UNUSED gconstpointer data)
+{
+	const gchar *cFileName = g_file_info_get_name (pFileInfo);
+	return g_str_has_suffix (cFileName, ".conf");
+}
+
+static gboolean _copy_filter_no_launchers (GFileInfo *pFileInfo, G_GNUC_UNUSED unsigned int depth, G_GNUC_UNUSED gconstpointer data)
+{
+	GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+	const gchar *cFileName = g_file_info_get_name (pFileInfo);
+	return (iFileType == G_FILE_TYPE_DIRECTORY) || !g_str_has_suffix (cFileName, ".desktop");
+}
+
+static gboolean _copy_filter_launchers (GFileInfo *pFileInfo, G_GNUC_UNUSED unsigned int depth, G_GNUC_UNUSED gconstpointer data)
+{
+	const gchar *cFileName = g_file_info_get_name (pFileInfo);
+	return g_str_has_suffix (cFileName, ".desktop");
+}
+
+static gboolean _copy_filter_no_launchers_conf (GFileInfo *pFileInfo, unsigned int depth, gconstpointer data)
+{
+	int recursive_exclude_conf = GPOINTER_TO_INT(data);
+	GFileType iFileType = g_file_info_get_file_type (pFileInfo);
+	const gchar *cFileName = g_file_info_get_name (pFileInfo);
+	
+	if (depth && !recursive_exclude_conf) return TRUE; // if we are not in the main directory, copy everything except potentially config files
+	if (iFileType == G_FILE_TYPE_DIRECTORY)
+		return !!strcmp (cFileName, CAIRO_DOCK_LAUNCHERS_DIR); // exclude launcher directory only
+	else return !g_str_has_suffix (cFileName, ".conf");
+}
+
+
 static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboolean bLoadBehavior, gboolean bLoadLaunchers)
 {
 	g_return_val_if_fail (cNewThemePath != NULL && g_file_test (cNewThemePath, G_FILE_TEST_EXISTS), FALSE);
@@ -476,9 +496,7 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	if (g_pMainDock == NULL || bLoadBehavior)
 	{
 		cairo_dock_fm_empty_directory (g_cCurrentThemePath, FALSE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".conf");
-
-		g_string_printf (sCommand, "cp \"%s\"/*.conf \"%s\"", cNewThemePath, g_cCurrentThemePath);
-		_launch_cmd (sCommand->str);
+		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_conf, NULL); // only copy from main directory (no recursion)
 	}
 	else
 	{
@@ -515,38 +533,35 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	gchar *cNewLocalIconsPath = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_ICONS_DIR);
 	if (! g_file_test (cNewLocalIconsPath, G_FILE_TEST_IS_DIR))  // it's an old theme: move icons to a new dir 'icons'.
 	{
-		g_string_printf (sCommand, "find \"%s/%s\" -mindepth 1 ! -name '*.desktop' -exec cp '{}' '%s' \\;", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentIconsPath);
+		g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
+		cairo_dock_fm_recursive_copy (sCommand->str, g_cCurrentIconsPath, _copy_filter_no_launchers, NULL);
 	}
 	else
 	{
+		//!! TODO: match icons with the same base filename !!
 		g_string_printf (sCommand, "for f in \"%s\"/* ; do rm -f \"%s/`basename \"${f%%.*}\"`\"*; done;", cNewLocalIconsPath, g_cCurrentIconsPath);  // we erase double items because we could have x.png and x.svg and the dock will not know which it has to use.
 		_launch_cmd (sCommand->str);
 		
-		g_string_printf (sCommand, "cp \"%s\"/* \"%s\"", cNewLocalIconsPath, g_cCurrentIconsPath);
+		cairo_dock_fm_recursive_copy (cNewLocalIconsPath, g_cCurrentIconsPath, NULL, NULL);
 	}
-	_launch_cmd (sCommand->str);
+	
 	g_free (cNewLocalIconsPath);
 	
 	//\___________________ We load extras.
 	g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_EXTRAS_DIR);
 	if (g_file_test (sCommand->str, G_FILE_TEST_IS_DIR))
-	{
-		g_string_printf (sCommand, "cp -r \"%s/%s\"/* \"%s\"", cNewThemePath, CAIRO_DOCK_LOCAL_EXTRAS_DIR, g_cExtrasDirPath);
-		_launch_cmd (sCommand->str);
-	}
+		cairo_dock_fm_recursive_copy (sCommand->str, g_cExtrasDirPath, NULL, NULL);
 	
 	//\___________________ We load launcher if needed after having removed old ones.
 	if (! g_file_test (g_cCurrentLaunchersPath, G_FILE_TEST_EXISTS))
-	{
-		g_string_printf (sCommand, "mkdir -p \"%s\"", g_cCurrentLaunchersPath);
-		_launch_cmd (sCommand->str);
-	}
+		g_mkdir (g_cCurrentLaunchersPath, 7*8*8+7*8+5); //!! TODO: error checking?
+	
 	if (g_pMainDock == NULL || bLoadLaunchers)
 	{
 		cairo_dock_fm_empty_directory (g_cCurrentLaunchersPath, TRUE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".desktop");
 
-		g_string_printf (sCommand, "cp \"%s/%s\"/*.desktop \"%s\"", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentLaunchersPath);
-		_launch_cmd (sCommand->str);
+		g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
+		cairo_dock_fm_recursive_copy (sCommand->str, g_cCurrentLaunchersPath, _copy_filter_launchers, NULL);
 	}
 	
 	//\___________________ We replace all files by the new ones.
@@ -554,14 +569,13 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 
 	if (g_pMainDock == NULL || bLoadBehavior)
 	{
-		g_string_printf (sCommand, "find \"%s\"/* -prune ! -name '*.conf' ! -name %s -exec cp -r '{}' \"%s\" \\;", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentThemePath);  // Copy all files of the new theme except launchers and .conf files in the dir of the current theme. Overwrite files with same names
-		_launch_cmd (sCommand->str);
+		// copy everything except conf files in the main dir (which were copied before) and launchers
+		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_no_launchers_conf, GINT_TO_POINTER(0));
 	}
 	else
 	{
 		// We copy all files of the new theme except launchers and .conf files (dock and plug-ins).
-		g_string_printf (sCommand, "find \"%s\" -mindepth 1 ! -name '*.conf' ! -path '%s/%s*' ! -type d -exec cp -p {} \"%s\" \\;", cNewThemePath, cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentThemePath);
-		_launch_cmd (sCommand->str);
+		cairo_dock_fm_recursive_copy (cNewThemePath, g_cCurrentThemePath, _copy_filter_no_launchers_conf, GINT_TO_POINTER(1));
 		
 		// iterate all .conf files of all plug-ins, then update them and merge them with the current theme.
 		gchar *cNewPlugInsDir = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_PLUG_INS_DIR);  // dir of plug-ins of the new theme.
@@ -580,9 +594,7 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 			if (! g_file_test (cUserDataDirPath, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
 			{
 				cd_debug ("    directory %s doesn't exist, it will be created.", cUserDataDirPath);
-				
-				g_string_printf (sCommand, "mkdir -p \"%s\"", cUserDataDirPath);
-				_launch_cmd (sCommand->str);
+				g_mkdir (cUserDataDirPath, 7*8*8+7*8+5);
 			}
 			
 			// we find the name and path of the .conf file of the plugin in the new theme.
@@ -625,10 +637,6 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	
 	g_string_printf (sCommand, "%s/last-modif", g_cCurrentThemePath);
 	cairo_dock_fm_delete_file (sCommand->str, TRUE);
-	
-	// precaution maybe useless.
-	g_string_printf (sCommand, "chmod -R 775 \"%s\"", g_cCurrentThemePath);
-	_launch_cmd (sCommand->str);
 	
 	cairo_dock_mark_current_theme_as_modified (FALSE);
 	

--- a/src/gldit/cairo-dock-themes-manager.c
+++ b/src/gldit/cairo-dock-themes-manager.c
@@ -219,11 +219,13 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 			//\___________________ On traite les lanceurs.
 			if (bSaveLaunchers)
 			{
-				g_string_printf (sCommand, "rm -f \"%s/%s\"/*", cNewThemePathEscaped, CAIRO_DOCK_LAUNCHERS_DIR);
-				cd_message ("%s", sCommand->str);
+				g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
+				cairo_dock_fm_empty_directory (sCommand->str, TRUE, NULL, NULL); // TRUE <-> recursive, although there should not be subdirectories
+
+/*				cd_message ("%s", sCommand->str);
 				r = system (sCommand->str);
 				if (r < 0)
-					cd_warning ("Not able to launch this command: %s", sCommand->str);
+					cd_warning ("Not able to launch this command: %s", sCommand->str); */
 				
 				g_string_printf (sCommand, "cp \"%s\"/* \"%s/%s\"", g_cCurrentLaunchersPath, cNewThemePathEscaped, CAIRO_DOCK_LAUNCHERS_DIR);
 				cd_message ("%s", sCommand->str);
@@ -279,8 +281,8 @@ gboolean cairo_dock_export_current_theme (const gchar *cNewThemeName, gboolean b
 	g_free (cReadmeFile);
 	g_free (cMessage);
 	
-	g_string_printf (sCommand, "rm -f \"%s/last-modif\"", cNewThemePathEscaped);
-	r = system (sCommand->str);
+	g_string_printf (sCommand, "%s/last-modif", cNewThemePath);
+	cairo_dock_fm_delete_file (sCommand->str, TRUE);
 	
 	//\___________________ make a preview of the current main dock.
 	gchar *cPreviewPath = g_strdup_printf ("%s/preview", cNewThemePath);
@@ -396,7 +398,7 @@ gboolean cairo_dock_delete_themes (gchar **cThemesList)
 	if (iClickedButton == 0 || iClickedButton == -1)  // ok button or Enter.
 	{
 		gchar *cThemeName;
-		int i, r;
+		int i;
 		for (i = 0; cThemesList[i] != NULL; i ++)
 		{
 			cThemeName = _escape_string_for_filename (cThemesList[i]);
@@ -408,10 +410,8 @@ gboolean cairo_dock_delete_themes (gchar **cThemesList)
 			cairo_dock_extract_package_type_from_name (cThemeName);
 			
 			bThemeDeleted = TRUE;
-			g_string_printf (sCommand, "rm -rf \"%s/%s\"", g_cThemesDirPath, cThemeName);
-			r = system (sCommand->str);  // g_rmdir only delete an empty dir...
-			if (r < 0)
-				cd_warning ("Not able to launch this command: %s", sCommand->str);
+			g_string_printf (sCommand, "%s/%s", g_cThemesDirPath, cThemeName);
+			cairo_dock_fm_delete_file (sCommand->str, TRUE);
 			g_free (cThemeName);
 		}
 	}
@@ -461,6 +461,11 @@ static void _launch_cmd (const gchar *cCommand)
 		cd_warning ("Not able to launch this command: %s", cCommand);
 }
 
+static gboolean _check_has_suffix_inv (const gchar *cFileName, gconstpointer data)
+{
+	return ! g_str_has_suffix (cFileName, (const char*)data);
+}
+
 static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboolean bLoadBehavior, gboolean bLoadLaunchers)
 {
 	g_return_val_if_fail (cNewThemePath != NULL && g_file_test (cNewThemePath, G_FILE_TEST_EXISTS), FALSE);
@@ -470,8 +475,7 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	cd_message ("Applying changes ...");
 	if (g_pMainDock == NULL || bLoadBehavior)
 	{
-		g_string_printf (sCommand, "rm -f \"%s\"/*.conf", g_cCurrentThemePath);
-		_launch_cmd (sCommand->str);
+		cairo_dock_fm_empty_directory (g_cCurrentThemePath, FALSE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".conf");
 
 		g_string_printf (sCommand, "cp \"%s\"/*.conf \"%s\"", cNewThemePath, g_cCurrentThemePath);
 		_launch_cmd (sCommand->str);
@@ -505,15 +509,8 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	//\___________________ We load icons
 	if (bLoadLaunchers)
 	{
-		g_string_printf (sCommand, "rm -f \"%s\"/*", g_cCurrentIconsPath);
-		_launch_cmd (sCommand->str);
-		g_string_printf (sCommand, "rm -f \"%s\"/.*", g_cCurrentIconsPath);
-		_launch_cmd (sCommand->str);
-		
-		g_string_printf (sCommand, "rm -f \"%s\"/*", g_cCurrentImagesPath);
-		_launch_cmd (sCommand->str);
-		g_string_printf (sCommand, "rm -f \"%s\"/.*", g_cCurrentImagesPath);
-		_launch_cmd (sCommand->str);
+		cairo_dock_fm_empty_directory (g_cCurrentIconsPath, FALSE, NULL, NULL);
+		cairo_dock_fm_empty_directory (g_cCurrentImagesPath, FALSE, NULL, NULL);
 	}
 	gchar *cNewLocalIconsPath = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_ICONS_DIR);
 	if (! g_file_test (cNewLocalIconsPath, G_FILE_TEST_IS_DIR))  // it's an old theme: move icons to a new dir 'icons'.
@@ -546,16 +543,14 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	}
 	if (g_pMainDock == NULL || bLoadLaunchers)
 	{
-		g_string_printf (sCommand, "rm -f \"%s\"/*.desktop", g_cCurrentLaunchersPath);
-		_launch_cmd (sCommand->str);
+		cairo_dock_fm_empty_directory (g_cCurrentLaunchersPath, TRUE, (CairoDockFMDirectoryFilterFunc)g_str_has_suffix, ".desktop");
 
 		g_string_printf (sCommand, "cp \"%s/%s\"/*.desktop \"%s\"", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR, g_cCurrentLaunchersPath);
 		_launch_cmd (sCommand->str);
 	}
 	
 	//\___________________ We replace all files by the new ones.
-	g_string_printf (sCommand, "find \"%s\" -mindepth 1 -maxdepth 1  ! -name '*.conf' -type f -exec rm -f '{}' \\;", g_cCurrentThemePath);  // remove all ficher of the theme except launchers and plugins.
-	_launch_cmd (sCommand->str);
+	cairo_dock_fm_empty_directory (g_cCurrentThemePath, FALSE, _check_has_suffix_inv, ".conf");
 
 	if (g_pMainDock == NULL || bLoadBehavior)
 	{
@@ -628,8 +623,8 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 		g_free (cNewPlugInsDir);
 	}
 	
-	g_string_printf (sCommand, "rm -f \"%s/last-modif\"", g_cCurrentThemePath);
-	_launch_cmd (sCommand->str);
+	g_string_printf (sCommand, "%s/last-modif", g_cCurrentThemePath);
+	cairo_dock_fm_delete_file (sCommand->str, TRUE);
 	
 	// precaution maybe useless.
 	g_string_printf (sCommand, "chmod -R 775 \"%s\"", g_cCurrentThemePath);

--- a/src/gldit/cairo-dock-themes-manager.c
+++ b/src/gldit/cairo-dock-themes-manager.c
@@ -441,14 +441,6 @@ static gchar *_cairo_dock_get_theme_path (const gchar *cThemeName)  // a theme n
 	return cNewThemePath;
 }
 
-static void _launch_cmd (const gchar *cCommand)
-{
-	cd_debug ("%s", cCommand);
-	int r = system (cCommand);
-	if (r < 0)
-		cd_warning ("Not able to launch this command: %s", cCommand);
-}
-
 static gboolean _check_has_suffix_inv (const gchar *cFileName, gconstpointer data)
 {
 	return ! g_str_has_suffix (cFileName, (const char*)data);
@@ -500,6 +492,7 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	}
 	else
 	{
+		//!! TODO: we want to copy the style properties even in this case !!
 		GDir *dir = g_dir_open (cNewThemePath, 0, NULL);
 		const gchar* cDockConfFile;
 		gchar *cThemeDockConfFile, *cUserDockConfFile;
@@ -525,25 +518,17 @@ static gboolean _cairo_dock_import_local_theme (const gchar *cNewThemePath, gboo
 	}
 	
 	//\___________________ We load icons
-	if (bLoadLaunchers)
-	{
-		cairo_dock_fm_empty_directory (g_cCurrentIconsPath, FALSE, NULL, NULL);
-		cairo_dock_fm_empty_directory (g_cCurrentImagesPath, FALSE, NULL, NULL);
-	}
+	// We always remove previous icons, otherwise we could end up with a mixed theme
+	cairo_dock_fm_empty_directory (g_cCurrentIconsPath, FALSE, NULL, NULL);
+	cairo_dock_fm_empty_directory (g_cCurrentImagesPath, FALSE, NULL, NULL);
+	
 	gchar *cNewLocalIconsPath = g_strdup_printf ("%s/%s", cNewThemePath, CAIRO_DOCK_LOCAL_ICONS_DIR);
 	if (! g_file_test (cNewLocalIconsPath, G_FILE_TEST_IS_DIR))  // it's an old theme: move icons to a new dir 'icons'.
 	{
 		g_string_printf (sCommand, "%s/%s", cNewThemePath, CAIRO_DOCK_LAUNCHERS_DIR);
 		cairo_dock_fm_recursive_copy (sCommand->str, g_cCurrentIconsPath, _copy_filter_no_launchers, NULL);
 	}
-	else
-	{
-		//!! TODO: match icons with the same base filename !!
-		g_string_printf (sCommand, "for f in \"%s\"/* ; do rm -f \"%s/`basename \"${f%%.*}\"`\"*; done;", cNewLocalIconsPath, g_cCurrentIconsPath);  // we erase double items because we could have x.png and x.svg and the dock will not know which it has to use.
-		_launch_cmd (sCommand->str);
-		
-		cairo_dock_fm_recursive_copy (cNewLocalIconsPath, g_cCurrentIconsPath, NULL, NULL);
-	}
+	else cairo_dock_fm_recursive_copy (cNewLocalIconsPath, g_cCurrentIconsPath, NULL, NULL);
 	
 	g_free (cNewLocalIconsPath);
 	

--- a/src/implementations/cairo-dock-gio-vfs.c
+++ b/src/implementations/cairo-dock-gio-vfs.c
@@ -40,8 +40,6 @@
 
 extern GldiContainer *g_pPrimaryContainer;
 
-static void _cairo_dock_gio_vfs_empty_dir (const gchar *cBaseURI);
-
 static GHashTable *s_hMonitorHandleTable = NULL;
 
 static void _gio_vfs_free_monitor_data (gpointer *data)
@@ -1259,7 +1257,7 @@ static gboolean cairo_dock_gio_vfs_delete_file (const gchar *cURI, gboolean bNoT
 		GFileType iFileType = g_file_info_get_file_type (pFileInfo);
 		if (iFileType == G_FILE_TYPE_DIRECTORY)
 		{
-			_cairo_dock_gio_vfs_empty_dir (cURI);
+			cairo_dock_fm_empty_directory (cURI, TRUE, NULL, NULL);
 		}
 		
 		bSuccess = g_file_delete (pFile, NULL, &erreur);
@@ -1422,71 +1420,6 @@ static gchar *cairo_dock_gio_vfs_get_desktop_path (void)
 	return cPath;
 }
 
-static void _cairo_dock_gio_vfs_empty_dir (const gchar *cBaseURI)
-{
-	if (cBaseURI == NULL)
-		return ;
-	
-	GFile *pFile = (*cBaseURI == '/' ? g_file_new_for_path (cBaseURI) : g_file_new_for_uri (cBaseURI));
-	GError *erreur = NULL;
-	const gchar *cAttributes = G_FILE_ATTRIBUTE_STANDARD_TYPE","
-		G_FILE_ATTRIBUTE_STANDARD_NAME;
-	GFileEnumerator *pFileEnum = g_file_enumerate_children (pFile,
-		cAttributes,
-		G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-		NULL,
-		&erreur);
-	if (erreur != NULL)
-	{
-		cd_warning ("gvfs-integration : %s", erreur->message);
-		g_object_unref (pFile);
-		g_error_free (erreur);
-		return ;
-	}
-	
-	GString *sFileUri = g_string_new ("");
-	GFileInfo *pFileInfo;
-	GFile *file;
-	do
-	{
-		pFileInfo = g_file_enumerator_next_file (pFileEnum, NULL, &erreur);
-		if (erreur != NULL)
-		{
-			cd_warning ("gvfs-integration : %s", erreur->message);
-			g_error_free (erreur);
-			erreur = NULL;
-			continue;
-		}
-		if (pFileInfo == NULL)
-			break ;
-		
-		GFileType iFileType = g_file_info_get_file_type (pFileInfo);
-		const gchar *cFileName = g_file_info_get_name (pFileInfo);
-		
-		g_string_printf (sFileUri, "%s/%s", cBaseURI, cFileName);
-		if (iFileType == G_FILE_TYPE_DIRECTORY)
-		{
-			_cairo_dock_gio_vfs_empty_dir (sFileUri->str);
-		}
-		
-		file = (*cBaseURI == '/' ? g_file_new_for_path (sFileUri->str) : g_file_new_for_uri (sFileUri->str));
-		g_file_delete (file, NULL, &erreur);
-		if (erreur != NULL)
-		{
-			cd_warning ("gvfs-integration : %s", erreur->message);
-			g_error_free (erreur);
-			erreur = NULL;
-		}
-		g_object_unref (file);
-		
-		g_object_unref (pFileInfo);
-	} while (1);
-	
-	g_string_free (sFileUri, TRUE);
-	g_object_unref (pFileEnum);
-	g_object_unref (pFile);
-}
-
 static inline int _convert_base16 (char c)
 {
 	int x;
@@ -1550,7 +1483,7 @@ static void cairo_dock_gio_vfs_empty_trash (void)
 			GFileType iFileType = g_file_info_get_file_type (pFileInfo);
 			if (iFileType == G_FILE_TYPE_DIRECTORY)  // can't delete a non-empty folder located on a different volume than home.
 			{
-				_cairo_dock_gio_vfs_empty_dir (sFileUri->str);
+				cairo_dock_fm_empty_directory (sFileUri->str, TRUE, NULL, NULL);
 			}
 			GFile *file = g_file_new_for_uri (sFileUri->str);
 			g_file_delete (file, NULL, &erreur);

--- a/src/implementations/cairo-dock-gio-vfs.c
+++ b/src/implementations/cairo-dock-gio-vfs.c
@@ -1231,50 +1231,17 @@ static void cairo_dock_gio_vfs_remove_monitor (const gchar *cURI)
 
 
 
-static gboolean cairo_dock_gio_vfs_delete_file (const gchar *cURI, gboolean bNoTrash)
+static gboolean cairo_dock_gio_vfs_delete_file (const gchar *cURI, G_GNUC_UNUSED gboolean bNoTrash)
 {
-	g_return_val_if_fail (cURI != NULL, FALSE);
+	// note: bNoTrash == TRUE always
 	GFile *pFile = (*cURI == '/' ? g_file_new_for_path (cURI) : g_file_new_for_uri (cURI));
 	
 	GError *erreur = NULL;
-	gboolean bSuccess;
-	if (bNoTrash)
+	gboolean bSuccess = g_file_trash (pFile, NULL, &erreur);
+	if (erreur != NULL)
 	{
-		const gchar *cQuery = G_FILE_ATTRIBUTE_STANDARD_TYPE;
-		GFileInfo *pFileInfo = g_file_query_info (pFile,
-			cQuery,
-			G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-			NULL,
-			&erreur);
-		if (erreur != NULL)
-		{
-			cd_warning ("gvfs-integration : %s", erreur->message);
-			g_error_free (erreur);
-			g_object_unref (pFile);
-			return FALSE;
-		}
-		
-		GFileType iFileType = g_file_info_get_file_type (pFileInfo);
-		if (iFileType == G_FILE_TYPE_DIRECTORY)
-		{
-			cairo_dock_fm_empty_directory (cURI, TRUE, NULL, NULL);
-		}
-		
-		bSuccess = g_file_delete (pFile, NULL, &erreur);
-		if (erreur != NULL)
-		{
-			cd_warning ("gvfs-integration : %s", erreur->message);
-			g_error_free (erreur);
-		}
-	}
-	else
-	{
-		bSuccess = g_file_trash (pFile, NULL, &erreur);
-		if (erreur != NULL)
-		{
-			cd_warning ("gvfs-integration : %s", erreur->message);
-			g_error_free (erreur);
-		}
+		cd_warning ("gvfs-integration : %s", erreur->message);
+		g_error_free (erreur);
 	}
 	g_object_unref (pFile);
 	return bSuccess;


### PR DESCRIPTION
Replace the use of `system()` with a combination of `cp`, `rm`, `find`, `tar`, etc. with internal functions that traverse directories using Gio (it was already implemented for `rm`, but not used that much). This will hopefully help avoid bugs and vulnerabilities related to running shell commands.

Additional smaller change: make loading new themes more consistent by always discarding existing icons (the idea of themes is to have a consistent set of icons, so it is not good to end up with a mix; users are prompted to save their current theme before changing in any case).