### PR TITLE
Also try to match apps based on their GTK application ID

### DIFF
--- a/src/gldit/cairo-dock-class-manager.c
+++ b/src/gldit/cairo-dock-class-manager.c
@@ -93,7 +93,7 @@ typedef struct _CairoDockClassAppli CairoDockClassAppli;
 static GHashTable *s_hClassTable = NULL;
 static GHashTable *s_hAltClass = NULL; // we store alternative class / app-ids here
 
-static gchar *_cairo_dock_register_class_full (const gchar *cSearchTerm, const gchar *cFallbackClass, const gchar *cWmClass,
+static gchar *_cairo_dock_register_class_full (const gchar *cSearchTerm, const gchar * const *cFallbackClass, const gchar *cWmClass,
 	gboolean bUseWmClass, gboolean bCreateAlways, gboolean bIsDesktopFile, GDesktopAppInfo *app, CairoDockClassAppli **pResult);
 
 static void _cairo_dock_free_class_appli (CairoDockClassAppli *pClassAppli)
@@ -1047,10 +1047,34 @@ gboolean cairo_dock_add_appli_icon_to_class (Icon *pIcon)
 		 *     some apps do otherwise, e.g. exfalso sets
 		 * WM_CLASS(STRING) = "io.github.quodlibet.ExFalso", "Exfalso"
 		 * (where the first string is wm_name and corresponds to the correct desktop file ID)
+		 * (4) we use the application-id of apps based on GtkApplication
+		 *     this is provided by:
+		 *       -- the _GTK_APPLICATION_ID property on X11 windows
+		 *       -- via the gtk-shell protocol on Wayland, currently only
+		 *          relayed by Wayfire as part of the app-id if the
+		 *          "workarounds.app_id_mode = full" setting is set
 		 */
-		char *cClass = _cairo_dock_register_class_full (pIcon->cClass, pIcon->pAppli->cWmName,
+		const char *cFallbackClass[] = {NULL, NULL, NULL};
+		int i = 0;
+		
+		// GTK app-id, needs to be converted to lower case
+		char *cGTKAppID = NULL;
+		if (pIcon->pAppli->pDBusProps && pIcon->pAppli->pDBusProps->cGTKAppID)
+			cGTKAppID = g_ascii_strdown (pIcon->pAppli->pDBusProps->cGTKAppID, -1);
+		if (cGTKAppID) {
+			cFallbackClass[i] = cGTKAppID;
+			i++;
+		}
+		
+		// res_name property, already converted to lower case in X-utilities
+		if (pIcon->pAppli->cWmName) {
+			cFallbackClass[i] = pIcon->pAppli->cWmName;
+			i++;
+		}
+		char *cClass = _cairo_dock_register_class_full (pIcon->cClass, cFallbackClass,
 			pIcon->pAppli->cWmClass, FALSE, TRUE, FALSE, NULL, &pClassAppli);
-		if (cClass) g_free (cClass);
+		g_free (cGTKAppID);
+		g_free (cClass);
 		if (!pClassAppli) return FALSE; // should not happen
 	}
 
@@ -2790,7 +2814,7 @@ gchar *cairo_dock_guess_class (const gchar *cCommand, const gchar *cStartupWMCla
 * is registered and (a copy of) cClassName is returned. Also, if an app is found, cClassName is always
 * added as a key (so if cClassName != NULL, the return value is always a copy of it).
 */
-static gchar *_cairo_dock_register_class_full (const gchar *cSearchTerm, const gchar *cFallbackClass, const gchar *cWmClass,
+static gchar *_cairo_dock_register_class_full (const gchar *cSearchTerm, const gchar * const *cFallbackClass, const gchar *cWmClass,
 	gboolean bUseWmClass, gboolean bCreateAlways, gboolean bIsDesktopFile, GDesktopAppInfo *app, CairoDockClassAppli **pResult)
 {
 	g_return_val_if_fail ((cSearchTerm || app), NULL);
@@ -2809,13 +2833,18 @@ static gchar *_cairo_dock_register_class_full (const gchar *cSearchTerm, const g
 	pClassAppli = _cairo_dock_lookup_class_appli (cSearchTerm);
 	if (!pClassAppli && cFallbackClass)
 	{
-		pClassAppli = _cairo_dock_lookup_class_appli (cFallbackClass);
-		if (pClassAppli)
+		int i;
+		for (i = 0; cFallbackClass[i]; i++)
 		{
-			// save the original class key as well (takes ownership of cClass)
-			g_hash_table_insert (s_hAltClass, g_strdup (cSearchTerm), pClassAppli);
-			// adjust the return value (for line 2114)
-			cClass = g_strdup (cFallbackClass);
+			pClassAppli = _cairo_dock_lookup_class_appli (cFallbackClass[i]);
+			if (pClassAppli)
+			{
+				// save the original class key as well (takes ownership of cClass)
+				g_hash_table_insert (s_hAltClass, g_strdup (cSearchTerm), pClassAppli);
+				// adjust the return value (for line 2114)
+				cClass = g_strdup (cFallbackClass[i]);
+				break;
+			}
 		}
 	}
 
@@ -2844,22 +2873,23 @@ static gchar *_cairo_dock_register_class_full (const gchar *cSearchTerm, const g
 	if (app) g_object_ref (app); // will be unrefed later
 
 	//\__________________ search the desktop file's path.
-	if (!app && cFallbackClass)
+	if (!app && cFallbackClass && *cFallbackClass)
 	{
 		// in this case, we do a two-stage search: first we try exact matches, then using heuristics
 		// this is to avoid edge cases where cFallbackClass would be an exact match
 		app = _search_desktop_file (cSearchTerm, TRUE, bIsDesktopFile);
-		if (!app)
+		
+		int i;
+		for (i = 0; !app && cFallbackClass[i]; i++)
+			app = _search_desktop_file (cFallbackClass[i], TRUE, FALSE);
+		
+		if (!app && cWmClass)
 		{
-			app = _search_desktop_file (cFallbackClass, TRUE, FALSE);
-			if (!app && cWmClass)
-			{
-				// note: cWmClass can contain upper-case characters, but we only
-				// store lower-case versions
-				gchar *tmp = g_ascii_strdown (cWmClass, -1);
-				app = _search_desktop_file (tmp, TRUE, FALSE);
-				g_free (tmp);
-			}
+			// note: cWmClass can contain upper-case characters, but we only
+			// store lower-case versions
+			gchar *tmp = g_ascii_strdown (cWmClass, -1);
+			app = _search_desktop_file (tmp, TRUE, FALSE);
+			g_free (tmp);
 		}
 	}
 	
@@ -2868,19 +2898,17 @@ static gchar *_cairo_dock_register_class_full (const gchar *cSearchTerm, const g
 		//!! TODO: maybe we should not allow heuristics for .desktop file names?
 		/// (e.g. should "terminal.desktop" match "org.gnome.Terminal.desktop" ?)
 		app = _search_desktop_file (cSearchTerm, FALSE, bIsDesktopFile);
-		if (!app)
+		
+		int i;
+		if (cFallbackClass) for (i = 0; !app && cFallbackClass[i]; i++)
+			app = _search_desktop_file (cFallbackClass[i], FALSE, FALSE);
+		
+		if (!app && cWmClass && !((cFallbackClass && *cFallbackClass)))
 		{
-			if (cFallbackClass)
-			{
-				app = _search_desktop_file (cFallbackClass, FALSE, FALSE);
-			}
-			else if (cWmClass)
-			{
-				// if cFallbackClass != NULL, we did this search already above
-				gchar *tmp = g_ascii_strdown (cWmClass, -1); // note: will already be lowercase if read from a launcher
-				app = _search_desktop_file (tmp, TRUE, FALSE);
-				g_free (tmp);
-			}
+			// if cFallbackClass != NULL, we did this search already above
+			gchar *tmp = g_ascii_strdown (cWmClass, -1); // note: will already be lowercase if read from a launcher
+			app = _search_desktop_file (tmp, TRUE, FALSE);
+			g_free (tmp);
 		}
 	}
 	

--- a/src/gldit/cairo-dock-windows-manager.c
+++ b/src/gldit/cairo-dock-windows-manager.c
@@ -529,6 +529,7 @@ static void reset_object (GldiObject *obj)
 		g_free (actor->pDBusProps->cGTKAppPath);
 		g_free (actor->pDBusProps->cKDEServiceName);
 		g_free (actor->pDBusProps->cKDEObjectPath);
+		g_free (actor->pDBusProps->cGTKAppID);
 		g_free (actor->pDBusProps);
 	}
 }

--- a/src/gldit/cairo-dock-windows-manager.h
+++ b/src/gldit/cairo-dock-windows-manager.h
@@ -65,6 +65,9 @@ typedef struct _DBusProps {
 	// Windows that support the com.canonical.dbusmenu interface
 	gchar *cKDEServiceName; // DBus name 
 	gchar *cKDEObjectPath; // object path
+	
+	// Additional info
+	gchar *cGTKAppID; // application-id for GTK apps
 } GldiWindowDBusProperties;
 
 /// Definition of a window actor.

--- a/src/implementations/cairo-dock-X-manager.c
+++ b/src/implementations/cairo-dock-X-manager.c
@@ -110,6 +110,7 @@ static Atom s_aGTKMenuBarPath;
 static Atom s_aGTKWindowPath;
 static Atom s_aGTKAppPath;
 static Atom s_aGTKDBusName;
+static Atom s_aGTKAppID;
 static GHashTable *s_hXWindowTable = NULL;  // table of (Xid,actor)
 static GHashTable *s_hXClientMessageTable = NULL;  // table of (Xid,client-message)
 static int s_iTime = 1;  // on peut aller jusqu'a 2^31, soit 17 ans a 4Hz.
@@ -220,6 +221,14 @@ static GldiXWindowActor *_make_new_actor (Window Xid)
 			actor->pDBusProps->cGTKWindowPath = window_path;
 			actor->pDBusProps->cGTKMenuBarPath = menu_path;
 			actor->pDBusProps->cGTKBusName = name;
+		}
+		
+		// GTK app-id
+		gchar *app_id = cairo_dock_get_xwindow_string_prop (Xid, s_aGTKAppID);
+		if (app_id)
+		{
+			if (!actor->pDBusProps) actor->pDBusProps = g_new0 (GldiWindowDBusProperties, 1);
+			actor->pDBusProps->cGTKAppID = app_id;
 		}
 	}
 	else  // make a dumy actor, so that we don't try to check it any more
@@ -778,6 +787,12 @@ static gboolean _cairo_dock_unstack_Xevents (G_GNUC_UNUSED gpointer data)
 					if (!actor->pDBusProps) actor->pDBusProps = g_new0 (GldiWindowDBusProperties, 1);
 					else g_free (actor->pDBusProps->cGTKBusName);
 					actor->pDBusProps->cGTKBusName = cairo_dock_get_xwindow_string_prop (Xid, s_aGTKDBusName);
+				}
+				else if (event.xproperty.atom == s_aGTKAppID)
+				{
+					if (!actor->pDBusProps) actor->pDBusProps = g_new0 (GldiWindowDBusProperties, 1);
+					else g_free (actor->pDBusProps->cGTKAppID);
+					actor->pDBusProps->cGTKAppID = cairo_dock_get_xwindow_string_prop (Xid, s_aGTKAppID);
 				}
 			}
 			else if (event.type == ConfigureNotify)
@@ -1696,6 +1711,7 @@ static void init (void)
 	s_aGTKWindowPath 		= XInternAtom (s_XDisplay, "_GTK_WINDOW_OBJECT_PATH", False);
 	s_aGTKAppPath 			= XInternAtom (s_XDisplay, "_GTK_APPLICATION_OBJECT_PATH", False);
 	s_aGTKDBusName 			= XInternAtom (s_XDisplay, "_GTK_UNIQUE_BUS_NAME", False);
+	s_aGTKAppID 			= XInternAtom (s_XDisplay, "_GTK_APPLICATION_ID", False);
 	
 	s_hXWindowTable = g_hash_table_new_full (g_int_hash,
 		g_int_equal,

--- a/src/implementations/cairo-dock-foreign-toplevel.c
+++ b/src/implementations/cairo-dock-foreign-toplevel.c
@@ -277,6 +277,7 @@ static void gldi_zwlr_foreign_toplevel_manager_init ()
 	gldi_windows_manager_register_backend (&wmb);
 	
 	gldi_wayland_wm_init(_destroy);
+	gldi_wf_backend_init_appid_tracking (); // optional functionality to get the GTK application-id supplied by Wayfire
 }
 
 static uint32_t protocol_id, protocol_version;

--- a/src/implementations/cairo-dock-wayfire-integration.c
+++ b/src/implementations/cairo-dock-wayfire-integration.c
@@ -20,11 +20,15 @@
 #include "gldi-config.h"
 #include "cairo-dock-wayfire-integration.h"
 #include "cairo-dock-log.h"
-#include "cairo-dock-windows-manager.h"
 
-#if defined(HAVE_JSON) && defined(HAVE_WAYLAND_PROTOCOLS)
+#ifdef HAVE_WAYLAND_PROTOCOLS
 
 #include "cairo-dock-wayland-wm.h"
+#include "cairo-dock-windows-manager.h"
+#include "cairo-dock-wayland-manager-priv.h"
+
+#ifdef HAVE_JSON
+
 #include "cairo-dock-dock-priv.h"
 #include "cairo-dock-dock-manager.h"
 #include "cairo-dock-dock-visibility.h"
@@ -41,7 +45,6 @@
 #endif
 
 #include "cairo-dock-desktop-manager.h"
-#include "cairo-dock-windows-manager.h"  // bIsHidden
 #include "cairo-dock-icon-factory.h"  // pAppli
 #include "cairo-dock-container-priv.h"  // gldi_container_get_gdk_window
 #include "cairo-dock-class-manager-priv.h"
@@ -1722,24 +1725,54 @@ void cd_init_wayfire_backend (void) {
 	g_io_channel_unref (pIOChannel); // note: ref taken by g_io_add_watch () if succesful
 }
 
-#else
+#else // HAVE_JSON
 
 void cd_init_wayfire_backend (void) {
 	cd_message("Cairo-Dock was not built with Wayfire IPC support");
 }
 
-void gldi_wf_init_sticky_above (void) { }
-void gldi_wf_can_sticky_above (gboolean *bCanSticky, gboolean *bCanAbove)
+#endif // HAVE_JSON
+
+static gboolean _wf_appid_changed (G_GNUC_UNUSED gpointer ptr, GldiWaylandWindowActor *wactor)
 {
-	if (bCanSticky) *bCanSticky = FALSE;
-	if (bCanAbove) *bCanAbove = FALSE;
+	if (!wactor) return GLDI_NOTIFICATION_LET_PASS;
+	
+	GldiWindowActor *actor = (GldiWindowActor*)wactor;
+	
+	// App ID format:
+	// xdg-shell-app-id gtk-shell-app-id wf-ipc-id
+	// cClassExtra already skipped the first part
+	const char *cGTKAppID = wactor->cClassExtra;
+	
+	while (*cGTKAppID == ' ') ++cGTKAppID;
+	if (!*cGTKAppID) return GLDI_NOTIFICATION_LET_PASS;
+	if (!strncmp (cGTKAppID, "wf-ipc-", 7)) return GLDI_NOTIFICATION_LET_PASS; // only IPC ID given
+	
+	// we have a valid string in cGTKAppID, potentially followed by a space and the IPC ID
+	const char *tmp2 = strchr (cGTKAppID, ' ');
+	size_t len = tmp2 ? (size_t)(tmp2 - cGTKAppID) : strlen(cGTKAppID); // will be > 0
+	
+	if (!actor->pDBusProps) actor->pDBusProps = g_new0 (GldiWindowDBusProperties, 1);
+	else g_free (actor->pDBusProps->cGTKAppID);
+	actor->pDBusProps->cGTKAppID = g_strndup (cGTKAppID, len);
+	
+	return GLDI_NOTIFICATION_LET_PASS;
 }
-void gldi_wf_set_sticky (G_GNUC_UNUSED GldiWindowActor *actor, G_GNUC_UNUSED gboolean bSticky) { }
-void gldi_wf_set_above (G_GNUC_UNUSED GldiWindowActor *actor, G_GNUC_UNUSED gboolean bAbove) { }
-void gldi_wf_is_above_or_below (G_GNUC_UNUSED GldiWindowActor *actor, gboolean *bIsAbove, gboolean *bIsBelow)
+
+void gldi_wf_backend_init_appid_tracking (void)
 {
-	if (bIsAbove) *bIsAbove = FALSE;
-	if (bIsBelow) *bIsBelow = FALSE;
+	GldiWaylandCompositorType type = gldi_wayland_get_compositor_type ();
+	if (type == WAYLAND_COMPOSITOR_WAYFIRE || type == WAYLAND_COMPOSITOR_UNKNOWN)
+		gldi_object_register_notification (&myWaylandWMObjectMgr,
+			NOTIFICATION_WAYLAND_APP_ID,
+			(GldiNotificationFunc) _wf_appid_changed,
+			GLDI_RUN_FIRST, NULL);
+}
+
+#else // HAVE_WAYLAND_PROTOCOLS
+
+void cd_init_wayfire_backend (void) {
+	cd_message("Cairo-Dock was not built with Wayfire IPC support");
 }
 
 #endif

--- a/src/implementations/cairo-dock-wayfire-integration.h
+++ b/src/implementations/cairo-dock-wayfire-integration.h
@@ -50,6 +50,9 @@ void gldi_wf_set_above (GldiWindowActor *actor, gboolean bAbove);
  *  - bIsAbove only reflects the state set by us, not by other methods (e.g. keybindings)
  */
 void gldi_wf_is_above_or_below (GldiWindowActor *actor, gboolean *bIsAbove, gboolean *bIsBelow);
+
+/** Set up extra tracking of app-id changes so that the GTK application-id can be extracted. */
+void gldi_wf_backend_init_appid_tracking (void);
 #endif
 
 G_END_DECLS

--- a/src/implementations/cairo-dock-wayland-wm.c
+++ b/src/implementations/cairo-dock-wayland-wm.c
@@ -153,6 +153,8 @@ void gldi_wayland_wm_appid_changed (GldiWaylandWindowActor *wactor, const char *
 		
 	}
 	else wactor->cClassExtra = NULL;
+	
+	gldi_object_notify (&myWaylandWMObjectMgr, NOTIFICATION_WAYLAND_APP_ID, wactor);
 	if (notify) gldi_wayland_wm_done (wactor);
 }
 

--- a/src/implementations/cairo-dock-wayland-wm.h
+++ b/src/implementations/cairo-dock-wayland-wm.h
@@ -68,7 +68,10 @@ extern GldiObjectManager myWaylandWMObjectMgr;
 
 // notifications (no additional ones beyond the WM notifications)
 typedef enum {
-	NB_NOTIFICATIONS_WAYLAND_WM_MANAGER = NB_NOTIFICATIONS_WINDOWS
+	// emitted when the app-id of a Wayland view has changed, but before it has been fully processed,
+	// use it only for additional internal processing
+	NOTIFICATION_WAYLAND_APP_ID = NB_NOTIFICATIONS_WINDOWS,
+	NB_NOTIFICATIONS_WAYLAND_WM_MANAGER
 } CairoWaylandWMManagerNotifications;
 
 // functions to update the state of a toplevel and potentially signal


### PR DESCRIPTION
Apps based on the [GtkApplication](https://docs.gtk.org/gtk4/class.Application.html) class and setting the `application-id` property might be identified based on it in some cases. Depending on the windowing system and GTK version, this might be provided by:
 - the `app-id` via `xdg-shell` on Wayland
 - via the [gtk-shell](https://wayland.app/protocols/gtk-shell#gtk_surface1:request:set_dbus_properties) protocol on Wayland (currently only relayed by [Wayfire](https://github.com/WayfireWM/wayfire/wiki/Configuration#workaroundsapp_id_mode))
 - the `_GTK_APPLICATION_ID` window property on X11
This PR provides the necessary changes for the latter two cases.