### PR TITLE
wayland-manager: expose globals to plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,12 @@ if (enable-x11-support)
 	# check for GLX -- TODO: using 'pkg_check_modules ("GLX" "glx")' should work, or very old versions do not provide glx.pc?
 	enable_if_not_defined (enable-glx-support)
 	if (enable-glx-support)
-		check_library_exists (GL glXMakeCurrent "" HAVE_GLX)  # HAVE_GLX remains undefined if not found, else it's "1"
+		check_library_exists (GL glXMakeCurrent "" GLX_FOUND)  # HAVE_GLX remains undefined if not found, else it's "1"
+		if (GLX_FOUND)
+			# Set this in a separate variable, since GLX_FOUND will be cached by CMake, thus disabling
+			# X11 or GLX would have no effect unless the cache is deleted.
+			set (HAVE_GLX 1)
+		endif()
 	endif()
 	
 	# check for X extensions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.6.100") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.6.101") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -55,6 +55,7 @@
 #include <glib/gstdio.h>
 
 #include "config.h"
+#include "gldi-config.h"
 #include "cairo-dock-icon-facility.h"  // cairo_dock_get_first_icon
 #include "cairo-dock-module-manager-priv.h"  // gldi_modules_new_from_directory
 #include "cairo-dock-module-instance-manager.h"  // GldiModuleInstance
@@ -105,7 +106,9 @@ extern gboolean g_bNoWaylandExclude;
 extern gboolean g_bDisableAllModules;
 extern gboolean g_bNoCheckModuleVersion;
 extern gchar **g_cExcludedModules;
+#ifdef HAVE_X11
 extern gboolean g_bX11UseEgl;
+#endif
 extern gboolean g_bDisableSystemd; // defined in cairo-dock-core.c
 extern gboolean g_bDisableDbusActivation; // defined in cairo-dock-class-manager.c
 extern gboolean g_bGioLaunch; // defined in cairo-dock-class-manager.c
@@ -451,9 +454,11 @@ int main (int argc, char** argv)
 		{"no-dbus-name", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_NONE,
 			&bNoDBusName,
 			_("Do not try to own the \"org.cairodock.CairoDock\" DBus name (DBus interface will be unavailable)."), NULL},
+#ifdef HAVE_X11
 		{"egl", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_NONE,
 			&g_bX11UseEgl,
 			_("Use EGL on X11."), NULL},
+#endif
 		{"no-layer-shell", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_NONE,
 			&g_bDisableLayerShell,
 			_("For debugging purpose only. Disable gtk-layer-shell support."), NULL},

--- a/src/gldit/cairo-dock-applet-canvas.h
+++ b/src/gldit/cairo-dock-applet-canvas.h
@@ -59,7 +59,7 @@ typedef struct _AppletData AppletData;
 #define CD_APPLET_DEFINE_PROTO \
 gboolean CD_APPLET_DEFINE_FUNC (GldiVisitCard *pVisitCard, GldiModuleInterface *pInterface)
 #define CD_APPLET_POST_LOAD_PROTO \
-gboolean CD_APPLET_POST_LOAD_FUNC (GldiVisitCard *pVisitCard, GldiModuleInterface *pInterface, G_GNUC_UNUSED gpointer pReserved)
+void CD_APPLET_POST_LOAD_FUNC (GldiModule *pModule, G_GNUC_UNUSED gpointer pReserved)
 #define CD_APPLET_INIT_PROTO(pApplet) \
 void CD_APPLET_INIT_FUNC (GldiModuleInstance *pApplet, G_GNUC_UNUSED GKeyFile *pKeyFile)
 #define CD_APPLET_STOP_PROTO \
@@ -175,7 +175,7 @@ CD_APPLET_DEFINE_PROTO \
 	pVisitCard->cTitle = dgettext (MY_APPLET_GETTEXT_DOMAIN, pVisitCard->cTitle);\
 	return TRUE ;\
 }
-/** Fonction de pre-initialisation generique. Ne fais que definir l'applet (en appelant les 2 macros precedentes), la plupart du temps cela est suffisant.
+/** General macro to define an applet. Deprecated; use \ref CD_APPLET_DEFINITION2 instead.
 */
 #define CD_APPLET_DEFINITION(cName, iMajorVersion, iMinorVersion, iMicroVersion, iAppletCategory, cDescription, cAuthor) \
 CD_APPLET_DEFINE_BEGIN (cName, iMajorVersion, iMinorVersion, iMicroVersion, iAppletCategory, cDescription, cAuthor) \
@@ -191,12 +191,26 @@ CD_APPLET_DEFINE_ALL_BEGIN (cName, 4, GLDI_ABI_VERSION, iFlags, _iAppletCategory
 	pVisitCard->postLoad = CD_APPLET_POST_LOAD_FUNC; \
 CD_APPLET_DEFINE_END \
 CD_APPLET_POST_LOAD_PROTO \
-{
+{ \
+	GldiVisitCard *pVisitCard = pModule->pVisitCard; \
+	GldiModuleInterface *pInterface = pModule->pInterface; \
+	(void)*pVisitCard; \
+	(void)*pInterface; \
 
+/// End of module definition in more complex cases. Use together with \ref CD_APPLET_DEFINE2_BEGIN
 #define CD_APPLET_DEFINE2_END \
-	return TRUE; \
 }
 
+/** General applet definition. Use this to define an applet and its interface in common cases.
+*@param cName name of the applet, shown to the user (use the N_() macro to translate it)
+*@param iFlags flags describing module compatibility; see \ref GldiModuleFlags
+*@param iAppletCategory category of the applet; see \ref GldiModuleCategory for available categories
+*@param cDescription (short) description of the applet, to be displayed to the user in a dialog bubble when the mouse is hovered on this applet in the configuration window
+*@param cAuthor Applet creator, displayed on the applet's settings page
+* 
+* Note: use this macro for simple cases. If you need to perform some early initialization, use the macro pair
+* \ref CD_APPLET_DEFINE2_BEGIN and \ref CD_APPLET_DEFINE2_END instead.
+*/
 #define CD_APPLET_DEFINITION2(cName, iFlags, iAppletCategory, cDescription, cAuthor) \
 CD_APPLET_DEFINE2_BEGIN (cName, iFlags, iAppletCategory, cDescription, cAuthor) \
 CD_APPLET_DEFINE_COMMON_APPLET_INTERFACE \

--- a/src/gldit/cairo-dock-applet-multi-instance.h
+++ b/src/gldit/cairo-dock-applet-multi-instance.h
@@ -21,11 +21,29 @@
 #ifndef __CAIRO_DOCK_APPLET_MULTI_INSTANCE__
 #define  __CAIRO_DOCK_APPLET_MULTI_INSTANCE__
 
+/**
+*@file cairo-dock-applet-multi-intance.h This file defines macros specific to multi-instance applets.
+* The same are also defined for single-instance applets with the same interface.
+*/
+
 
 #define CD_APPLET_DEFINE_BEGIN(cName, iMajorVersion, iMinorVersion, iMicroVersion, iAppletCategory, cDescription, cAuthor) \
 	CD_APPLET_DEFINE_ALL_BEGIN (cName, iMajorVersion, iMinorVersion, iMicroVersion, iAppletCategory, cDescription, cAuthor) \
 	pVisitCard->bMultiInstance = TRUE;
 
+/** General applet definition. Use this to define an applet and its interface in more complex cases.
+ * Code enclosed between this macro and \ref CD_APPLET_DEFINE2_END will be executed when the plug-in
+ * module is first loaded and can perform basic checks and initialization that must be done before the
+ * module is activated via the \ref CD_APPLET_INIT_BEGIN function. Be careful that the applet's instance
+ * variable (myApplet) and configuration (myConfig) are not available at this point. You can call the
+ * \ref gldi_module_disable () function from here to disable the module entirely if it is not possible
+ * to use it in the current environment.
+*@param cName name of the applet, shown to the user (use the N_() macro to translate it)
+*@param iFlags flags describing module compatibility; see \ref GldiModuleFlags
+*@param iAppletCategory category of the applet; see \ref GldiModuleCategory for available categories
+*@param cDescription (short) description of the applet, to be displayed to the user in a dialog bubble when the mouse is hovered on this applet in the configuration window
+*@param cAuthor Applet creator, displayed on the applet's settings page
+*/
 #define CD_APPLET_DEFINE2_BEGIN(cName, iFlags, _iAppletCategory, _cDescription, _cAuthor) \
 	CD_APPLET_DEFINE2_ALL_BEGIN (cName, iFlags, _iAppletCategory, _cDescription, _cAuthor) \
 	pVisitCard->bMultiInstance = TRUE;

--- a/src/gldit/cairo-dock-module-manager.c
+++ b/src/gldit/cairo-dock-module-manager.c
@@ -145,6 +145,12 @@ GldiModule *gldi_module_new (GldiVisitCard *pVisitCard, GldiModuleInterface *pIn
 {
 	g_return_val_if_fail (pVisitCard != NULL && pVisitCard->cModuleName != NULL, NULL);
 	
+	if (g_hash_table_lookup (s_hModuleTable, pVisitCard->cModuleName) != NULL)
+	{
+		cd_warning ("a module with the name '%s' is already registered", pVisitCard->cModuleName);
+		return NULL;
+	}
+	
 	GldiModuleAttr attr = {pVisitCard, pInterface};
 	return (GldiModule*)gldi_object_new (&myModuleObjectMgr, &attr);
 }
@@ -159,7 +165,6 @@ static void _module_new_from_so_file (const gchar *cSoFilePath)
 	GldiModuleInterface *pInterface = NULL;
 	
 	// open the .so file
-	///GModule *module = g_module_open (pGldiModule->cSoFilePath, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
 	gpointer handle = dlopen (cSoFilePath, RTLD_NOW | RTLD_LOCAL);
 	if (! handle)
 	{
@@ -168,10 +173,7 @@ static void _module_new_from_so_file (const gchar *cSoFilePath)
 	}
 	
 	// find the pre-init entry point
-	GldiModulePreInit function_pre_init = NULL;
-	/**bSymbolFound = g_module_symbol (module, "pre_init", (gpointer) &function_pre_init);
-	if (bSymbolFound && function_pre_init != NULL)*/
-	function_pre_init = dlsym (handle, "pre_init");
+	GldiModulePreInit function_pre_init = dlsym (handle, "pre_init");
 	if (function_pre_init == NULL)
 	{
 		cd_warning ("this module ('%s') does not have the common entry point 'pre_init', it may be broken or icompatible with cairo-dock", cSoFilePath);
@@ -244,9 +246,6 @@ static void _module_new_from_so_file (const gchar *cSoFilePath)
 				bDisable = TRUE;
 				cDisableReason = _("This plug-in requires OpenGL, but it is not enabled.");
 			}
-			if (!bDisable && pVisitCard->postLoad)
-				if (!pVisitCard->postLoad (pVisitCard, pInterface, NULL))
-					bDisable = TRUE;
 		}
 		else
 		{
@@ -266,16 +265,21 @@ static void _module_new_from_so_file (const gchar *cSoFilePath)
 	}
 	
 	// create a new module with these info
-	GldiModule *pModule = gldi_module_new (pVisitCard, pInterface);  // takes ownership of pVisitCard and pInterface
+	GldiModule *pModule = gldi_module_new (pVisitCard, pInterface);  // takes ownership of pVisitCard and pInterface only if returns non-NULL
 	if (pModule)
-	{
 		pModule->handle = handle;
-		if (bDisable) gldi_module_disable (pModule, cDisableReason);
-	}
+	else goto discard; // this can only happen if the module has already been loaded before (cModuleName is in s_hModuleTable)
+	
+	if (pVisitCard->iMajorVersionNeeded == 4) // always call the postLoad () function if it exists (and the module has not been disabled yet)
+		if (!bDisable && pVisitCard->postLoad) pVisitCard->postLoad (pModule, NULL);
+	
+	if (bDisable) gldi_module_disable (pModule, cDisableReason); // keep loaded but disabled
+	else if (gldi_module_is_auto_loaded (pModule))  // a module that doesn't have an init/stop entry point, or that extends a manager; we'll activate it automatically (and before the others).
+		s_AutoLoadedModules = g_list_prepend (s_AutoLoadedModules, pModule);
+	
 	return;
 	
 discard:
-	///g_module_close (pModule);
 	dlclose (handle);
 	g_free (pVisitCard); // toutes les chaines sont statiques.
 	g_free (pInterface);
@@ -504,6 +508,9 @@ void gldi_module_deactivate (GldiModule *module)  // stop all instances of a mod
 
 void gldi_module_disable (GldiModule *pModule, const gchar *cReason)
 {
+	g_return_if_fail (pModule != NULL);
+	g_return_if_fail (pModule->iState != CAIRO_DOCK_MODULE_DISABLED);
+	
 	_module_deactivate (pModule);
 	pModule->iState = CAIRO_DOCK_MODULE_DISABLED;
 	if (cReason) pModule->cDisableReason = g_strdup (cReason);
@@ -752,12 +759,12 @@ static void _module_remove_from_config (GldiModule *pModule)
 
 gboolean _on_module_activated (gpointer pUserData, G_GNUC_UNUSED const gchar *cModuleName, gboolean bActivated)
 {
-	// only if the module was deactivated and the notification does not come from ourselves
-	if (!bActivated && !s_bSelfNotify)
-	{
-		GldiModule *pModule = (GldiModule*)pUserData;
+	GldiModule *pModule = (GldiModule*)pUserData;
+	
+	// only if the module was deactivated, the notification does not come from ourselves
+	// and it is not an auto-loaded module
+	if (!bActivated && !s_bSelfNotify && !gldi_module_is_auto_loaded (pModule))
 		_module_remove_from_config (pModule);
-	}
 	
 	return GLDI_NOTIFICATION_LET_PASS;
 }
@@ -794,15 +801,8 @@ static void init_object (GldiObject *obj, gpointer attr)
 	GldiModule *pModule = (GldiModule*)obj;
 	GldiModuleAttr *mattr = (GldiModuleAttr*)attr;
 	
-	// check everything is ok
+	// check everything is ok -- not needed? (only called from gldi_module_new ())
 	g_return_if_fail (mattr != NULL && mattr->pVisitCard != NULL && mattr->pVisitCard->cModuleName);
-	
-	if (g_hash_table_lookup (s_hModuleTable, mattr->pVisitCard->cModuleName) != NULL)
-	{
-		//!! TODO: pModule is leaked (caller will not expect to free it)
-		cd_warning ("a module with the name '%s' is already registered", mattr->pVisitCard->cModuleName);
-		return;
-	}
 	
 	// set params
 	pModule->pVisitCard = mattr->pVisitCard;
@@ -815,11 +815,8 @@ static void init_object (GldiObject *obj, gpointer attr)
 	// register the module
 	g_hash_table_insert (s_hModuleTable, (gpointer)pModule->pVisitCard->cModuleName, pModule);
 	
-	if (gldi_module_is_auto_loaded (pModule))  // a module that doesn't have an init/stop entry point, or that extends a manager; we'll activate it automatically (and before the others).
-		s_AutoLoadedModules = g_list_prepend (s_AutoLoadedModules, pModule);
-	else // we need to listen to when the last instance is removed to delete the module from the config
-		gldi_object_register_notification (GLDI_OBJECT (pModule), NOTIFICATION_MODULE_ACTIVATED,
-			(GldiNotificationFunc) _on_module_activated, FALSE, pModule);
+	gldi_object_register_notification (GLDI_OBJECT (pModule), NOTIFICATION_MODULE_ACTIVATED,
+		(GldiNotificationFunc) _on_module_activated, FALSE, pModule);
 	
 	// notify everybody
 	gldi_object_notify (&myModuleObjectMgr, NOTIFICATION_MODULE_REGISTERED, pModule->pVisitCard->cModuleName, TRUE);

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20260702
+#define GLDI_ABI_VERSION 20260712
 
 // manager
 #ifndef _MANAGER_DEF_

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20260712
+#define GLDI_ABI_VERSION 20260715
 
 // manager
 #ifndef _MANAGER_DEF_
@@ -81,9 +81,13 @@ typedef enum {
 	CAIRO_DOCK_MODULE_CAN_OTHERS 	= 1<<2
 	} GldiModuleContainerType;
 
+/// Flags for compatibility checks when loading a plug-in
 typedef enum {
+	/// This plug-in can function in an X11 desktop environment
 	CAIRO_DOCK_MODULE_SUPPORTS_X11 = 1<<0,
+	/// This plug-in can function in a Wayland desktop environment
 	CAIRO_DOCK_MODULE_SUPPORTS_WAYLAND = 1<<1,
+	/// This plug-in requires OpenGL to function (if OpenGL is not available, it will be disabled)
 	CAIRO_DOCK_MODULE_REQUIRES_OPENGL = 1<<2
 } GldiModuleFlags;
 
@@ -97,62 +101,69 @@ typedef enum {
 	CAIRO_DOCK_MODULE_DISABLED,
 } GldiModuleState;
 
+/// Default compatibility flags: the plug-in can work on both X11 and Wayland and does not require OpenGL
 #define CAIRO_DOCK_MODULE_DEFAULT_FLAGS (CAIRO_DOCK_MODULE_SUPPORTS_X11 | CAIRO_DOCK_MODULE_SUPPORTS_WAYLAND)
 
 /// Definition of the visit card of a module. Contains everything that is statically defined for a module.
 struct _GldiVisitCard {
-	// nom du module qui servira a l'identifier.
+	/// name of the module (only used internally)
 	const gchar *cModuleName;
-	// minimum major version needed for this module (if <= 3), or indicator of new API / ABI (if == 4)
+	/// minimum major version needed for this module (if <= 3), or indicator of new API / ABI (if == 4)
 	gint iMajorVersionNeeded;
-	// minimum minor version needed for this module (if major version <= 3), or exact ABI version needed if major version == 4
+	/// minimum minor version needed for this module (if major version <= 3), or exact ABI version needed if major version == 4
 	gint iMinorVersionNeeded;
-	// numero de version micro de cairo-dock necessaire au bon fonctionnement du module (if major version <= 3)
-	//   or flags (if major version == 4)
+	/// minimum micro version needed for this module (if major version <= 3), or compatibility flags
+	/// if major version == 4, see \ref GldiModuleFlags
 	gint iMicroVersionNeeded;
-	// chemin d'une image de previsualisation.
+	/// preview image (shown in the advanced GUI main panel and in the module settings page)
 	const gchar *cPreviewFilePath;
-	// Nom du domaine pour la traduction du module par 'gettext'.
+	/// gettext translation domain
 	const gchar *cGettextDomain;
-	// Version du dock pour laquelle a ete compilee le module.
+	/// Version du dock pour laquelle a ete compilee le module.
 	const gchar *cDockVersionOnCompilation;
-	// version courante du module.
+	/// version courante du module.
 	const gchar *cModuleVersion;
-	// repertoire du plug-in cote utilisateur.
+	/// repertoire du plug-in cote utilisateur.
 	const gchar *cUserDataDir;
-	// repertoire d'installation du plug-in.
+	/// repertoire d'installation du plug-in.
 	const gchar *cShareDataDir;
-	// nom de son fichier de conf.
+	/// nom de son fichier de conf.
 	const gchar *cConfFileName;
-	// categorie de l'applet.
+	/// plug-in category
 	GldiModuleCategory iCategory;
-	// chemin d'une image pour l'icone du module dans le panneau de conf du dock.
+	/// chemin d'une image pour l'icone du module dans le panneau de conf du dock.
 	const gchar *cIconFilePath;
-	// taille de la structure contenant la config du module.
+	/// size of module configuration to allocate
 	gint iSizeOfConfig;
-	// taille de la structure contenant les donnees du module.
+	/// size of module data to allocate
 	gint iSizeOfData;
-	// VRAI ssi le plug-in peut etre instancie plusiers fois.
+	/// whether multiple instances of this plug-ing can be activated
 	gboolean bMultiInstance;
-	// description et mode d'emploi succint.
+	/// short description to display to the user
 	const gchar *cDescription;
-	// auteur/pseudo
+	/// plug-in author to display to the user
 	const gchar *cAuthor;
-	// nom d'un module interne auquel ce module se rattache, ou NULL si aucun.
+	/// name of the internal component that this plug-in is attached to or NULL if none
+	/// (typically used for plug-ins that provide core functionality, e.g. dock-rendering)
 	const gchar *cInternalModule;
-	// nom du module tel qu'affiche a l'utilisateur.
+	/// plug-in name to display to the user
 	const gchar *cTitle;
+	/// type of the container that this plug-in can be attached to
 	GldiModuleContainerType iContainerType;
 	gboolean bStaticDeskletSize;
-	// whether to display the applet's name on the icon's label if it's NULL or not.
+	/// whether to display the applet's name on the icon's label if it's NULL or not.
 	gboolean bAllowEmptyTitle;
-	// if TRUE and the applet inhibites a class, then appli icons will be placed after the applet icon.
+	/// if TRUE and the applet inhibites a class, then appli icons will be placed after the applet icon.
 	gboolean bActAsLauncher;
-	// function called after the module has been successfully loaded; use this to register functionality that should always be active
-	// return FALSE to unload the module (in this case, care should be taken to not register any functions / callbacks / signals, to not crash later)
-	// members of pVisitCard and pInterface can be filled out / updated here if it was not done in pre_init already
-	// only available if iMajorVersionNeeded == 4
-	gboolean (* postLoad) (GldiVisitCard *pVisitCard, GldiModuleInterface *pInterface, gpointer reserved);
+	/** Function called after the module has been successfully loaded; use this to register functionality
+	 * that should always be active. Call \ref gldi_module_disable () from this function to disable this module
+	 * (will not be possible to activate it, i.e. the initModule () function will never be called;
+	 * in this case, care should be taken to not register any functions / callbacks / signals, to not crash later).
+	 * members of pVisitCard and pInterface in pModule can be filled out / updated here if it was not
+	 * done in pre_init () already.
+	 * Only available if iMajorVersionNeeded == 4.
+	 */
+	void (* postLoad) (GldiModule *pModule, gpointer reserved);
 	gpointer reserved;
 };
 

--- a/src/gldit/cairo-dock-opengl.c
+++ b/src/gldit/cairo-dock-opengl.c
@@ -383,12 +383,14 @@ void gldi_gl_container_finish (GldiContainer *pContainer)
 		s_backend.container_finish (pContainer);
 }
 
+#ifdef HAVE_X11
 GLuint gldi_gl_texture_from_pixmap (Window Xid, Pixmap iBackingPixmap)
 {
 	if (g_bUseOpenGL && s_backend.texture_from_pixmap)
 		return s_backend.texture_from_pixmap (Xid, iBackingPixmap);
 	return 0;
 }
+#endif
 
 const gchar *gldi_gl_get_backend_name ()
 {

--- a/src/gldit/cairo-dock-struct.h
+++ b/src/gldit/cairo-dock-struct.h
@@ -404,6 +404,7 @@
  * Some applets need more control over their life-cycle. Beyond applets that define their own message domain for internationalization (see \ref translations), this typically relates to applets that provide some essential functionality for the dock (e.g. renderers, desktop environment integration, etc.). In this case, instead of defining the applet with CD_APPLET_DEFINITION2, use the macro pair CD_APPLET_DEFINE2_BEGIN / CD_APPLET_DEFINE2_END and
  * - Add early initialization steps between these; this will be run when the applet is first opened (loaded from disk), regardless wether it is enabled yet. Be careful that the applet's instance variable (myApplet) and configuration (myConfig) are not available at this point (so you will need to use static variables to save any state). Also, no docks, cairo or OpenGL contexts exist, and the current theme has not been loaded at this point as well. It is thus recommended to keep things here absolute minimal.
  * - Also you have to manually define the applet's interface here (load, stop, config functions, etc.); see the GldiModuleInterface struct from cairo-dock-module-manager.h for a description of each function and what it does, or use the CD_APPLET_DEFINE_COMMON_APPLET_INTERFACE macro that defines these with the usual function names thus you can use the same macros as you would with CD_APPLET_DEFINITION2.
+ * - You can also call the function \ref gldi_module_disable () at this point to prevent you applet to be loaded (it will still show up in the config panel, but will not be possible to enable it).
  * 
  * 
  * \subsection auto_load Auto-loaded applets
@@ -418,7 +419,14 @@
  * - it does not have a stopModule () function
  * - it extends a core functionality ("manager") of Cairo-Dock: this is achieved by using the CD_APPLET_EXTEND_MANAGER macro when the module is read
  * 
- * Note: all of the above need to be defined by using CD_APPLET_DEFINE2_BEGIN / CD_APPLET_DEFINE2_END
+ * Note: all of the above need to be defined by using the macro pair \ref CD_APPLET_DEFINE2_BEGIN and \ref CD_APPLET_DEFINE2_END
+ * 
+ * 
+ * \subsection disable Disabling applets
+ * 
+ * Applets will be disabled via two possible mechanisms:
+ *  - API / ABI incompatibility. This happens if the applet's .so file cannot be loaded (due to e.g. missing symbols if it was compiled for a different API version) or if the ABI version stored in the .so file does not match that of the running Cairo-Dock instance (if it was compiled against a different ABI version, defined via the \ref GLDI_ABI_VERSION macro). In this case, loading of the module is aborted early in the process and thus the applet will not show up among available plug-ins in the configuration window. Applets that are disabled by the "-D" command line option will be treated like this as well. The ABI version check can be overridden with the "--no-module-version-check" command line option, which will then likely result in crashes later. Of course, failures from opening the .so file due to missing symbols cannot be circumvented.
+ *  - Incompatible environment. This happens if the applet is not compatible with the current environment, either detected via automated checks based on the module flags given to the \ref CD_APPLET_DEFINITION2 macro (currently it checks for X11, Wayland and OpenGL support), or if the applet calls the \ref gldi_module_disable () function at any time (including in between the \ref CD_APPLET_DEFINE2_BEGIN and \ref CD_APPLET_DEFINE2_END macro pair). In this case, the applet will be shown in the configuration window, but will not be possible to enable it. An optional message will be shown to the user as a tooltip to explain why the applet is disabled.
  * 
  */
 

--- a/src/gldit/gldi.pc.in
+++ b/src/gldit/gldi.pc.in
@@ -9,6 +9,7 @@ plugins_prefix = @plugins-prefix@
 plugins_locale = @plugins-locale@
 plugins_gettext = @plugins-gettext@
 gtkversion = @GTK_MAJOR@
+have_wayland = @WAYLAND_FOUND@
 
 Name: gldi
 Description: openGL Desktop Interface. A library to build advanced interfaces for the desktop (dock, panel, desklet, dialog, ...); it supports both cairo and openGL.

--- a/src/implementations/cairo-dock-compiz-integration.c
+++ b/src/implementations/cairo-dock-compiz-integration.c
@@ -17,16 +17,18 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "cairo-dock-log.h"
+
+#include "gldi-config.h"
+
+#ifdef HAVE_X11
+
 #include <glib.h>
 #include <gio/gio.h>
 
-#include "gldi-config.h"
-#ifdef HAVE_X11
 #include <X11/Xatom.h>
 #include <gdk/gdkx.h>  // GDK_WINDOW_XID
-#endif
 
-#include "cairo-dock-log.h"
 #include "cairo-dock-desktop-manager.h"
 #include "cairo-dock-windows-manager.h"  // bIsHidden
 #include "cairo-dock-icon-factory.h"  // pAppli
@@ -542,3 +544,12 @@ void cd_init_compiz_backend (void)
 	g_bus_watch_name (G_BUS_TYPE_SESSION, CD_COMPIZ_BUS, G_BUS_NAME_WATCHER_FLAGS_NONE,
 		_on_name_appeared, _on_name_vanished, NULL, NULL);
 }
+#else // HAVE_X11
+
+void cd_init_compiz_backend (void)
+{
+	cd_message ("Cairo-Dock was not built with X11 support, not loading Compiz integration");
+}
+
+#endif
+

--- a/src/implementations/cairo-dock-cosmic-toplevel.c
+++ b/src/implementations/cairo-dock-cosmic-toplevel.c
@@ -5,7 +5,7 @@
  * and cosmic_toplevel_management_unstable_v1 protocol.
  * See for more info: https://github.com/pop-os/cosmic-protocols
  * 
- * Copyright 2020-2025 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2020-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -44,6 +44,7 @@
 #include "cairo-dock-log.h"
 #include "cairo-dock-cosmic-toplevel.h"
 #include "cairo-dock-wayland-wm.h"
+#include "cairo-dock-wayland-manager.h"
 #include "cairo-dock-ext-workspaces.h"
 
 #include <stdio.h>
@@ -84,12 +85,7 @@ static gboolean can_fullscreen = FALSE;
 static gboolean can_move_workspace = FALSE;
 static gboolean can_sticky = FALSE;
 
-static gboolean list_found = FALSE;
-static gboolean manager_found = FALSE;
-static gboolean info_found = FALSE;
-static gboolean overlap_found = FALSE;
-static uint32_t list_id, manager_id, info_id, overlap_id, list_version, manager_version, info_version, overlap_version;
-
+static uint32_t manager_version = 0;
 
 /**********************************************************************
  * window manager interface -- toplevel manager                       */
@@ -783,6 +779,47 @@ static void _visibility_refresh (CairoDock *pDock)
 
 gboolean gldi_cosmic_toplevel_try_init (struct wl_registry *registry)
 {
+	gboolean list_found = FALSE;
+	gboolean manager_found = FALSE;
+	gboolean info_found = FALSE;
+	gboolean overlap_found = FALSE;
+	uint32_t list_id, manager_id, info_id, overlap_id, list_version, info_version, overlap_version;
+	const GldiWaylandProtocolInfo *info;
+	
+	info = gldi_wayland_get_global (zcosmic_toplevel_manager_v1_interface.name);
+	if (info)
+	{
+		manager_found = TRUE;
+		manager_id = info->id;
+		manager_version = info->version;
+	}
+	info = gldi_wayland_get_global (zcosmic_toplevel_info_v1_interface.name);
+	if (info)
+	{
+		info_found = TRUE;
+		info_id = info->id;
+		info_version = info->version;
+	}
+	info = gldi_wayland_get_global (ext_foreign_toplevel_list_v1_interface.name);
+	if (info)
+	{
+		list_found = TRUE;
+		list_id = info->id;
+		list_version = info->version;
+	}
+#ifdef HAVE_GTK_LAYER_SHELL
+	if (!g_bDisableLayerShell)
+	{
+		info = gldi_wayland_get_global (zcosmic_overlap_notify_v1_interface.name);
+		if (info)
+		{
+			overlap_found = TRUE;
+			overlap_id = info->id;
+			overlap_version = info->version;
+		}
+	}
+#endif
+	
 	if (!(manager_found && info_found && list_found)) return FALSE;
 	
 	if (list_version > (uint32_t)ext_foreign_toplevel_list_v1_interface.version)
@@ -906,42 +943,6 @@ gboolean gldi_cosmic_toplevel_try_init (struct wl_registry *registry)
 	gldi_dock_visibility_register_backend (&dvb);
 	
 	return TRUE;
-}
-
-
-gboolean gldi_cosmic_toplevel_match_protocol (uint32_t id, const char *interface, uint32_t version)
-{
-	if (!strcmp (interface, zcosmic_toplevel_manager_v1_interface.name))
-	{
-		manager_found = TRUE;
-		manager_id = id;
-		manager_version = version;
-		return TRUE;
-	}
-	if (!strcmp (interface, zcosmic_toplevel_info_v1_interface.name))
-	{
-		info_found = TRUE;
-		info_id = id;
-		info_version = version;
-		return TRUE;
-	}
-	if (!strcmp (interface, ext_foreign_toplevel_list_v1_interface.name))
-	{
-		list_found = TRUE;
-		list_id = id;
-		list_version = version;
-		return TRUE;
-	}
-#ifdef HAVE_GTK_LAYER_SHELL
-	if (!g_bDisableLayerShell && !strcmp (interface, zcosmic_overlap_notify_v1_interface.name))
-	{
-		overlap_found = TRUE;
-		overlap_id = id;
-		overlap_version = version;
-		return TRUE;
-	}
-#endif
-	return FALSE;
 }
 
 #endif

--- a/src/implementations/cairo-dock-cosmic-toplevel.h
+++ b/src/implementations/cairo-dock-cosmic-toplevel.h
@@ -5,7 +5,7 @@
  * and cosmic_toplevel_management_unstable_v1 protocol.
  * See for more info: https://github.com/pop-os/cosmic-protocols
  * 
- * Copyright 2020-2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2020-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,7 +28,6 @@
 #include <wayland-client.h>
 #include <stdint.h>
 
-gboolean gldi_cosmic_toplevel_match_protocol (uint32_t id, const char *interface, uint32_t version);
 gboolean gldi_cosmic_toplevel_try_init (struct wl_registry *registry);
 
 #endif

--- a/src/implementations/cairo-dock-egl.c
+++ b/src/implementations/cairo-dock-egl.c
@@ -221,7 +221,7 @@ static gboolean _initialize_opengl_backend (gboolean bForceOpenGL)
 			if (bForceOpenGL)
 			{
 				cd_warning ("we could not get an ARGB-visual, trying to get an RGB one (fake transparency will be used in return) ...");
-				config_attribs[12] = None;
+				config_attribs[12] = EGL_NONE;
 				bAlphaAvailable = FALSE;
 				eglChooseConfig (dpy, config_attribs, &config, 1, &numConfigs);
 			}

--- a/src/implementations/cairo-dock-ext-workspaces.c
+++ b/src/implementations/cairo-dock-ext-workspaces.c
@@ -2,7 +2,7 @@
  * cairo-dock-ext-workspaces.c -- desktop / workspace management
  *  facilities based on the ext-workspace Wayland protocol
  * 
- * Copyright 2024-2025 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2024-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -23,6 +23,7 @@
 #include "cairo-dock-windows-manager.h"
 #include "cairo-dock-ext-workspaces.h"
 #include "cairo-dock-wayland-wm.h"
+#include "cairo-dock-wayland-manager.h"
 
 struct wl_output *s_ws_output = NULL;
 
@@ -571,26 +572,17 @@ static void _remove_workspace (void)
 }
 */
 
-static uint32_t protocol_id, protocol_version;
-static gboolean protocol_found = FALSE;
-
-gboolean gldi_ext_workspaces_match_protocol (uint32_t id, const char *interface, uint32_t version)
-{
-	if (!strcmp(interface, ext_workspace_manager_v1_interface.name))
-	{
-		protocol_found = TRUE;
-		protocol_id = id;
-		protocol_version = version;
-		if ((uint32_t)ext_workspace_manager_v1_interface.version < protocol_version)
-			protocol_version = ext_workspace_manager_v1_interface.version;
-		return TRUE;
-	}
-	return FALSE;
-}
-
 gboolean gldi_ext_workspaces_try_init (struct wl_registry *registry)
 {
-	if (!protocol_found) return FALSE;
+	uint32_t protocol_id, protocol_version;
+	const GldiWaylandProtocolInfo *info = gldi_wayland_get_global (ext_workspace_manager_v1_interface.name);
+	if (!info) return FALSE;
+	
+	protocol_id = info->id;
+	protocol_version = info->version;
+	if ((uint32_t)ext_workspace_manager_v1_interface.version < protocol_version)
+		protocol_version = ext_workspace_manager_v1_interface.version;
+	
 	s_pWSManager = wl_registry_bind (registry, protocol_id, &ext_workspace_manager_v1_interface, protocol_version);
 	if (!s_pWSManager) return FALSE;
 	

--- a/src/implementations/cairo-dock-ext-workspaces.h
+++ b/src/implementations/cairo-dock-ext-workspaces.h
@@ -2,7 +2,7 @@
  * cairo-dock-ext-workspaces.h -- desktop / workspace management
  *  facilities based on the ext-workspace Wayland protocol
  * 
- * Copyright 2024-2025 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2024-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,7 +27,6 @@
 
 extern struct wl_output *s_ws_output;
 
-gboolean gldi_ext_workspaces_match_protocol (uint32_t id, const char *interface, uint32_t version);
 gboolean gldi_ext_workspaces_try_init (struct wl_registry *registry);
 struct ext_workspace_handle_v1 *gldi_ext_workspaces_get_handle (int x, int y);
 gboolean gldi_ext_workspaces_find (struct ext_workspace_handle_v1 *handle, int *x, int *y);

--- a/src/implementations/cairo-dock-foreign-toplevel.c
+++ b/src/implementations/cairo-dock-foreign-toplevel.c
@@ -4,7 +4,7 @@
  * Interact with Wayland clients via the zwlr_foreign_toplevel_manager
  * protocol. See e.g. https://github.com/swaywm/wlr-protocols/blob/master/unstable/wlr-foreign-toplevel-management-unstable-v1.xml
  * 
- * Copyright 2020-2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2020-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -280,25 +280,14 @@ static void gldi_zwlr_foreign_toplevel_manager_init ()
 	gldi_wf_backend_init_appid_tracking (); // optional functionality to get the GTK application-id supplied by Wayfire
 }
 
-static uint32_t protocol_id, protocol_version;
-static gboolean protocol_found = FALSE;
-
-gboolean gldi_wlr_foreign_toplevel_match_protocol (uint32_t id, const char *interface, uint32_t version)
-{
-	if (!strcmp(interface, zwlr_foreign_toplevel_manager_v1_interface.name))
-	{
-		protocol_found = TRUE;
-		protocol_id = id;
-		protocol_version = version;
-		return TRUE;
-	}
-	return FALSE;
-}
-
 
 gboolean gldi_wlr_foreign_toplevel_try_init (struct wl_registry *registry)
 {
-	if (!protocol_found) return FALSE;
+	const GldiWaylandProtocolInfo *info = gldi_wayland_get_global (zwlr_foreign_toplevel_manager_v1_interface.name);
+	if (!info) return FALSE;
+	
+	uint32_t protocol_id = info->id;
+	uint32_t protocol_version = info->version;
 	
 	if (protocol_version > (uint32_t)zwlr_foreign_toplevel_manager_v1_interface.version)
 	{
@@ -315,7 +304,6 @@ gboolean gldi_wlr_foreign_toplevel_try_init (struct wl_registry *registry)
 	cd_error ("Could not bind wlr-foreign-toplevel-manager!");
     return FALSE;
 }
-
 
 #endif
 

--- a/src/implementations/cairo-dock-foreign-toplevel.h
+++ b/src/implementations/cairo-dock-foreign-toplevel.h
@@ -4,7 +4,7 @@
  * Interact with Wayland clients via the zwlr_foreign_toplevel_manager
  * protocol. See e.g. https://github.com/swaywm/wlr-protocols/blob/master/unstable/wlr-foreign-toplevel-management-unstable-v1.xml
  * 
- * Copyright 2020-2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2020-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,7 +27,6 @@
 #include <wayland-client.h>
 #include <stdint.h>
 
-gboolean gldi_wlr_foreign_toplevel_match_protocol (uint32_t id, const char *interface, uint32_t version);
 gboolean gldi_wlr_foreign_toplevel_try_init (struct wl_registry *registry);
 
 #endif

--- a/src/implementations/cairo-dock-kwin-integration.c
+++ b/src/implementations/cairo-dock-kwin-integration.c
@@ -123,12 +123,16 @@ static void present_class (const gchar *cClass, CairoDockDesktopManagerActionRes
 		else
 #endif
 		{
+#ifdef HAVE_X11
+			// note: this code path will only be called if HAVE_X11 is defined (since otherwise, we will not
+			// have a taskbar in the first place on X11)
 			unsigned long xid = gldi_X_manager_get_window_xid (pOneIcon->pAppli);
 			if (xid)
 			{
 				g_variant_builder_add_value (&builder, g_variant_new_take_string (g_strdup_printf ("%lu", xid)));
 				i++;
 			}
+#endif
 		}
 	}
 	

--- a/src/implementations/cairo-dock-plasma-virtual-desktop.c
+++ b/src/implementations/cairo-dock-plasma-virtual-desktop.c
@@ -2,7 +2,7 @@
  * cairo-dock-plasma-virtual-desktop.c -- desktop / workspace management
  *  facilities for KWin / KDE Plasma
  * 
- * Copyright 2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2024-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,6 +24,7 @@
 #include "cairo-dock-windows-manager.h"
 #include "cairo-dock-plasma-virtual-desktop.h"
 #include "cairo-dock-wayland-wm.h"
+#include "cairo-dock-wayland-manager.h"
 
 typedef struct _PlasmaDesktop {
 	struct org_kde_plasma_virtual_desktop *handle; // protocol object representing this desktop
@@ -332,26 +333,17 @@ static void _remove_workspace (void)
 }
 
 
-static uint32_t protocol_id, protocol_version;
-static gboolean protocol_found = FALSE;
-
-gboolean gldi_plasma_virtual_desktop_match_protocol (uint32_t id, const char *interface, uint32_t version)
-{
-	if (!strcmp(interface, org_kde_plasma_virtual_desktop_management_interface.name))
-	{
-		protocol_found = TRUE;
-		protocol_id = id;
-		protocol_version = version;
-		if ((uint32_t)org_kde_plasma_virtual_desktop_management_interface.version < protocol_version)
-			protocol_version = org_kde_plasma_virtual_desktop_management_interface.version;
-		return TRUE;
-	}
-	return FALSE;
-}
-
 gboolean gldi_plasma_virtual_desktop_try_init (struct wl_registry *registry)
 {
-	if (!protocol_found) return FALSE;
+	uint32_t protocol_id, protocol_version;
+	const GldiWaylandProtocolInfo *info = gldi_wayland_get_global (org_kde_plasma_virtual_desktop_management_interface.name);
+	if (!info) return FALSE;
+	
+	protocol_id = info->id;
+	protocol_version = info->version;
+	if ((uint32_t)org_kde_plasma_virtual_desktop_management_interface.version < protocol_version)
+		protocol_version = org_kde_plasma_virtual_desktop_management_interface.version;
+	
 	s_pmanager = wl_registry_bind (registry, protocol_id, &org_kde_plasma_virtual_desktop_management_interface, protocol_version);
 	if (!s_pmanager) return FALSE;
 	

--- a/src/implementations/cairo-dock-plasma-virtual-desktop.h
+++ b/src/implementations/cairo-dock-plasma-virtual-desktop.h
@@ -2,7 +2,7 @@
  * cairo-dock-plasma-virtual-desktop.h -- desktop / workspace management
  *  facilities for KWin / KDE Plasma
  * 
- * Copyright 2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2024-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,7 +24,6 @@
 #include <wayland-client.h>
 #include <stdint.h>
 
-gboolean gldi_plasma_virtual_desktop_match_protocol (uint32_t id, const char *interface, uint32_t version);
 gboolean gldi_plasma_virtual_desktop_try_init (struct wl_registry *registry);
 
 /// Try to get the coordinates of a virtual desktop with the associated ID.

--- a/src/implementations/cairo-dock-plasma-window-manager.c
+++ b/src/implementations/cairo-dock-plasma-window-manager.c
@@ -4,7 +4,7 @@
  * Interact with Wayland clients via the plasma-window-management
  * protocol. See e.g. https://invent.kde.org/libraries/plasma-wayland-protocols/-/blob/master/src/protocols/plasma-window-management.xml
  * 
- * Copyright 2021-2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2021-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,6 +36,7 @@
 #include "cairo-dock-plasma-window-manager.h"
 #include "cairo-dock-desktop-manager.h"
 #include "cairo-dock-wayland-wm.h"
+#include "cairo-dock-wayland-manager.h"
 #include "cairo-dock-plasma-virtual-desktop.h"
 
 #include <stdio.h>
@@ -622,9 +623,6 @@ static void _reset_object (GldiObject* obj)
 	}
 }
 
-static uint32_t protocol_id;
-static gboolean protocol_found = FALSE;
-
 static void gldi_plasma_window_manager_init ()
 {
 	// hash table to map uuids to windows
@@ -685,23 +683,13 @@ static void gldi_plasma_window_manager_init ()
 	gldi_object_set_manager (GLDI_OBJECT (&myPlasmaWindowObjectMgr), &myWaylandWMObjectMgr);
 }
 
-
-gboolean gldi_plasma_window_manager_match_protocol (uint32_t id, const char *interface, uint32_t version)
-{
-	if (!strcmp(interface, org_kde_plasma_window_management_interface.name))
-	{
-		protocol_found = TRUE;
-		protocol_id = id;
-		server_protocol_version = version;
-		return TRUE;
-	}
-	return FALSE;
-}
-
 gboolean gldi_plasma_window_manager_try_init (struct wl_registry *registry)
 {
-	if (!protocol_found) return FALSE;
+	const GldiWaylandProtocolInfo *info = gldi_wayland_get_global (org_kde_plasma_window_management_interface.name);
+	if (!info) return FALSE;
 	
+	uint32_t protocol_id = info->id;
+	server_protocol_version = info->version;
 	uint32_t protocol_version = server_protocol_version;
 	if (protocol_version > (uint32_t)org_kde_plasma_window_management_interface.version)
 	{

--- a/src/implementations/cairo-dock-plasma-window-manager.h
+++ b/src/implementations/cairo-dock-plasma-window-manager.h
@@ -5,7 +5,7 @@
  * org_kde_plasma_window_management protocol.
  * See e.g. https://wayland.app/protocols/kde-plasma-window-management
  * 
- * Copyright 2020-2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2020-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,7 +28,6 @@
 #include <wayland-client.h>
 #include <stdint.h>
 
-gboolean gldi_plasma_window_manager_match_protocol (uint32_t id, const char *interface, uint32_t version);
 gboolean gldi_plasma_window_manager_try_init (struct wl_registry *registry);
 
 const char *gldi_plasma_window_manager_get_uuid (GldiWindowActor *actor);

--- a/src/implementations/cairo-dock-wayland-hotspots.c
+++ b/src/implementations/cairo-dock-wayland-hotspots.c
@@ -3,7 +3,7 @@
  * 
  * Functions to monitor screen edges for recalling a hidden dock.
  * 
- * Copyright 2021-2025 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2021-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
@@ -101,8 +101,6 @@ static void _hotspot_hit_cb (CairoDock *pDock, gpointer user_data)
 #ifdef HAVE_WAYLAND_PROTOCOLS
 /// Private variables
 static struct zwf_shell_manager_v2 *s_pshell_manager = NULL;
-static uint32_t wf_shell_id, wf_shell_version;
-static gboolean wf_shell_found = FALSE;
 static guint s_sidMenu = 0;
 
 typedef struct _wf_hotspots {
@@ -460,34 +458,18 @@ void gldi_wayland_hotspots_update (void)
 }
 
 
-/// Try to match Wayland protocols that we need to use
-gboolean gldi_wayland_hotspots_match_protocol (uint32_t id, const char *interface, uint32_t version)
-{
-#ifdef HAVE_WAYLAND_PROTOCOLS
-	if (!strcmp (interface, zwf_shell_manager_v2_interface.name))
-	{
-		wf_shell_id = id;
-		wf_shell_version = version;
-		wf_shell_found = TRUE;
-		return TRUE;
-	}
-#else
-	// avoid warnings for unused variables
-	(void)id;
-	(void)interface;
-	(void)version;
-#endif
-	return FALSE;
-}
-
 /// Try to init based on the protocols found
 GldiWaylandHotspotsType gldi_wayland_hotspots_try_init (struct wl_registry *registry)
 {
 	GldiWaylandHotspotsType type = GLDI_WAYLAND_HOTSPOTS_NONE;
 	
 #ifdef HAVE_WAYLAND_PROTOCOLS
-	if (wf_shell_found)
+	const GldiWaylandProtocolInfo *info = gldi_wayland_get_global (zwf_shell_manager_v2_interface.name);
+	if (info)
 	{
+		uint32_t wf_shell_id = info->id;
+		uint32_t wf_shell_version = info->version;
+		
 		if (wf_shell_version > (uint32_t)zwf_shell_manager_v2_interface.version)
 		{
 			wf_shell_version = zwf_shell_manager_v2_interface.version;

--- a/src/implementations/cairo-dock-wayland-hotspots.h
+++ b/src/implementations/cairo-dock-wayland-hotspots.h
@@ -6,7 +6,7 @@
  *   -- on Wayfire, wf-shell is used 
  *   -- as a generic case, a transparent layer-shell surface is used
  * 
- * Copyright 2021-2024 Daniel Kondor <kondor.dani@gmail.com>
+ * Copyright 2021-2026 Daniel Kondor <kondor.dani@gmail.com>
  * 
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
@@ -28,9 +28,6 @@
 #include <wayland-client.h>
 #include <stdint.h>
 #include <glib.h>
-
-/// Try to match Wayland protocols that we need to use
-gboolean gldi_wayland_hotspots_match_protocol (uint32_t id, const char *interface, uint32_t version);
 
 typedef enum {
 	GLDI_WAYLAND_HOTSPOTS_NONE, // we could not init support for hotspots

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -77,7 +77,8 @@ static gboolean s_bHave_Layer_Shell = FALSE;
 
 static GldiWaylandCompositorType s_CompositorType = WAYLAND_COMPOSITOR_NONE;
 
-
+////////////////////////////////////////////////////////////////////////
+// Utilities
 static void _try_detect_compositor (void)
 {
 	const char *dmb_names = gldi_desktop_manager_get_backend_names ();
@@ -97,6 +98,11 @@ static void _try_detect_compositor (void)
 GldiWaylandCompositorType gldi_wayland_get_compositor_type (void) { return s_CompositorType; }
 void gldi_wayland_set_compositor_type (GldiWaylandCompositorType type) { s_CompositorType = type; }
 
+static gboolean _is_wayland() { return TRUE; }
+
+
+////////////////////////////////////////////////////////////////////////
+// Containers: positioning, input shape, keyboard and mouse focus
 CairoDockPositionType gldi_wayland_get_edge_for_dock (const CairoDock *pDock)
 {
 	CairoDockPositionType pos;
@@ -460,8 +466,12 @@ static void _adjust_aimed_point (const Icon *pIcon, G_GNUC_UNUSED GtkWidget *pWi
 	}
 }
 
-static gboolean _is_wayland() { return TRUE; }
 
+////////////////////////////////////////////////////////////////////////
+// Registry
+struct wl_registry *s_pRegistry = NULL;
+static GHashTable *s_pProtocolMap = NULL; // key: name (owned), value: GldiWaylandProtocolInfo (owned)
+static GHashTable *s_pProtocolMapRev = NULL; // key: id, value: name (unowned, from the above)
 
 static gboolean s_bInitializing = TRUE;  // each time a callback is called on startup, it will set this to TRUE, and we'll make a roundtrip to the server until no callback is called.
 
@@ -473,30 +483,13 @@ static void _registry_global_cb ( G_GNUC_UNUSED void *data, struct wl_registry *
 		s_pCompositor = wl_registry_bind(registry, id, &wl_compositor_interface, 1);
 	}
 #ifdef HAVE_WAYLAND_PROTOCOLS
-	else if (gldi_wayland_hotspots_match_protocol (id, interface, version))
-	{
-		/* this space is intentionally left blank */
-	}
-	else if (gldi_wlr_foreign_toplevel_match_protocol (id, interface, version))
-	{
-		cd_debug("Found foreign-toplevel-manager");
-	}
-	else if (gldi_plasma_window_manager_match_protocol (id, interface, version))
-	{
-		cd_debug("Found plasma-window-manager");
-	}
-	else if (gldi_plasma_virtual_desktop_match_protocol (id, interface, version))
-	{
-		cd_debug("Found plasma-virtual-desktop-manager");
-	}
-	else if (gldi_cosmic_toplevel_match_protocol (id, interface, version))
-	{
-		cd_debug("Found cosmic-toplevel-manager");
-	}
-	else if (gldi_ext_workspaces_match_protocol (id, interface, version))
-	{
-		cd_debug("Found ext-workspace-manager");
-	}
+	gchar *key = g_strdup (interface);
+	GldiWaylandProtocolInfo *info = g_new (GldiWaylandProtocolInfo, 1);
+	info->id = id;
+	info->version = version;
+	g_hash_table_insert (s_pProtocolMap, key, info);
+	g_hash_table_insert (s_pProtocolMapRev, GUINT_TO_POINTER (id), key);
+	/// TODO: send out a notification?
 #else
 	(void)version; // avoid warning
 #endif
@@ -506,7 +499,15 @@ static void _registry_global_cb ( G_GNUC_UNUSED void *data, struct wl_registry *
 static void _registry_global_remove_cb (G_GNUC_UNUSED void *data, G_GNUC_UNUSED struct wl_registry *registry, uint32_t id)
 {
 	cd_debug ("got a global object has disappeared: id=%d", id);
-	/// TODO: find it and destroy it...
+	
+	char *interface = g_hash_table_lookup (s_pProtocolMapRev, GUINT_TO_POINTER (id));
+	if (!interface) cd_warning ("Global %d not found", id);
+	else
+	{
+		g_hash_table_remove (s_pProtocolMapRev, GUINT_TO_POINTER (id));
+		g_hash_table_remove (s_pProtocolMap, interface);
+	}
+	/// TODO: send out a notification?
 }
 
 static const struct wl_registry_listener registry_listener = {
@@ -514,11 +515,24 @@ static const struct wl_registry_listener registry_listener = {
 	_registry_global_remove_cb
 };
 
+const GldiWaylandProtocolInfo *gldi_wayland_get_global (const char *cInterfaceName)
+{
+	return g_hash_table_lookup (s_pProtocolMap, cInterfaceName);
+}
+struct wl_registry *gldi_wayland_get_registry ()
+{
+	return s_pRegistry;
+}
+
 
 static void init (void)
 {
 	//\__________________ listen for Wayland events
-	struct wl_registry *registry = wl_display_get_registry (s_pDisplay);
+	s_pProtocolMap = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+	s_pProtocolMapRev = g_hash_table_new (NULL, NULL);
+	
+	s_pRegistry = wl_display_get_registry (s_pDisplay);
+	struct wl_registry *registry = s_pRegistry;
 	wl_registry_add_listener (registry, &registry_listener, NULL);
 	do
 	{

--- a/src/implementations/cairo-dock-wayland-manager.h
+++ b/src/implementations/cairo-dock-wayland-manager.h
@@ -63,5 +63,19 @@ void gldi_wayland_release_keyboard (GldiContainer *pContainer, GldiWaylandReleas
 /// Get the name of the Wayland compositor that was detected
 const gchar *gldi_wayland_get_detected_compositor (void);
 
+
+#ifdef HAVE_WAYLAND
+
+typedef struct _GldiWaylandProtocolInfo {
+	uint32_t id;
+	uint32_t version;
+} GldiWaylandProtocolInfo;
+
+/// Get information about a Wayland global or NULL if it does not exist
+const GldiWaylandProtocolInfo *gldi_wayland_get_global (const char *cInterfaceName);
+/// Get the registry that can be used to bind globals
+struct wl_registry *gldi_wayland_get_registry (void);
+#endif
+
 G_END_DECLS
 #endif


### PR DESCRIPTION
This allows plugins to provide functions based on specific protocols.