### PR TITLE
More robust crash handling

### DIFF
--- a/data/systemd/cairo-dock.service.in
+++ b/data/systemd/cairo-dock.service.in
@@ -8,6 +8,12 @@ Requisite=graphical-session.target
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/cairo-dock
 Type=exec
 BusName=org.cairodock.CairoDock
+# We want to restart on OOM or if killed by a signal not caught by our crash
+# manager, but not on nonzero exit code which happens if we already tried
+# restarting ourselves several times, if wrong command line options were given
+# (which should not happen as there are no options above) or if an instance is
+# already running.
+Restart=on-abnormal
 
 [Install]
 WantedBy=graphical-session.target

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -204,9 +204,10 @@ static gboolean _cairo_dock_quit (G_GNUC_UNUSED gpointer user_data)
  *  - 5th crash: quit with error code (1)
  * 
  * Note: this is to catch crashes due to bugs, so it handles the corresponding signals:
- *   SIGSEGV, SIGFPE, SIGILL, SIGABRT
- * while SIGPIPE is set to ignore by GTK and SIGTERM and SIGINT are handled above, leading to a
- * clean exit (TODO: SIGHUP?). Other errors will lead to exit with an error code:
+ *   SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGABRT
+ * while SIGPIPE is set to ignore by GTK, we explicitly ignore SIGHUP, while SIGTERM and SIGINT
+ * are handled above, leading to a clean exit.
+ * Other errors will lead to exit with an error code:
  *  - bad command line options (these will typically come from launching the dock from a terminal,
  *    so it is better to show the error to the user)
  *  - already running (to avoid having multiple instances; can be overridden by the "-I" option)
@@ -273,9 +274,11 @@ static void _cairo_dock_intercept_signal (int signal)
 static void _cairo_dock_set_signal_interception (void)
 {
 	signal (SIGSEGV, _cairo_dock_intercept_signal);  // Segmentation violation
+	signal (SIGBUS, _cairo_dock_intercept_signal);  // Bad memory access (can happen instead of SIGSEGV in some cases)
 	signal (SIGFPE, _cairo_dock_intercept_signal);  // Floating-point exception
 	signal (SIGILL, _cairo_dock_intercept_signal);  // Illegal instruction
 	signal (SIGABRT, _cairo_dock_intercept_signal);  // Abort // kill -6
+	signal (SIGHUP, SIG_IGN); // ignore SIGHUP, not really useful (we will instead quit if the connection to the X server / Wayland compositor closes)
 }
 
 static gboolean on_delete_maintenance_gui (G_GNUC_UNUSED GtkWidget *pWidget, GMainLoop *pBlockingLoop)
@@ -1080,10 +1083,12 @@ int main (int argc, char** argv)
 	gtk_main ();
 	
 	signal (SIGSEGV, NULL);  // Segmentation violation
+	signal (SIGBUS, NULL);
 	signal (SIGFPE, NULL);  // Floating-point exception
 	signal (SIGILL, NULL);  // Illegal instruction
 	signal (SIGABRT, NULL);
 	signal (SIGTERM, NULL);
+	signal (SIGINT, NULL);
 	signal (SIGHUP, NULL);
 
 	gldi_free_all ();

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -53,6 +53,7 @@
 #include <time.h>
 
 #include <glib/gstdio.h>
+#include <glib-unix.h> // g_unix_signal_add
 
 #include "config.h"
 #include "gldi-config.h"
@@ -187,9 +188,10 @@ static gboolean _cairo_dock_first_launch_setup (G_GNUC_UNUSED gpointer data)
 	cairo_dock_launch_command_single (CAIRO_DOCK_SHARE_DATA_DIR"/scripts/initial-setup.sh");
 	return FALSE;
 }
-static void _cairo_dock_quit (G_GNUC_UNUSED int signal)
+static gboolean _cairo_dock_quit (G_GNUC_UNUSED gpointer user_data)
 {
 	gtk_main_quit ();
+	return G_SOURCE_CONTINUE;
 }
 /* Crash handler that tries to restart Cairo-Dock. The motivation is that since Cairo-Dock may
  * provide the main (or only) desktop UI, it should not "just disappear" due to a crash. The
@@ -203,9 +205,8 @@ static void _cairo_dock_quit (G_GNUC_UNUSED int signal)
  * 
  * Note: this is to catch crashes due to bugs, so it handles the corresponding signals:
  *   SIGSEGV, SIGFPE, SIGILL, SIGABRT
- * Other signals (SIGTERM, SIGINT) are not handled and they can be used to quite Cairo-Dock
- * (TODO: handle these while manipulating config files to avoid having half-written output?),
- * while SIGPIPE is set to ignore by GTK. Other errors will lead to exit with an error code:
+ * while SIGPIPE is set to ignore by GTK and SIGTERM and SIGINT are handled above, leading to a
+ * clean exit (TODO: SIGHUP?). Other errors will lead to exit with an error code:
  *  - bad command line options (these will typically come from launching the dock from a terminal,
  *    so it is better to show the error to the user)
  *  - already running (to avoid having multiple instances; can be overridden by the "-I" option)
@@ -836,8 +837,8 @@ int main (int argc, char** argv)
 		_cairo_dock_set_signal_interception ();
 	
 	//\___________________ handle terminate signals to quit properly (especially when the system shuts down).
-	signal (SIGTERM, _cairo_dock_quit);  // Term // kill -15 (system)
-	signal (SIGHUP,  _cairo_dock_quit);  // sent to a process when its controlling terminal is closed
+	g_unix_signal_add (SIGTERM, _cairo_dock_quit, NULL);  // Term // kill -15 (system)
+	g_unix_signal_add (SIGINT, _cairo_dock_quit, NULL);  // Int // Ctrl-C
 
 	//\___________________ Disable modules that have crashed
 	if (cExcludeModule != NULL && (s_iNbCrashes > 2 || bMaintenance)) // 3th crash or 4th (with -m)

--- a/src/cairo-dock.c
+++ b/src/cairo-dock.c
@@ -191,11 +191,33 @@ static void _cairo_dock_quit (G_GNUC_UNUSED int signal)
 {
 	gtk_main_quit ();
 }
-/* Crash at startup:
+/* Crash handler that tries to restart Cairo-Dock. The motivation is that since Cairo-Dock may
+ * provide the main (or only) desktop UI, it should not "just disappear" due to a crash. The
+ * crash handler thus tries to ensure that it keeps running by restarting it. If the crash happens
+ * at startup, we try to disable any module that may have caused it to avoid endless crash loops.
+ * Specifically, the following sequence is followed:
  *  - First 2 crashes: retry with a delay of 2 sec (maybe due to a problem at startup)
- *  - 3th crash: remove the applet and restart the dock
+ *  - 3th crash: restart the dock immediately
  *  - 4th crash: show the maintenance mode
- *  - 5th crash: quit
+ *  - 5th crash: quit with error code (1)
+ * 
+ * Note: this is to catch crashes due to bugs, so it handles the corresponding signals:
+ *   SIGSEGV, SIGFPE, SIGILL, SIGABRT
+ * Other signals (SIGTERM, SIGINT) are not handled and they can be used to quite Cairo-Dock
+ * (TODO: handle these while manipulating config files to avoid having half-written output?),
+ * while SIGPIPE is set to ignore by GTK. Other errors will lead to exit with an error code:
+ *  - bad command line options (these will typically come from launching the dock from a terminal,
+ *    so it is better to show the error to the user)
+ *  - already running (to avoid having multiple instances; can be overridden by the "-I" option)
+ *  - if the DBus connection to the session bus is closed, Gio will exit (with SIGTERM); this
+ *    should not happen under normal circumstances
+ * 
+ * If running as a systemd unit, an additional protection against OOM kills is provided by the
+ * "Restart=on-abnormal" option that will try to restart the dock after being killed in this case
+ * (since the OOM uses SIGKILL, it is not possible to catch this ourselves). All other cases
+ * covered by this are already handled above, and we do not ask to restart after exit with an
+ * error code, since that corresponds to errors that could not be fixed if running as a systemd
+ * unit.
  */
 static void _cairo_dock_intercept_signal (int signal)
 {
@@ -491,7 +513,13 @@ int main (int argc, char** argv)
 	GOptionContext *context = g_option_context_new ("Cairo-Dock");
 	g_option_context_add_main_entries (context, pOptionsTable, NULL);
 	g_option_context_parse (context, &argc, &argv, &erreur);
-	if (erreur != NULL) cd_error ("ERROR in options: %s", erreur->message); // will exit
+	if (erreur != NULL)
+	{
+		// return instead of using cd_error () so that systemd will not attempt to restart us
+		// (no point if the problem was with wrong command line options)
+		cd_critical ("ERROR in options: %s", erreur->message);
+		return 1;
+	}
 	
 	if (bPrintVersion)
 	{
@@ -505,9 +533,15 @@ int main (int argc, char** argv)
 		return 0;
 	}
 	if (g_bDisableDbusActivation && g_bGioLaunch)
-		cd_error ("Cannot disable DBus activation if launching apps with GIO (use only one of the --disable-dbus-activation and --force-gio-launch options)!\n");
+	{
+		cd_critical ("Cannot disable DBus activation if launching apps with GIO (use only one of the --disable-dbus-activation and --force-gio-launch options)!\n");
+		return 1;
+	}
 	if (g_bForceWayland && g_bForceX11)
-		cd_error ("Both Wayland and X11 backends cannot be requested (use only one of the -L and -X options)!\n");
+	{
+		cd_critical ("Both Wayland and X11 backends cannot be requested (use only one of the -L and -X options)!\n");
+		return 1;
+	}
 	if (g_bForceWayland) gdk_set_allowed_backends ("wayland");
 	if (g_bForceX11) gdk_set_allowed_backends ("x11");
 	
@@ -560,7 +594,8 @@ int main (int argc, char** argv)
 		else if (!bAllowMultiInstance)
 		{
 			//!! TODO: check if another instance is really running and responsive? (e.g. with a Ping-like call)
-			cd_error ("Cairo-Dock is already running, not starting another instance (use the \"-I\" command line option to override).");
+			cd_critical ("Cairo-Dock is already running, not starting another instance (use the \"-I\" command line option to override).");
+			return 1;
 		}
 	}
 	

--- a/src/gldit/cairo-dock-keyfile-utilities.c
+++ b/src/gldit/cairo-dock-keyfile-utilities.c
@@ -17,10 +17,12 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define _DEFAULT_SOURCE
+
 #include <string.h>
 #include <stdlib.h>
+#include <fcntl.h> // O_CLOEXEC (need _DEFAULT_SOURCE above)
 #include <glib/gstdio.h>
-#include <gio/gunixoutputstream.h>
 
 #include "cairo-dock-log.h"
 #include "cairo-dock-keyfile-utilities.h"
@@ -41,53 +43,43 @@ GKeyFile *cairo_dock_open_key_file (const gchar *cConfFilePath)
 	return pKeyFile;
 }
 
-void cairo_dock_write_keys_to_file_full (GKeyFile *pKeyFile, const gchar *cConfFilePath, gboolean bAllowEmpty)
+static gboolean _write_keys_to_file_internal (GKeyFile *pKeyFile, const gchar *cConfFilePath, gboolean bAllowEmpty)
 {
-	cd_debug ("%s (%s)", __func__, cConfFilePath);
 	GError *erreur = NULL;
-
-	gchar *cDirectory = g_path_get_dirname (cConfFilePath);
-	if (! g_file_test (cDirectory, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_EXECUTABLE))
-	{
-		g_mkdir_with_parents (cDirectory, 7*8*8+7*8+5);
-	}
-	g_free (cDirectory);
-
-
 	gsize length=0;
 	gchar *cNewConfFileContent = g_key_file_to_data (pKeyFile, &length, &erreur);
 	if (erreur != NULL)
 	{
 		cd_warning ("Error while fetching data : %s", erreur->message);
 		g_error_free (erreur);
-		return ;
+		return FALSE;
 	}
-	if (! bAllowEmpty) g_return_if_fail (cNewConfFileContent != NULL && *cNewConfFileContent != '\0');
-
-	g_file_set_contents (cConfFilePath, cNewConfFileContent, length, &erreur);
+	if (! bAllowEmpty)
+	{
+		if (! cNewConfFileContent || !*cNewConfFileContent || !length)
+		{
+			cd_warning ("Empty keyfile contents");
+			g_free (cNewConfFileContent);
+			return FALSE;
+		}
+	}
+	
+	g_file_set_contents_full (cConfFilePath, cNewConfFileContent ? cNewConfFileContent : "",
+		length, G_FILE_SET_CONTENTS_CONSISTENT, 0600, &erreur);
+	g_free (cNewConfFileContent);
 	if (erreur != NULL)
 	{
 		cd_warning ("Error while writing data to %s : %s", cConfFilePath, erreur->message);
 		g_error_free (erreur);
-		return ;
+		return FALSE;
 	}
-	g_free (cNewConfFileContent);
+	
+	return TRUE;
 }
 
-gchar *cairo_dock_write_keys_to_new_file (GKeyFile *pKeyFile, const gchar *cConfFilePath)
+void cairo_dock_write_keys_to_file_full (GKeyFile *pKeyFile, const gchar *cConfFilePath, gboolean bAllowEmpty)
 {
-	GError *erreur = NULL;
-	GOutputStream *out = NULL;
-	gchar *cTemplate = NULL;
-
-	gsize length = 0;
-	// note: g_key_file_to_data () never reports errors
-	gchar *cNewConfFileContent = g_key_file_to_data (pKeyFile, &length, NULL);
-	if ( !(cNewConfFileContent && length && *cNewConfFileContent) )
-	{
-		cd_warning ("Error while fetching data for keyfile");
-		return NULL;
-	}
+	cd_debug ("%s (%s)", __func__, cConfFilePath);
 
 	gchar *cDirectory = g_path_get_dirname (cConfFilePath);
 	if (! g_file_test (cDirectory, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_EXECUTABLE))
@@ -95,65 +87,57 @@ gchar *cairo_dock_write_keys_to_new_file (GKeyFile *pKeyFile, const gchar *cConf
 		g_mkdir_with_parents (cDirectory, 7*8*8+7*8+5);
 	}
 	g_free (cDirectory);
+	
+	_write_keys_to_file_internal (pKeyFile, cConfFilePath, bAllowEmpty);
+}
 
-	GFile *file = g_file_new_for_path (cConfFilePath);
-	out = G_OUTPUT_STREAM (g_file_create (file, G_FILE_CREATE_NONE, NULL, NULL));
-	g_object_unref (file);
-	if (out) cTemplate = g_strdup (cConfFilePath);
-	else
+gchar *cairo_dock_write_keys_to_new_file (GKeyFile *pKeyFile, const gchar *cConfFilePath)
+{
+	gchar *cDirectory = g_path_get_dirname (cConfFilePath);
+	if (! g_file_test (cDirectory, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_EXECUTABLE))
+	{
+		g_mkdir_with_parents (cDirectory, 7*8*8+7*8+5);
+	}
+	g_free (cDirectory);
+
+	/* Potentially add a suffix to cConfFilePath if it exists.
+	 * In this function, we care about:
+	 *   -- not overwriting an existing valid config file
+	 *   -- not leaving a half-written config file after a crash
+	 * We do not care about TOCTOU, since g_file_set_contents() will replace any existing
+	 * file in a safe way (using rename()), and no one else should be (legitimately) writing
+	 * to our config directory. This way, just checking for existence of a file is sufficient.
+	 */
+	gchar *cNewPath = NULL;
+	if (g_file_test (cConfFilePath, G_FILE_TEST_EXISTS))
 	{
 		size_t len = strlen (cConfFilePath);
 		if (g_str_has_suffix (cConfFilePath, ".desktop")) len -= 8;
+		
 		GString *sTemplate = g_string_sized_new (len + 16); // suffix + _XXXXXX.desktop + 0-terminator
 		g_string_append_len (sTemplate, cConfFilePath, len);
 		g_string_append (sTemplate, "_XXXXXX.desktop");
-		cTemplate = g_string_free (sTemplate, FALSE);
+		gchar *cTemplate = g_string_free (sTemplate, FALSE);
 
-		gint fd = g_mkstemp (cTemplate);
+		gint fd = g_mkstemp_full (cTemplate, O_CLOEXEC, 0600);
 		if (fd == -1)
 		{
 			cd_warning ("Error creating new launcher for template: %s", cConfFilePath);
 			g_free (cTemplate);
-			g_free (cNewConfFileContent);
 			return NULL; // cannot create new file
 		}
-		out = g_unix_output_stream_new (fd, TRUE);
-		if (!out)
-		{
-			// should not happen at this point
-			g_free (cTemplate);
-			g_free (cNewConfFileContent);
-			close (fd);
-			return NULL;
-		}
+		
+		close (fd); // not needed, file will be overwritten below
+		cNewPath = cTemplate;
 	}
-
-	gboolean res = g_output_stream_write_all (out, cNewConfFileContent, length, NULL, NULL, &erreur);
-	if (!res)
-	{
-		cd_warning ("Error while writing data to %s : %s", cTemplate, erreur->message);
-		g_error_free (erreur);
-		erreur = NULL;
-	}
-
-	if (!g_output_stream_close (out, NULL, &erreur))
-	{
-		if (res) // otherwise we already printed a warning above
-			cd_warning ("Error while writing data to %s : %s", cTemplate, erreur->message);
-		g_error_free (erreur);
-		erreur = NULL;
-		res = FALSE;
-	}
-	g_object_unref (out);
-	g_free (cNewConfFileContent);
-
-	if (!res)
-	{
-		g_unlink (cTemplate);
-		g_free (cTemplate);
-		cTemplate = NULL;
-	}
-	return cTemplate;
+	
+	// now that we have a valid path, write to the file
+	if (_write_keys_to_file_internal (pKeyFile, cNewPath ? cNewPath : cConfFilePath, FALSE))
+		return cNewPath ? cNewPath : g_strdup (cConfFilePath); // success: return a newly allocated string
+	
+	// failure: free any memory and return NULL
+	g_free (cNewPath);
+	return NULL;
 }
 
 


### PR DESCRIPTION
 - Restart on `SIGKILL` (including OOM) if running as a systemd unit
 - Also handle `SIGBUS` and `SIGINT`, use `g_unix_signal_add()` for signals that should exit cleanly
 - Ensure that conf file writes are atomic, even for new files