### PR TITLE
dialogs: fix a crash and improve the situation for dialogs without an icon

### DIFF
--- a/src/gldit/cairo-dock-container.c
+++ b/src/gldit/cairo-dock-container.c
@@ -426,33 +426,53 @@ void gldi_container_move_to_rect (GldiContainer *pContainer, const GdkRectangle 
 void gldi_container_calculate_rect (const GldiContainer* pContainer, const Icon* pPointedIcon,
 	GdkRectangle *rect, GdkGravity* rect_anchor, GdkGravity* window_anchor, gboolean bSkipLabel)
 {
-	if (! (pPointedIcon && pContainer) ) return;
+	if (!pContainer) return;
 
 	if (pContainer->bIsHorizontal)
 	{
-		rect->x = pPointedIcon->fDrawX;
-		rect->y = pPointedIcon->fDrawY;
-		rect->width = pPointedIcon->fWidth * pPointedIcon->fScale;
-		rect->height = pPointedIcon->fHeight * pPointedIcon->fScale;
+		if (pPointedIcon)
+		{
+			rect->x = pPointedIcon->fDrawX;
+			rect->y = pPointedIcon->fDrawY;
+			rect->width = pPointedIcon->fWidth * pPointedIcon->fScale;
+			rect->height = pPointedIcon->fHeight * pPointedIcon->fScale;
+		}
+		else
+		{
+			rect->x = pContainer->iWidth / 2;
+			rect->y = 0;
+			rect->width = 1;
+			rect->height = pContainer->iHeight;
+		}
 		if (pContainer->bDirectionUp)
 		{
 			*rect_anchor = GDK_GRAVITY_NORTH;
 			*window_anchor = GDK_GRAVITY_SOUTH;
-			if (bSkipLabel) rect->y -= myIconsParam.iLabelSize;
+			if (pPointedIcon && bSkipLabel) rect->y -= myIconsParam.iLabelSize;
 		}
 		else
 		{
 			*rect_anchor = GDK_GRAVITY_SOUTH;
 			*window_anchor = GDK_GRAVITY_NORTH;
-			if (bSkipLabel) rect->y += myIconsParam.iLabelSize;
+			if (pPointedIcon && bSkipLabel) rect->y += myIconsParam.iLabelSize;
 		}
 	}
 	else
 	{
-		rect->x = pPointedIcon->fDrawY;
-		rect->y = pPointedIcon->fDrawX;
-		rect->width = pPointedIcon->fHeight * pPointedIcon->fScale;
-		rect->height = pPointedIcon->fWidth * pPointedIcon->fScale;
+		if (pPointedIcon)
+		{
+			rect->x = pPointedIcon->fDrawY;
+			rect->y = pPointedIcon->fDrawX;
+			rect->width = pPointedIcon->fHeight * pPointedIcon->fScale;
+			rect->height = pPointedIcon->fWidth * pPointedIcon->fScale;
+		}
+		else
+		{
+			rect->x = 0;
+			rect->y = pContainer->iWidth / 2;
+			rect->width = pContainer->iHeight;
+			rect->height = 1;
+		}
 		if (pContainer->bDirectionUp)
 		{
 			*rect_anchor = GDK_GRAVITY_WEST;

--- a/src/gldit/cairo-dock-dialog-manager.c
+++ b/src/gldit/cairo-dock-dialog-manager.c
@@ -719,7 +719,7 @@ static void _place_dialog (CairoDialog *pDialog, GldiContainer *pContainer)
 	if (gldi_container_use_new_positioning_code ())
 	{
 		Icon* pPointedIcon = pDialog->pIcon;
-		if (pPointedIcon && pContainer)
+		if (pContainer)
 		{
 			GdkRectangle rect = {0, 0, 1, 1};
 			GdkGravity rect_anchor = GDK_GRAVITY_NORTH, dialog_anchor = GDK_GRAVITY_SOUTH;
@@ -790,7 +790,7 @@ static void _refresh_all_dialogs (gboolean bReplace)
 			next = ic->next;
 			pDialog = next->data;
 			pIcon = pDialog->pIcon;
-			pContainer = cairo_dock_get_icon_container (pIcon);
+			pContainer = pIcon ? cairo_dock_get_icon_container (pIcon) : NULL;
 			gboolean bDelete = FALSE;
 			if (pContainer && !gldi_container_is_visible (pContainer))
 			{


### PR DESCRIPTION
This is unlikely to happen, but is possible if a dock has no icons but is kept alive for some reason (e.g. could not load plugins, or has plugins that are not displaying any icons currently, etc.).