### PR TITLE
Improve monitor selection and matching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.6.101") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
+set (VERSION "3.6.102") # no dash, only numbers, dots and maybe alpha/beta/rc, e.g.: 3.3.1 or 3.3.99.alpha1
 
 add_compile_options (-std=c99 -Wall -Wextra -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/data/cairo-dock-simple.conf.in
+++ b/data/cairo-dock-simple.conf.in
@@ -9,9 +9,11 @@ frame_pos =
 #l-[bottom;top;right;left] Choose which border of the screen the dock will be placed on:
 screen border = 0
 
-#r- Multi-screens
+#_ Multi-screens
 num_screen = 0
-
+screen_description = 
+screen_name = 
+screen_geometry = 
 
 #F-[Visibility of the main dock;@pkgdatadir@/icons/icon-visibility.svg]
 frame_visi =

--- a/data/cairo-dock.conf.in
+++ b/data/cairo-dock.conf.in
@@ -15,8 +15,11 @@ screen border = 0
 #{When set to 0 the dock will position itself relative to the left corner if horizontal and the top corner if vertical. When set to 1 it will position itself relative to the right corner if horizontal and the bottom corner if vertical. When set to 0.5, it will position itself relative to the middle of the screen's edge.}
 alignment = .5
 
-#r- Multi-screens
+#_ Multi-screens
 num_screen = 0
+screen_description = 
+screen_name = 
+screen_geometry = 
 
 #X-[Offset from the screen's edge;view-restore]
 frame_scr =

--- a/data/main-dock.conf.in
+++ b/data/main-dock.conf.in
@@ -16,8 +16,11 @@ screen border = 0
 #{When set to 0 the dock will position itself relative to the left corner if horizontal and the top corner if vertical. When set to 1 it will position itself relative to the right corner if horizontal and the bottom corner if vertical. When set to 0.5, it will position itself relative to the middle of the screen's edge.}
 alignment = .5
 
-#r- Multi-screens
+#_ Multi-screens
 num_screen = 0
+screen_description = 
+screen_name = 
+screen_geometry = 
 
 #F-[Visibility of the dock;@pkgdatadir@/icons/icon-visibility.svg]
 frame_visi =

--- a/data/themes/default-theme-panel/cairo-dock.conf
+++ b/data/themes/default-theme-panel/cairo-dock.conf
@@ -15,8 +15,11 @@ screen border=0
 #{When set to 0 the dock will position itself relative to the left corner if horizontal and the top corner if vertical. When set to 1 it will position itself relative to the right corner if horizontal and the bottom corner if vertical. When set to 0.5, it will position itself relative to the middle of the screen's edge.}
 alignment=0.5
 
-#r- Multi-screens
-num_screen=0
+#_ Multi-screens
+num_screen = 0
+screen_description = 
+screen_name = 
+screen_geometry = 
 
 #X-[Offset from the screen's edge;view-restore]
 frame_scr=

--- a/data/themes/default-theme/cairo-dock.conf
+++ b/data/themes/default-theme/cairo-dock.conf
@@ -15,8 +15,11 @@ screen border=0
 #{When set to 0 the dock will position itself relative to the left corner if horizontal and the top corner if vertical. When set to 1 it will position itself relative to the right corner if horizontal and the bottom corner if vertical. When set to 0.5, it will position itself relative to the middle of the screen's edge.}
 alignment=0.5
 
-#r- Multi-screens
-num_screen=0
+#_ Multi-screens
+num_screen = 0
+screen_description = 
+screen_name = 
+screen_geometry = 
 
 #X-[Offset from the screen's edge;view-restore]
 frame_scr=

--- a/src/cairo-dock-widget-config-group.c
+++ b/src/cairo-dock-widget-config-group.c
@@ -42,8 +42,6 @@ static void _config_group_widget_apply (CDWidget *pCdWidget)
 	g_return_if_fail (pKeyFile != NULL);
 
 	cairo_dock_update_keyfile_from_widget_list (pKeyFile, pCdWidget->pWidgetList);
-	cairo_dock_write_keys_to_conf_file (pKeyFile, g_cConfFile);
-	g_key_file_free (pKeyFile);
 	
 	// reload the associated managers.
 	const gchar *cManagerName, *cModuleName;
@@ -59,7 +57,9 @@ static void _config_group_widget_apply (CDWidget *pCdWidget)
 		cManagerName = m->data;
 		pManager = gldi_manager_get (cManagerName);
 		g_return_if_fail (pManager != NULL);
-		gldi_object_reload (GLDI_OBJECT(pManager), TRUE);
+		
+		if (pManager->save_custom_widget)
+			pManager->save_custom_widget (pKeyFile, pCdWidget->pWidgetList);
 		
 		// reload the extensions too
 		for (e = pManager->pExternalModules; e != NULL && w != NULL; e = e->next)
@@ -84,9 +84,32 @@ static void _config_group_widget_apply (CDWidget *pCdWidget)
 			
 			cairo_dock_update_keyfile_from_widget_list (pExtraKeyFile, pExtraWidgetList);
 			if (pModule->pInterface->save_custom_widget != NULL)
-				pModule->pInterface->save_custom_widget (pExtraInstance, pKeyFile, pExtraWidgetList);
+				pModule->pInterface->save_custom_widget (pExtraInstance, pExtraKeyFile, pExtraWidgetList);
 			cairo_dock_write_keys_to_conf_file (pExtraKeyFile, pExtraInstance->cConfFilePath);
 			g_key_file_free (pExtraKeyFile);
+		}
+	}
+	
+	cairo_dock_write_keys_to_conf_file (pKeyFile, g_cConfFile);
+	g_key_file_free (pKeyFile);
+	
+	for (m = pConfigGroupWidget->pManagers; m != NULL; m = m->next)
+	{
+		cManagerName = m->data;
+		pManager = gldi_manager_get (cManagerName);
+		gldi_object_reload (GLDI_OBJECT(pManager), TRUE);
+	
+		for (e = pManager->pExternalModules; e != NULL && w != NULL; e = e->next)
+		{
+			// get the extension
+			cModuleName = e->data;
+			pModule = gldi_module_get (cModuleName);
+			if (!pModule)
+				continue;
+			
+			pExtraInstance = pModule->pInstancesList->data;
+			if (pExtraInstance == NULL)
+				continue;
 			
 			// reload it
 			gldi_object_reload (GLDI_OBJECT(pExtraInstance), TRUE);
@@ -237,6 +260,9 @@ ConfigGroupWidget *cairo_dock_config_group_widget_new (GList *pGroups, GList *pM
 			
 			g_key_file_free (pExtraKeyFile);
 		}
+		
+		if (pManager->load_custom_widget)
+			pManager->load_custom_widget (pKeyFile, pConfigGroupWidget->widget.pWidgetList);
 	}
 	
 	pConfigGroupWidget->widget.pWidget = (pNoteBook ? pNoteBook : pWidget);

--- a/src/cairo-dock-widget-config.c
+++ b/src/cairo-dock-widget-config.c
@@ -177,6 +177,15 @@ static GKeyFile *_make_simple_conf_file (ConfigWidget *pConfigWidget)
 	
 	g_key_file_set_string (pSimpleKeyFile, "Behavior", "raise shortcut", myDocksParam.cRaiseDockShortcut);
 	
+	g_key_file_set_integer (pSimpleKeyFile, "Behavior", "num_screen", myDocksParam.iScreenReq);
+	
+	g_key_file_set_string (pSimpleKeyFile, "Behavior", "screen_description", myDocksParam.cScreenReqDesc ? myDocksParam.cScreenReqDesc : "");
+	
+	g_key_file_set_string (pSimpleKeyFile, "Behavior", "screen_name", myDocksParam.cScreenReqName ? myDocksParam.cScreenReqName : "");
+	
+	int geom[4] = {myDocksParam.screenReqGeom.x, myDocksParam.screenReqGeom.y, myDocksParam.screenReqGeom.width, myDocksParam.screenReqGeom.height};
+	g_key_file_set_integer_list (pSimpleKeyFile, "Behavior", "screen_geometry", geom, 4);
+	
 	int iTaskbarType;
 	if (! myTaskbarParam.bShowAppli)
 		iTaskbarType = 0;
@@ -385,6 +394,15 @@ static void _build_config_widget (ConfigWidget *pConfigWidget)
 	pConfigWidget->widget.pWidgetList = pWidgetList;
 	pConfigWidget->widget.pDataGarbage = pDataGarbage;
 	
+	//\_____________ complete the main dock screen selection widget.
+	GldiManager *pManager = gldi_manager_get ("Docks");
+	if (!pManager) cd_warning ("Cannot find docks manager!");
+	else
+	{
+		if (pManager->load_custom_widget)
+			pManager->load_custom_widget (pKeyFile, pWidgetList);
+	}
+	
 	//\_____________ complete with the animations widgets.
 	_make_double_anim_widget (pWidgetList, pKeyFile, "Behavior", "anim_hover");
 	_make_double_anim_widget (pWidgetList, pKeyFile, "Behavior", "anim_click");
@@ -433,6 +451,15 @@ static void _config_widget_apply (CDWidget *pCdWidget)
 	// update the keys with the widgets.
 	cairo_dock_update_keyfile_from_widget_list (pSimpleKeyFile, pConfigWidget->widget.pWidgetList);
 	
+	// We need to save the screen setting separately
+	GldiManager *pManager = gldi_manager_get ("Docks");
+	if (!pManager) cd_warning ("Cannot find docks manager!");
+	else
+	{
+		if (pManager->save_custom_widget)
+			pManager->save_custom_widget (pSimpleKeyFile, pConfigWidget->widget.pWidgetList);
+	}
+	
 	cairo_dock_write_keys_to_file (pSimpleKeyFile, cConfFilePath);
 	g_free (cConfFilePath);
 	
@@ -454,6 +481,24 @@ static void _config_widget_apply (CDWidget *pCdWidget)
 	gchar *cRaiseDockShortcut = g_key_file_get_string (pSimpleKeyFile, "Behavior", "raise shortcut", NULL);
 	g_key_file_set_string (pKeyFile, "Accessibility", "raise shortcut", cRaiseDockShortcut);
 	g_free (cRaiseDockShortcut);
+	
+	int iScreenReq = g_key_file_get_integer (pSimpleKeyFile, "Behavior", "num_screen", NULL);
+	g_key_file_set_integer (pKeyFile, "Position", "num_screen", iScreenReq);
+	
+	gchar *tmp = g_key_file_get_string (pSimpleKeyFile, "Behavior", "screen_description", NULL);
+	g_key_file_set_string (pKeyFile, "Position", "screen_description", tmp ? tmp : "");
+	g_free (tmp);
+	
+	tmp = g_key_file_get_string (pSimpleKeyFile, "Behavior", "screen_name", NULL);
+	g_key_file_set_string (pKeyFile, "Position", "screen_name", tmp ? tmp : "");
+	g_free (tmp);
+	
+	int default_geom[4] = {0, 0, 0, 0};
+	gsize len = 0;
+	int *geom = g_key_file_get_integer_list (pSimpleKeyFile, "Behavior", "screen_geometry", &len, NULL);
+	if (geom && len > 4) len = 4;
+	g_key_file_set_integer_list (pKeyFile, "Position", "screen_geometry", geom ? geom : default_geom, geom ? len : 4);
+	g_free (geom);
 	
 	int iShowOnClick = (g_key_file_get_integer (pSimpleKeyFile, "Behavior", "show_on_click", NULL) == 1);
 	g_key_file_set_integer (pKeyFile, "Accessibility", "show_on_click", iShowOnClick);
@@ -721,7 +766,6 @@ static void _config_widget_apply (CDWidget *pCdWidget)
 	cairo_dock_write_keys_to_conf_file (pKeyFile, g_cConfFile);
 	
 	//\_____________ reload modules that are concerned by these changes
-	GldiManager *pManager;
 	if (bUpdateColors)
 	{
 		cd_reload ("Style");

--- a/src/cairo-dock-widget-items.c
+++ b/src/cairo-dock-widget-items.c
@@ -226,16 +226,26 @@ static gboolean _on_select_one_item_in_tree (G_GNUC_UNUSED GtkTreeSelection * se
 				gldi_dock_add_conf_file_for_name (cDockName);
 			}
 			
-			pDataGarbage = g_ptr_array_new ();
-			pItemsWidget->pCurrentLauncherWidget = cairo_dock_build_conf_file_widget (cConfFilePath,
-				NULL,
-				GTK_WIDGET (pItemsWidget->pMainWindow),
-				&pWidgetList,
-				pDataGarbage,
-				NULL);
-			
-			pItemsWidget->pCurrentContainer = CAIRO_CONTAINER (pDock);
-			
+			GKeyFile* pKeyFile = cairo_dock_open_key_file (cConfFilePath);
+			if (pKeyFile == NULL) cd_warning ("Cannot open key file: %s", cConfFilePath);
+			else
+			{
+				pDataGarbage = g_ptr_array_new ();
+				pItemsWidget->pCurrentLauncherWidget = cairo_dock_build_key_file_widget (
+					pKeyFile, NULL, GTK_WIDGET (pItemsWidget->pMainWindow), &pWidgetList, pDataGarbage, NULL);
+				
+				pItemsWidget->pCurrentContainer = CAIRO_CONTAINER (pDock);
+				
+				// We need to add a custom widget for setting the screen
+				GldiManager *pManager = gldi_manager_get ("Docks");
+				if (!pManager) cd_warning ("Cannot find docks manager!");
+				else
+				{
+					if (pManager->load_custom_widget)
+						pManager->load_custom_widget (pKeyFile, pWidgetList);
+				}
+				g_key_file_free (pKeyFile);
+			}
 			g_free (cConfFilePath);
 		}
 		else  // main dock, we display a message
@@ -838,6 +848,15 @@ static void _items_widget_apply (CDWidget *pCdWidget)
 			
 			// update the keys with the widgets.
 			cairo_dock_update_keyfile_from_widget_list (pKeyFile, pWidgetList);
+			
+			// We need to save the screen setting separately
+			GldiManager *pManager = gldi_manager_get ("Docks");
+			if (!pManager) cd_warning ("Cannot find docks manager!");
+			else
+			{
+				if (pManager->save_custom_widget)
+					pManager->save_custom_widget (pKeyFile, pWidgetList);
+			}
 			
 			// write everything in the conf file.
 			cairo_dock_write_keys_to_conf_file (pKeyFile, cConfFilePath);

--- a/src/gldit/cairo-dock-desktop-manager.c
+++ b/src/gldit/cairo-dock-desktop-manager.c
@@ -562,6 +562,32 @@ GdkMonitor *const *gldi_desktop_get_monitors (int *iNumMonitors)
 	return s_pMonitors;
 }
 
+char *gldi_desktop_get_monitor_description (int i)
+{
+	if (i < 0 || i >= g_desktopGeometry.iNbScreens)
+		return NULL;
+	
+	const char *cManufacturer = gdk_monitor_get_manufacturer (s_pMonitors[i]);
+	const char *cModel = gdk_monitor_get_model (s_pMonitors[i]);
+	// We don't want "Unknown" -- see e.g. https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5045
+	if (cManufacturer && (!*cManufacturer || !strcmp (cManufacturer, "Unknown")))
+		cManufacturer = NULL;
+	if (cModel && (!*cModel || !strcmp (cModel, "Unknown")))
+		cModel = NULL;
+	
+	if (cModel && cManufacturer)
+		return g_strdup_printf ("%s - %s", cManufacturer, cModel);
+	if (cModel) return g_strdup (cModel);
+	if (cManufacturer) return g_strdup (cManufacturer);
+	return NULL;
+}
+
+const char *gldi_desktop_get_monitor_name (G_GNUC_UNUSED int i)
+{
+	return NULL; // not supported yet
+}
+
+
 
   ////////////
  /// INIT ///

--- a/src/gldit/cairo-dock-desktop-manager.c
+++ b/src/gldit/cairo-dock-desktop-manager.c
@@ -567,6 +567,12 @@ char *gldi_desktop_get_monitor_description (int i)
 	if (i < 0 || i >= g_desktopGeometry.iNbScreens)
 		return NULL;
 	
+	if (s_backend.get_monitor_description)
+	{
+		char *tmp = s_backend.get_monitor_description (s_pMonitors[i]);
+		if (tmp) return tmp; // if there is some useful info, return it, otherwise fall back to GdkMonitor
+	}
+	
 	const char *cManufacturer = gdk_monitor_get_manufacturer (s_pMonitors[i]);
 	const char *cModel = gdk_monitor_get_model (s_pMonitors[i]);
 	// We don't want "Unknown" -- see e.g. https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5045
@@ -584,6 +590,7 @@ char *gldi_desktop_get_monitor_description (int i)
 
 const char *gldi_desktop_get_monitor_name (G_GNUC_UNUSED int i)
 {
+	if (s_backend.get_monitor_name) return s_backend.get_monitor_name (s_pMonitors[i]);
 	return NULL; // not supported yet
 }
 

--- a/src/gldit/cairo-dock-desktop-manager.h
+++ b/src/gldit/cairo-dock-desktop-manager.h
@@ -288,6 +288,10 @@ void gldi_desktop_get_current (int *iCurrentDesktop, int *iCurrentViewportX, int
 
 /// Get the list of monitors currently managed -- caller should not modify the GdkMonitor* pointers stored here
 GdkMonitor *const *gldi_desktop_get_monitors (int *iNumMonitors);
+/// Get the description of the ith monitor or NULL if i is out of range. The caller should free the return value with g_free().
+char *gldi_desktop_get_monitor_description (int i);
+/// Get the (connector) name of the ith monitor or NULL if i is out of range. The return value belongs to the desktop manager and should not be freed.
+const char *gldi_desktop_get_monitor_name (int i);
 
   ////////////////////////
  // Desktop background //

--- a/src/gldit/cairo-dock-desktop-manager.h
+++ b/src/gldit/cairo-dock-desktop-manager.h
@@ -167,6 +167,8 @@ struct _GldiDesktopManagerBackend {
 	void (*grab_shortkey) (GldiShortkey *pBinding, gboolean grab, CairoDockGrabKeyResult cb); // note: cb will only be called if grab == TRUE
 	void (*add_workspace) (void); // gldi_desktop_add_workspace ()
 	void (*remove_last_workspace) (void); // gldi_desktop_remove_last_workspace ()
+	gchar* (*get_monitor_description) (GdkMonitor *pMonitor);
+	const gchar* (*get_monitor_name) (GdkMonitor *pMonitor);
 	};
 
 /// Definition of a Desktop Background Buffer. It has a reference count so that it can be shared across all the lib.

--- a/src/gldit/cairo-dock-dock-factory.h
+++ b/src/gldit/cairo-dock-dock-factory.h
@@ -146,8 +146,12 @@ struct _CairoDock {
 	gint iNumScreen;
 	/// number of the screen requested by the user
 	gint iScreenReq;
-	/// name of the screen requested by the user -- TODO: not used yet, should implement saving screen names !
-	gchar *cScreenReq;
+	/// description of the screen requested by the user (combination of gdk_monitor_get_manufacturer() - gdk_monitor_get_model ())
+	gchar *cScreenReqDesc;
+	/// name of the screen requested by the user (currently only on Wayland, the xdg_output.name() property)
+	gchar *cScreenReqName;
+	/// geometry of the screen requested by the user (from gdk_monitor_get_geometry ())
+	GdkRectangle screenReqGeom;
 	
 	// icons
 	/// icon size, as specified in the config of the dock

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -1504,7 +1504,6 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDocksParam *pDocksParam)
 		cairo_dock_get_integer_list_key_value (pKeyFile, "Position", "screen_geometry", &bFlushConfFileNeeded, geom, 4, NULL, NULL, NULL);
 		pPosition->screenReqGeom.x = geom[0]; pPosition->screenReqGeom.y = geom[1];
 		pPosition->screenReqGeom.width = geom[2]; pPosition->screenReqGeom.height = geom[3];
-		
 	}
 	else
 	{
@@ -1670,6 +1669,198 @@ static void reset_config (CairoDocksParam *pDocksParam)
 	// position
 	g_free (pPosition->cScreenReqDesc);
 	g_free (pPosition->cScreenReqName);
+}
+
+
+  //////////////////
+ /// CONFIG GUI ///
+//////////////////
+
+typedef enum {
+	CD_SCREEN_LABEL = 0,   // displayed name
+	CD_SCREEN_DESCRIPTION, // screen_description
+	CD_SCREEN_NAME,        // screen_name
+	CD_SCREEN_INDEX,       // num_screen
+	CD_SCREEN_GEOM,        // screen_geometry
+	CD_SCREEN_NB_COLUMNS
+	} CDScreenModelColumns;
+
+static void _load_custom_widget (G_GNUC_UNUSED GKeyFile *pKeyFile, GSList *pWidgetList)
+{
+	GtkListStore *pListStore = gtk_list_store_new (CD_SCREEN_NB_COLUMNS,
+		G_TYPE_STRING,   /* CD_SCREEN_LABEL*/
+		G_TYPE_STRING,   /* CD_SCREEN_DESCRIPTION*/
+		G_TYPE_STRING,   /* CD_SCREEN_NAME*/
+		G_TYPE_INT,      /* CD_SCREEN_INDEX*/
+		GDK_TYPE_RECTANGLE);  /* CD_SCREEN_GEOM*/
+	gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (pListStore), CD_SCREEN_INDEX, GTK_SORT_ASCENDING);
+	
+	/* default: empty label, keep the current screen */
+	GtkTreeIter iter;
+	memset (&iter, 0, sizeof (GtkTreeIter));
+	gtk_list_store_append (GTK_LIST_STORE (pListStore), &iter);
+	
+	gtk_list_store_set (GTK_LIST_STORE (pListStore), &iter,
+		CD_SCREEN_LABEL, "",
+		CD_SCREEN_INDEX, -1,
+		-1);
+	
+	int N = 0;
+	GdkMonitor *const *pMonitors = gldi_desktop_get_monitors (&N);
+	
+	GdkRectangle rect;
+	int xmax=0, ymax=0, i;
+	for (i = 0; i < N; i++)
+	{
+		gdk_monitor_get_geometry (pMonitors[i], &rect); // more accurate than cairo_dock_get_screen_position_x/_y
+		if (rect.x > xmax) xmax = rect.x;
+		if (rect.y > ymax) ymax = rect.y;
+	}
+	
+	const gchar *xpos;
+	const gchar *ypos;
+	GString *sLabel = g_string_new (NULL);
+	for (i = 0; i < N; i++)
+	{
+		GdkRectangle rect;
+		gdk_monitor_get_geometry (pMonitors[i], &rect);
+		
+		xpos = ypos = NULL;
+		
+		if (xmax > 0)  // at least 2 screens horizontally
+		{
+			if (rect.x == 0)
+				xpos = _("left");
+			else if (rect.x == xmax)
+				xpos = _("right");
+			else
+				xpos = _("middle");
+			
+		}
+		if (ymax > 0)  // at least 2 screens vertically
+		{
+			if (rect.y == 0)
+				ypos = _("top");
+			else if (rect.y == ymax)
+				ypos = _("bottom");
+			else
+				ypos = _("middle");
+			
+		}
+		
+		g_string_printf (sLabel, "%s %d", _("Screen"), i);
+		if (xpos || ypos)
+			g_string_append_printf (sLabel, " (%s%s%s)", xpos ? xpos : "", (xpos && ypos) ? " - " : "", ypos ? ypos : "");
+		
+		gchar *cDesc = gldi_desktop_get_monitor_description (i);
+		const gchar *cName = gldi_desktop_get_monitor_name (i);
+		
+		if (cDesc) g_string_append_printf (sLabel, ": %s", cDesc);
+		if (cName) g_string_append_printf (sLabel, " [%s]", cName);
+		
+		memset (&iter, 0, sizeof (GtkTreeIter));
+		gtk_list_store_append (GTK_LIST_STORE (pListStore), &iter);
+		
+		gtk_list_store_set (GTK_LIST_STORE (pListStore), &iter,
+			CD_SCREEN_LABEL, sLabel->str,
+			CD_SCREEN_DESCRIPTION, cDesc,
+			CD_SCREEN_NAME, cName,
+			CD_SCREEN_INDEX, i,
+			CD_SCREEN_GEOM, &rect,
+			-1);
+		
+		g_free (cDesc);
+	}
+	
+	g_string_free (sLabel, TRUE);
+	
+	GtkWidget *pOneWidget = gtk_combo_box_new_with_model (GTK_TREE_MODEL (pListStore));
+	GtkCellRenderer *rend = gtk_cell_renderer_text_new ();
+	gtk_cell_layout_pack_start (GTK_CELL_LAYOUT (pOneWidget), rend, FALSE);
+	gtk_cell_layout_set_attributes (GTK_CELL_LAYOUT (pOneWidget), rend, "text", CD_SCREEN_LABEL, NULL);
+	g_object_unref (G_OBJECT (pListStore)); // the others all have floating references
+	
+	// gtk_combo_box_set_active_iter (GTK_COMBO_BOX (pOneWidget), &iter);
+	CairoDockGroupKeyWidget *pGroupKeyWidget = cairo_dock_gui_find_group_key_widget_in_list (pWidgetList, "Behavior", "num_screen");
+	if (!pGroupKeyWidget)
+	{
+		pGroupKeyWidget = cairo_dock_gui_find_group_key_widget_in_list (pWidgetList, "Position", "num_screen");
+		if (!pGroupKeyWidget)
+		{
+			cd_warning ("Cannot find widget for dock position");
+			g_object_unref (G_OBJECT(pOneWidget));
+			return;
+		}
+	}
+	
+	gtk_box_pack_end (GTK_BOX (pGroupKeyWidget->pKeyBox), pOneWidget, FALSE, FALSE, 0);
+}
+
+static void _save_custom_widget (GKeyFile *pKeyFile, GSList *pWidgetList)
+{
+	const gchar *cGroup = "Position"; // only in the main config file
+	if (!g_key_file_has_group (pKeyFile, cGroup))
+	{
+		cGroup = "Behavior";
+		if (!g_key_file_has_group (pKeyFile, cGroup))
+		{
+			cd_warning ("Config file group does not exist!");
+			return;
+		}
+	}
+	
+	CairoDockGroupKeyWidget *pGroupKeyWidget = cairo_dock_gui_find_group_key_widget_in_list (pWidgetList, cGroup, "num_screen");
+	if (!pGroupKeyWidget)
+	{
+		cd_warning ("Widget not found!");
+		return;
+	}
+	
+	GList *l = gtk_container_get_children (GTK_CONTAINER (pGroupKeyWidget->pKeyBox));
+	GList *l2 = l ? g_list_last (l) : NULL;
+	GtkWidget *pCombo = (l2 && l2->data) ? (GtkWidget*)l2->data : NULL;
+	if (l) g_list_free (l);
+	if (!GTK_IS_COMBO_BOX (pCombo))
+	{
+		cd_warning ("Widget not found!");
+		return;
+	}
+	
+	GtkTreeIter iter;
+	if (!gtk_combo_box_get_active_iter (GTK_COMBO_BOX (pCombo), &iter))
+	{
+		cd_message ("No item selected!"); // not warning, since this is valid if there is no current selection
+		return;
+	}
+	
+	GtkTreeModel *pModel = gtk_combo_box_get_model (GTK_COMBO_BOX (pCombo));
+	gchar *cDesc;
+	gchar *cName;
+	int ix;
+	GdkRectangle *rect = NULL;
+	gtk_tree_model_get (pModel, &iter,
+		CD_SCREEN_DESCRIPTION, &cDesc,
+		CD_SCREEN_NAME, &cName,
+		CD_SCREEN_INDEX, &ix,
+		CD_SCREEN_GEOM, &rect,
+		-1);
+	
+	if (ix >= 0) // don't save results if the "empty" item is selected
+	{
+		g_key_file_set_integer (pKeyFile, cGroup, "num_screen", ix);
+		g_key_file_set_string (pKeyFile, cGroup, "screen_description", cDesc ? cDesc : "");
+		g_key_file_set_string (pKeyFile, cGroup, "screen_name", cName ? cName : "");
+		if (rect)
+		{
+			int geom[4] = {rect->x, rect->y, rect->width, rect->height};
+			g_key_file_set_integer_list (pKeyFile, cGroup, "screen_geometry", geom, 4);
+		}
+		else g_key_file_set_string (pKeyFile, cGroup, "screen_geometry", ""); // set it to empty
+	}
+	
+	g_free (cDesc);
+	g_free (cName);
+	g_free (rect);
 }
 
 
@@ -2249,6 +2440,8 @@ void gldi_register_docks_manager (void)
 	myDocksMgr.reload        = (GldiManagerReloadFunc)reload;
 	myDocksMgr.get_config    = (GldiManagerGetConfigFunc)get_config;
 	myDocksMgr.reset_config  = (GldiManagerResetConfigFunc)reset_config;
+	myDocksMgr.load_custom_widget = _load_custom_widget;
+	myDocksMgr.save_custom_widget = _save_custom_widget;
 	// Config
 	memset (&myDocksParam, 0, sizeof (CairoDocksParam));
 	myDocksMgr.pConfig = (GldiManagerConfigPtr)&myDocksParam;

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -567,49 +567,60 @@ GldiIconSizeEnum cairo_dock_convert_icon_size_to_enum (int iIconSize)
 	return s;
 }
 
-static void _update_dock_screen_num (CairoDock *pDock)
+static int _find_matching_monitor (const char *cScreenReqDesc, const GdkRectangle *pScreenReqGeom, const char *cScreenReqName, gboolean bFuzzy)
 {
-	int i, numMonitors = 0;
+	int i, j, numMonitors = 0;
 	GdkMonitor *const *pMonitors = gldi_desktop_get_monitors (&numMonitors);
-	if (! numMonitors)
-	{
-		pDock->iNumScreen = 0;
-		return;
-	}
+	if (! numMonitors) return -1;
+	
+	int *pMatches = NULL;
+	int nMatched = 0;
 	
 	// first, try to match the description
-	if (pDock->cScreenReqDesc && *pDock->cScreenReqDesc)
+	if (cScreenReqDesc && *cScreenReqDesc)
 	{
+		pMatches = g_new (int, numMonitors);
 		for (i = 0; i < numMonitors; i++)
 		{
 			char *cDesc = gldi_desktop_get_monitor_description (i);
 			if (cDesc)
 			{
-				gboolean bMatched = !(strcmp (pDock->cScreenReqDesc, cDesc));
+				gboolean bMatched = !strcmp (cScreenReqDesc, cDesc);
 				g_free (cDesc);
 				if (bMatched)
 				{
-					pDock->iNumScreen = i;
-					return;
+					pMatches[nMatched] = i;
+					nMatched++;
 				}
 			}
 		}
 	}
 	
+	if (nMatched == 1)
+	{
+		// unique match, return it
+		i = pMatches[0];
+		g_free (pMatches);
+		return i;
+	}
+	
 	// next, the geometry (name can be a connector name that is unreliable)
-	if (pDock->screenReqGeom.width > 0 && pDock->screenReqGeom.height > 0)
+	int n = nMatched ? nMatched : numMonitors;
+	if (pScreenReqGeom->width > 0 && pScreenReqGeom->height > 0)
 	{
 		int iBestMatch = numMonitors;
-		for (i = 0; i < numMonitors; i++)
+		for (j = 0; j < n; j++)
 		{
+			i = nMatched ? pMatches[j] : j;
 			GdkRectangle rect;
 			gdk_monitor_get_geometry (pMonitors[i], &rect);
-			if (rect.x == pDock->screenReqGeom.x && rect.y == pDock->screenReqGeom.y)
+			if (rect.x == pScreenReqGeom->x && rect.y == pScreenReqGeom->y)
 			{
-				if (rect.width == pDock->screenReqGeom.width && rect.height == pDock->screenReqGeom.height)
+				if (rect.width == pScreenReqGeom->width && rect.height == pScreenReqGeom->height)
 				{
-					pDock->iNumScreen = i;
-					return;
+					// exact match, we can just return it (assuming that there will be no two overlapping monitors
+					g_free (pMatches);
+					return i;
 				}
 				if (iBestMatch == numMonitors) iBestMatch = i;
 			}
@@ -617,27 +628,38 @@ static void _update_dock_screen_num (CairoDock *pDock)
 		
 		if (iBestMatch < numMonitors)
 		{
-			pDock->iNumScreen = iBestMatch;
-			return;
+			// fuzzy match
+			g_free (pMatches);
+			return bFuzzy ? iBestMatch : -1;
 		}
 	}
 	
+	if (!bFuzzy && !pMatches) return -1; // don't allow non-fuzzy match based only on the name field
+	
 	// next, the name
-	if (pDock->cScreenReqName && *pDock->cScreenReqName)
+	if (cScreenReqName && *cScreenReqName)
 	{
-		for (i = 0; i < numMonitors; i++)
+		for (j = 0; j < n; j++)
 		{
+			i = nMatched ? pMatches[j] : j;
 			const char *cName = gldi_desktop_get_monitor_name (i);
-			if (cName && !(strcmp (pDock->cScreenReqName, cName)))
+			if (cName && !strcmp (cScreenReqName, cName))
 			{
-				pDock->iNumScreen = i;
-				return;
+				g_free (pMatches);
+				return i;
 			}
 		}
 	}
 	
-	// finally the numeric request
-	pDock->iNumScreen = pDock->iScreenReq;
+	g_free (pMatches);
+	return -1;
+}
+
+static void _update_dock_screen_num (CairoDock *pDock)
+{
+	pDock->iNumScreen = _find_matching_monitor (pDock->cScreenReqDesc, &pDock->screenReqGeom, pDock->cScreenReqName, TRUE);
+	if (pDock->iNumScreen < 0) pDock->iNumScreen = pDock->iScreenReq; // finally the numeric request (old behavior)
+	
 	if (pDock->iNumScreen < 0 || pDock->iNumScreen >= g_desktopGeometry.iNbScreens)
 		pDock->iNumScreen = 0;
 }
@@ -1685,8 +1707,19 @@ typedef enum {
 	CD_SCREEN_NB_COLUMNS
 	} CDScreenModelColumns;
 
-static void _load_custom_widget (G_GNUC_UNUSED GKeyFile *pKeyFile, GSList *pWidgetList)
+static void _load_custom_widget (GKeyFile *pKeyFile, GSList *pWidgetList)
 {
+	const gchar *cGroup = "Position"; // only in the main config file
+	if (!g_key_file_has_group (pKeyFile, cGroup))
+	{
+		cGroup = "Behavior";
+		if (!g_key_file_has_group (pKeyFile, cGroup))
+		{
+			cd_warning ("Config file group does not exist!");
+			return;
+		}
+	}
+	
 	GtkListStore *pListStore = gtk_list_store_new (CD_SCREEN_NB_COLUMNS,
 		G_TYPE_STRING,   /* CD_SCREEN_LABEL*/
 		G_TYPE_STRING,   /* CD_SCREEN_DESCRIPTION*/
@@ -1695,15 +1728,44 @@ static void _load_custom_widget (G_GNUC_UNUSED GKeyFile *pKeyFile, GSList *pWidg
 		GDK_TYPE_RECTANGLE);  /* CD_SCREEN_GEOM*/
 	gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (pListStore), CD_SCREEN_INDEX, GTK_SORT_ASCENDING);
 	
-	/* default: empty label, keep the current screen */
-	GtkTreeIter iter;
-	memset (&iter, 0, sizeof (GtkTreeIter));
-	gtk_list_store_append (GTK_LIST_STORE (pListStore), &iter);
-	
-	gtk_list_store_set (GTK_LIST_STORE (pListStore), &iter,
-		CD_SCREEN_LABEL, "",
-		CD_SCREEN_INDEX, -1,
-		-1);
+	/* default: current screen in config */
+	int iCurrent = -1;
+	gboolean bDisconnected = FALSE;
+	{
+		char *cScreenReqDesc = g_key_file_get_string (pKeyFile, cGroup, "screen_description", NULL);
+		char *cScreenReqName = g_key_file_get_string (pKeyFile, cGroup, "screen_name", NULL);
+		int geom[] = {0, 0, 0, 0};
+		cairo_dock_get_integer_list_key_value (pKeyFile, cGroup, "screen_geometry", NULL, geom, 4, NULL, NULL, NULL);
+		GdkRectangle rect;
+		rect.x = geom[0]; rect.y = geom[1]; rect.width = geom[2]; rect.height = geom[3];
+		
+		iCurrent = _find_matching_monitor (cScreenReqDesc, &rect, cScreenReqName, FALSE);
+		
+		if (iCurrent == -1 && ((cScreenReqDesc && *cScreenReqDesc) ||
+			(cScreenReqName && *cScreenReqName) ||
+			(rect.width > 0 && rect.height > 0)))
+		{
+			bDisconnected = TRUE;
+			GtkTreeIter iter;
+			memset (&iter, 0, sizeof (GtkTreeIter));
+			gtk_list_store_append (GTK_LIST_STORE (pListStore), &iter);
+			
+			char *cLabel = g_strdup_printf ("(Disconnected): %s [%s]", cScreenReqDesc ? cScreenReqDesc : "",
+				cScreenReqName ? cScreenReqName : ""); //!! TODO: add position (at least if we don't have the other fields?)
+			
+			gtk_list_store_set (GTK_LIST_STORE (pListStore), &iter,
+				CD_SCREEN_LABEL, cLabel,
+				CD_SCREEN_DESCRIPTION, cScreenReqDesc,
+				CD_SCREEN_NAME, cScreenReqName,
+				CD_SCREEN_INDEX, -1,
+				CD_SCREEN_GEOM, &geom,
+				-1);
+			g_free (cLabel);
+		}
+		
+		g_free (cScreenReqDesc);
+		g_free (cScreenReqName);
+	}
 	
 	int N = 0;
 	GdkMonitor *const *pMonitors = gldi_desktop_get_monitors (&N);
@@ -1758,6 +1820,7 @@ static void _load_custom_widget (G_GNUC_UNUSED GKeyFile *pKeyFile, GSList *pWidg
 		if (cDesc) g_string_append_printf (sLabel, ": %s", cDesc);
 		if (cName) g_string_append_printf (sLabel, " [%s]", cName);
 		
+		GtkTreeIter iter;
 		memset (&iter, 0, sizeof (GtkTreeIter));
 		gtk_list_store_append (GTK_LIST_STORE (pListStore), &iter);
 		
@@ -1780,17 +1843,16 @@ static void _load_custom_widget (G_GNUC_UNUSED GKeyFile *pKeyFile, GSList *pWidg
 	gtk_cell_layout_set_attributes (GTK_CELL_LAYOUT (pOneWidget), rend, "text", CD_SCREEN_LABEL, NULL);
 	g_object_unref (G_OBJECT (pListStore)); // the others all have floating references
 	
-	// gtk_combo_box_set_active_iter (GTK_COMBO_BOX (pOneWidget), &iter);
-	CairoDockGroupKeyWidget *pGroupKeyWidget = cairo_dock_gui_find_group_key_widget_in_list (pWidgetList, "Behavior", "num_screen");
+	if (bDisconnected) gtk_combo_box_set_active (GTK_COMBO_BOX (pOneWidget), 0); // screen set, but not found (it was added first)
+	else if (iCurrent >= 0) gtk_combo_box_set_active (GTK_COMBO_BOX (pOneWidget), iCurrent); // screen set and found
+	// note: if there is no setting, the combo box will be blank, since we don't have access to which screen the dock is actually on
+	
+	CairoDockGroupKeyWidget *pGroupKeyWidget = cairo_dock_gui_find_group_key_widget_in_list (pWidgetList, cGroup, "num_screen");
 	if (!pGroupKeyWidget)
 	{
-		pGroupKeyWidget = cairo_dock_gui_find_group_key_widget_in_list (pWidgetList, "Position", "num_screen");
-		if (!pGroupKeyWidget)
-		{
-			cd_warning ("Cannot find widget for dock position");
-			g_object_unref (G_OBJECT(pOneWidget));
-			return;
-		}
+		cd_warning ("Cannot find widget for dock position");
+		g_object_unref (G_OBJECT(pOneWidget));
+		return;
 	}
 	
 	gtk_box_pack_end (GTK_BOX (pGroupKeyWidget->pKeyBox), pOneWidget, FALSE, FALSE, 0);
@@ -1845,7 +1907,7 @@ static void _save_custom_widget (GKeyFile *pKeyFile, GSList *pWidgetList)
 		CD_SCREEN_GEOM, &rect,
 		-1);
 	
-	if (ix >= 0) // don't save results if the "empty" item is selected
+	if (ix >= 0) // don't save results if the user did not change away from the currently disconnected monitor
 	{
 		g_key_file_set_integer (pKeyFile, cGroup, "num_screen", ix);
 		g_key_file_set_string (pKeyFile, cGroup, "screen_description", cDesc ? cDesc : "");

--- a/src/gldit/cairo-dock-dock-manager.c
+++ b/src/gldit/cairo-dock-dock-manager.c
@@ -135,6 +135,11 @@ static void _make_sub_dock (CairoDock *pDock, CairoDock *pParentDock, const gcha
 	pDock->container.bDirectionUp = pParentDock->container.bDirectionUp;
 	pDock->iNumScreen = pParentDock->iNumScreen;
 	pDock->iScreenReq = pParentDock->iScreenReq;
+	g_free (pDock->cScreenReqDesc);
+	g_free (pDock->cScreenReqName);
+	pDock->cScreenReqDesc = g_strdup (pParentDock->cScreenReqDesc);
+	pDock->cScreenReqName = g_strdup (pParentDock->cScreenReqName);
+	pDock->screenReqGeom = pParentDock->screenReqGeom;
 	
 	//\__________________ set a renderer
 	cairo_dock_set_renderer (pDock, cRendererName);
@@ -564,6 +569,74 @@ GldiIconSizeEnum cairo_dock_convert_icon_size_to_enum (int iIconSize)
 
 static void _update_dock_screen_num (CairoDock *pDock)
 {
+	int i, numMonitors = 0;
+	GdkMonitor *const *pMonitors = gldi_desktop_get_monitors (&numMonitors);
+	if (! numMonitors)
+	{
+		pDock->iNumScreen = 0;
+		return;
+	}
+	
+	// first, try to match the description
+	if (pDock->cScreenReqDesc && *pDock->cScreenReqDesc)
+	{
+		for (i = 0; i < numMonitors; i++)
+		{
+			char *cDesc = gldi_desktop_get_monitor_description (i);
+			if (cDesc)
+			{
+				gboolean bMatched = !(strcmp (pDock->cScreenReqDesc, cDesc));
+				g_free (cDesc);
+				if (bMatched)
+				{
+					pDock->iNumScreen = i;
+					return;
+				}
+			}
+		}
+	}
+	
+	// next, the geometry (name can be a connector name that is unreliable)
+	if (pDock->screenReqGeom.width > 0 && pDock->screenReqGeom.height > 0)
+	{
+		int iBestMatch = numMonitors;
+		for (i = 0; i < numMonitors; i++)
+		{
+			GdkRectangle rect;
+			gdk_monitor_get_geometry (pMonitors[i], &rect);
+			if (rect.x == pDock->screenReqGeom.x && rect.y == pDock->screenReqGeom.y)
+			{
+				if (rect.width == pDock->screenReqGeom.width && rect.height == pDock->screenReqGeom.height)
+				{
+					pDock->iNumScreen = i;
+					return;
+				}
+				if (iBestMatch == numMonitors) iBestMatch = i;
+			}
+		}
+		
+		if (iBestMatch < numMonitors)
+		{
+			pDock->iNumScreen = iBestMatch;
+			return;
+		}
+	}
+	
+	// next, the name
+	if (pDock->cScreenReqName && *pDock->cScreenReqName)
+	{
+		for (i = 0; i < numMonitors; i++)
+		{
+			const char *cName = gldi_desktop_get_monitor_name (i);
+			if (cName && !(strcmp (pDock->cScreenReqName, cName)))
+			{
+				pDock->iNumScreen = i;
+				return;
+			}
+		}
+	}
+	
+	// finally the numeric request
 	pDock->iNumScreen = pDock->iScreenReq;
 	if (pDock->iNumScreen < 0 || pDock->iNumScreen >= g_desktopGeometry.iNbScreens)
 		pDock->iNumScreen = 0;
@@ -583,6 +656,11 @@ static gboolean _get_root_dock_config (CairoDock *pDock)
 		pDock->fAlign = myDocksParam.fAlign;
 		
 		pDock->iScreenReq = myDocksParam.iScreenReq;
+		g_free (pDock->cScreenReqDesc);
+		g_free (pDock->cScreenReqName);
+		pDock->cScreenReqDesc = g_strdup (myDocksParam.cScreenReqDesc);
+		pDock->cScreenReqName = g_strdup (myDocksParam.cScreenReqName);
+		pDock->screenReqGeom = myDocksParam.screenReqGeom;
 		_update_dock_screen_num (pDock);
 		
 		_set_dock_orientation (pDock, myDocksParam.iScreenBorder);  // do it after all position parameters have been set; it sets the sub-docks orientation too.
@@ -629,6 +707,13 @@ static gboolean _get_root_dock_config (CairoDock *pDock)
 	pDock->fAlign = cairo_dock_get_double_key_value (pKeyFile, "Behavior", "alignment", &bFlushConfFileNeeded, 0.5, "Position", NULL);
 	
 	pDock->iScreenReq = cairo_dock_get_integer_key_value (pKeyFile, "Behavior", "num_screen", &bFlushConfFileNeeded, GLDI_DEFAULT_SCREEN, "Position", NULL);
+	g_free (pDock->cScreenReqDesc);
+	g_free (pDock->cScreenReqName);
+	pDock->cScreenReqDesc = cairo_dock_get_string_key_value (pKeyFile, "Behavior", "screen_description", &bFlushConfFileNeeded, NULL, "Position", NULL);
+	pDock->cScreenReqName = cairo_dock_get_string_key_value (pKeyFile, "Behavior", "screen_name", &bFlushConfFileNeeded, NULL, "Position", NULL);
+	int geom[] = {0, 0, 0, 0};
+	cairo_dock_get_integer_list_key_value (pKeyFile, "Behavior", "screen_geometry", &bFlushConfFileNeeded, geom, 4, NULL, "Position", NULL);
+	pDock->screenReqGeom.x = geom[0]; pDock->screenReqGeom.y = geom[1]; pDock->screenReqGeom.width = geom[2]; pDock->screenReqGeom.height = geom[3];
 	_update_dock_screen_num (pDock);
 	
 	CairoDockPositionType iScreenBorder = cairo_dock_get_integer_key_value (pKeyFile, "Behavior", "screen border", &bFlushConfFileNeeded, 0, "Position", NULL);
@@ -715,16 +800,28 @@ void gldi_dock_add_conf_file_for_name (const gchar *cDockName)
 	cairo_dock_add_conf_file (GLDI_SHARE_DATA_DIR"/"CAIRO_DOCK_MAIN_DOCK_CONF_FILE, cConfFilePath);
 	
 	// on placera le nouveau dock a l'oppose du main dock, meme ecran et meme visibilite.
-	cairo_dock_update_conf_file (cConfFilePath,
-		G_TYPE_INT, "Behavior", "screen border",
-		(g_pMainDock->container.bIsHorizontal ?
+	GKeyFile *pConfFile = cairo_dock_open_key_file (cConfFilePath);
+	if (! pConfFile)
+		cd_warning ("Cannot open new dock's config file: %s !", cConfFilePath);
+	else
+	{
+		g_key_file_set_integer (pConfFile, "Behavior", "screen border",
+			(g_pMainDock->container.bIsHorizontal ?
 			(g_pMainDock->container.bDirectionUp ? 1 : 0) :
-			(g_pMainDock->container.bDirectionUp ? 3 : 2)),
-		G_TYPE_INT, "Behavior", "visibility",
-		g_pMainDock->iVisibility,
-		G_TYPE_INT, "Behavior", "num_screen",
-		g_pMainDock->iScreenReq,
-		G_TYPE_INVALID);
+			(g_pMainDock->container.bDirectionUp ? 3 : 2)));
+		g_key_file_set_integer (pConfFile, "Behavior", "visibility", g_pMainDock->iVisibility);
+		g_key_file_set_integer (pConfFile, "Behavior", "num_screen", g_pMainDock->iScreenReq);
+		g_key_file_set_string (pConfFile, "Behavior", "screen_description",
+			g_pMainDock->cScreenReqDesc ? g_pMainDock->cScreenReqDesc : "");
+		g_key_file_set_string (pConfFile, "Behavior", "screen_name",
+			g_pMainDock->cScreenReqName ? g_pMainDock->cScreenReqName : "");
+		int geom[] = {g_pMainDock->screenReqGeom.x, g_pMainDock->screenReqGeom.y,
+			g_pMainDock->screenReqGeom.width, g_pMainDock->screenReqGeom.height};
+		g_key_file_set_integer_list (pConfFile, "Behavior", "screen_geometry", geom, 4);
+		
+		cairo_dock_write_keys_to_file (pConfFile, cConfFilePath);
+		g_key_file_free (pConfFile);
+	}
 	g_free (cConfFilePath);
 }
 
@@ -788,6 +885,11 @@ void gldi_subdock_synchronize_orientation (CairoDock *pSubDock, CairoDock *pDock
 		bUpdateDockSize = TRUE;
 	}
 	pSubDock->iScreenReq = pDock->iScreenReq;
+	g_free (pSubDock->cScreenReqDesc);
+	g_free (pSubDock->cScreenReqName);
+	pSubDock->cScreenReqDesc = g_strdup (pDock->cScreenReqDesc);
+	pSubDock->cScreenReqName = g_strdup (pDock->cScreenReqName);
+	pSubDock->screenReqGeom = pDock->screenReqGeom;
 	if (pSubDock->iNumScreen != pDock->iNumScreen)
 	{
 		pSubDock->iNumScreen = pDock->iNumScreen;
@@ -1393,7 +1495,17 @@ static gboolean get_config (GKeyFile *pKeyFile, CairoDocksParam *pDocksParam)
 	
 	pPosition->iScreenReq = GLDI_DEFAULT_SCREEN;
 	if (g_key_file_has_key (pKeyFile, "Position", "num_screen", NULL))  // "num_screen" is the new key
+	{
 		pPosition->iScreenReq = g_key_file_get_integer (pKeyFile, "Position", "num_screen", NULL);
+		
+		pPosition->cScreenReqDesc = g_key_file_get_string (pKeyFile, "Position", "screen_description", NULL);
+		pPosition->cScreenReqName = g_key_file_get_string (pKeyFile, "Position", "screen_name", NULL);
+		int geom[] = {0, 0, 0, 0};
+		cairo_dock_get_integer_list_key_value (pKeyFile, "Position", "screen_geometry", &bFlushConfFileNeeded, geom, 4, NULL, NULL, NULL);
+		pPosition->screenReqGeom.x = geom[0]; pPosition->screenReqGeom.y = geom[1];
+		pPosition->screenReqGeom.width = geom[2]; pPosition->screenReqGeom.height = geom[3];
+		
+	}
 	else
 	{
 		if (g_key_file_has_key (pKeyFile, "Position", "xinerama", NULL))  // "xinerama" and "num screen" old keys
@@ -1545,6 +1657,7 @@ static void reset_config (CairoDocksParam *pDocksParam)
 {
 	CairoDocksParam *pBackground = pDocksParam;
 	CairoDocksParam *pAccessibility = pDocksParam;
+	CairoDocksParam *pPosition = pDocksParam;
 	
 	// background
 	g_free (pBackground->cBackgroundImageFile);
@@ -1553,6 +1666,10 @@ static void reset_config (CairoDocksParam *pDocksParam)
 	g_free (pAccessibility->cRaiseDockShortcut);
 	g_free (pAccessibility->cHideEffect);
 	g_free (pAccessibility->cZoneImage);
+	
+	// position
+	g_free (pPosition->cScreenReqDesc);
+	g_free (pPosition->cScreenReqName);
 }
 
 
@@ -1637,9 +1754,34 @@ static void reload (CairoDocksParam *pPrevDocksParam, CairoDocksParam *pDocksPar
 	gldi_docks_foreach_root ((GFunc)_reload_bg, NULL);
 	
 	// position
+	gboolean bPosChange = FALSE;
 	if (pPosition->iScreenReq != pPrevPosition->iScreenReq)
 	{
 		pDock->iScreenReq = pPosition->iScreenReq;
+		bPosChange = TRUE;
+	}
+	if (g_strcmp0 (pPosition->cScreenReqDesc, pPrevPosition->cScreenReqDesc))
+	{
+		g_free (pDock->cScreenReqDesc);
+		pDock->cScreenReqDesc = g_strdup (pPosition->cScreenReqDesc);
+		bPosChange = TRUE;
+	}
+	if (g_strcmp0 (pPosition->cScreenReqName, pPrevPosition->cScreenReqName))
+	{
+		g_free (pDock->cScreenReqName);
+		pDock->cScreenReqName = g_strdup (pPosition->cScreenReqName);
+		bPosChange = TRUE;
+	}
+	if (pPosition->screenReqGeom.x != pPrevPosition->screenReqGeom.x || 
+		pPosition->screenReqGeom.y != pPrevPosition->screenReqGeom.y || 
+		pPosition->screenReqGeom.width != pPrevPosition->screenReqGeom.width || 
+		pPosition->screenReqGeom.height != pPrevPosition->screenReqGeom.height)
+	{
+		pDock->screenReqGeom = pPosition->screenReqGeom;
+		bPosChange = TRUE;
+	}
+	if (bPosChange)
+	{
 		_update_dock_screen_num (pDock);
 		gldi_container_set_screen (CAIRO_CONTAINER (pDock), pDock->iNumScreen);
 		_reposition_root_docks (TRUE);  // on replace tous les docks racines sauf le main dock, puisque c'est fait apres.
@@ -1656,7 +1798,7 @@ static void reload (CairoDocksParam *pPrevDocksParam, CairoDocksParam *pDocksPar
 	pDock->iGapY = pPosition->iGapY;
 	pDock->fAlign = pPosition->fAlign;
 	
-	if (pPosition->iScreenReq != pPrevPosition->iScreenReq
+	if (bPosChange
 	|| pPosition->iScreenBorder != pPrevPosition->iScreenBorder  // if the orientation or the screen has changed, the available size may have changed too
 	|| pPosition->iGapX != pPrevPosition->iGapX
 	|| pPosition->iGapY != pPrevPosition->iGapY)
@@ -1919,6 +2061,9 @@ static void init_object (GldiObject *obj, gpointer attr)
 		pDock->container.bIsHorizontal = pParentDock->container.bIsHorizontal;
 		pDock->container.bDirectionUp = pParentDock->container.bDirectionUp;
 		pDock->iScreenReq = pParentDock->iScreenReq;
+		pDock->cScreenReqDesc = g_strdup (pParentDock->cScreenReqDesc);
+		pDock->cScreenReqName = g_strdup (pParentDock->cScreenReqName);
+		pDock->screenReqGeom = pParentDock->screenReqGeom;
 		pDock->iNumScreen = pParentDock->iNumScreen;
 		pDock->iIconSize = pParentDock->iIconSize;
 		
@@ -2032,6 +2177,9 @@ static void reset_object (GldiObject *obj)
 	{
 		pDock->pRenderer->free_data (pDock);
 	}
+	
+	g_free (pDock->cScreenReqDesc);
+	g_free (pDock->cScreenReqName);
 	
 	g_free (pDock->cRendererName);
 	g_free (pDock->cBgImagePath);

--- a/src/gldit/cairo-dock-dock-manager.h
+++ b/src/gldit/cairo-dock-dock-manager.h
@@ -72,6 +72,9 @@ struct _CairoDocksParam {
 	CairoDockPositionType iScreenBorder;
 	gdouble fAlign;
 	gint iScreenReq;
+	gchar *cScreenReqDesc;
+	gchar *cScreenReqName;
+	GdkRectangle screenReqGeom;
 	// Root dock visibility
 	CairoDockVisibility iVisibility;
 	gchar *cHideEffect;

--- a/src/gldit/cairo-dock-manager.h
+++ b/src/gldit/cairo-dock-manager.h
@@ -51,8 +51,10 @@ typedef void (*GldiManagerInitFunc) (void);
 typedef void (*GldiManagerLoadFunc) (void);
 typedef void (*GldiManagerUnloadFunc) (void);
 typedef void (* GldiManagerReloadFunc) (GldiManagerConfigPtr pPrevConfig, GldiManagerConfigPtr pNewConfig);
-typedef gboolean (* GldiManagerGetConfigFunc) (GKeyFile *pKeyFile, GldiManagerConfigPtr pConfig);
-typedef void (* GldiManagerResetConfigFunc) (GldiManagerConfigPtr pConfig);
+typedef gboolean (*GldiManagerGetConfigFunc) (GKeyFile *pKeyFile, GldiManagerConfigPtr pConfig);
+typedef void (*GldiManagerResetConfigFunc) (GldiManagerConfigPtr pConfig);
+typedef void (*GldiManagerLoadCustomWidgetFunc) (GKeyFile *pKeyFile, GSList *pWidgetList);
+typedef void (*GldiManagerSaveCustomWidgetFunc) (GKeyFile *pKeyFile, GSList *pWidgetList);
 /// Definition of a Manager.
 struct _GldiManager {
 	/// object
@@ -74,6 +76,9 @@ struct _GldiManager {
 	GldiManagerGetConfigFunc get_config;
 	/// function called when resetting the current theme, or a part of it.
 	GldiManagerResetConfigFunc reset_config;
+	/** Functions used for defining custom widgets for configuring this manager. */
+	GldiManagerLoadCustomWidgetFunc load_custom_widget;
+	GldiManagerSaveCustomWidgetFunc save_custom_widget;
 	//\_____________ Instance.
 	GldiManagerConfigPtr pConfig;
 	GldiManagerDataPtr pData;

--- a/src/gldit/cairo-dock-module-manager.h
+++ b/src/gldit/cairo-dock-module-manager.h
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * It is not required the change this when adding a function to the
  * public API (loading the module will fail if it refers to an
  * unresolved symbol anyway). */
-#define GLDI_ABI_VERSION 20260715
+#define GLDI_ABI_VERSION 20260802
 
 // manager
 #ifndef _MANAGER_DEF_

--- a/src/implementations/CMakeLists.txt
+++ b/src/implementations/CMakeLists.txt
@@ -94,6 +94,10 @@ if(WaylandScanner_FOUND)
 		impl_SRCS
 		PROTOCOL "proto/xdg-shell.xml"
 		BASENAME "xdg-shell")
+	ecm_add_wayland_client_protocol(
+		impl_SRCS
+		PROTOCOL "proto/xdg-output-unstable-v1.xml"
+		BASENAME "xdg-output")
 endif()
 
 add_library(implementations STATIC ${impl_SRCS})

--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -51,6 +51,7 @@
 #include "cairo-dock-plasma-virtual-desktop.h"
 #include "cairo-dock-ext-workspaces.h"
 #include "cairo-dock-wayland-wm.h"
+#include "wayland-xdg-output-client-protocol.h"
 #endif
 #include "cairo-dock-wayland-hotspots.h"
 #include "cairo-dock-egl.h"
@@ -74,6 +75,8 @@ extern gboolean g_bUseOpenGL;
 static struct wl_display *s_pDisplay = NULL;
 static struct wl_compositor* s_pCompositor = NULL;
 static gboolean s_bHave_Layer_Shell = FALSE;
+
+static struct zxdg_output_manager_v1 *s_pXdgOutput = NULL;
 
 static GldiWaylandCompositorType s_CompositorType = WAYLAND_COMPOSITOR_NONE;
 
@@ -468,6 +471,102 @@ static void _adjust_aimed_point (const Icon *pIcon, G_GNUC_UNUSED GtkWidget *pWi
 
 
 ////////////////////////////////////////////////////////////////////////
+// Outputs
+typedef struct _XdgOutputInto {
+	char *cDescription;
+	char *cName;
+	struct zxdg_output_v1 *output;
+} XdgOutputInfo;
+
+static void _xdg_output_info_free (gpointer ptr)
+{
+	if (!ptr) return;
+	XdgOutputInfo *info = (XdgOutputInfo*)ptr;
+	if (info->output) zxdg_output_v1_destroy (info->output);
+	g_free (info->cDescription);
+	g_free (info->cName);
+	g_free (info);
+}
+
+static GHashTable *s_pOutputMap = NULL; // key: GdkMonitor, value: XdgOutputInfo
+
+static char *_get_output_description (GdkMonitor *mon)
+{
+	if (!s_pOutputMap) return NULL;
+	XdgOutputInfo *info = g_hash_table_lookup (s_pOutputMap, mon);
+	return info ? g_strdup (info->cDescription) : NULL; // strdup() handles NULL as well
+}
+
+static const char *_get_output_name (GdkMonitor *mon)
+{
+	if (!s_pOutputMap) return NULL;
+	XdgOutputInfo *info = g_hash_table_lookup (s_pOutputMap, mon);
+	return info ? info->cName : NULL;
+}
+
+static void _output_dummy (G_GNUC_UNUSED void *data,
+	G_GNUC_UNUSED struct zxdg_output_v1 *zxdg_output_v1, G_GNUC_UNUSED int32_t x, G_GNUC_UNUSED int32_t y)
+{
+	// no-op (works for both position and size events)
+}
+
+static void _output_done (void *data, struct zxdg_output_v1 *output)
+{
+	XdgOutputInfo *info = (XdgOutputInfo*)data;
+	info->output = NULL;
+	zxdg_output_v1_destroy (output); // no need to keep it, should not change
+}
+
+static void _output_description (void *data, G_GNUC_UNUSED struct zxdg_output_v1 *output, const char *description)
+{
+	XdgOutputInfo *info = (XdgOutputInfo*)data;
+	g_free (info->cDescription);
+	if (description && *description) info->cDescription = g_strdup (description);
+	else info->cDescription = NULL;
+}
+
+static void _output_name (void *data, G_GNUC_UNUSED struct zxdg_output_v1 *output, const char *name)
+{
+	XdgOutputInfo *info = (XdgOutputInfo*)data;
+	g_free (info->cName);
+	if (name && *name) info->cName = g_strdup (name);
+	else info->cName = NULL;
+}
+
+static struct zxdg_output_v1_listener s_output_listener = {
+	.logical_position = _output_dummy,
+	.logical_size = _output_dummy,
+	.done = _output_done,
+	.name = _output_name,
+	.description = _output_description
+};
+
+static void _add_monitor (G_GNUC_UNUSED GdkDisplay *dsp, GdkMonitor *mon, G_GNUC_UNUSED gpointer data)
+{
+	struct wl_output *wloutput = gdk_wayland_monitor_get_wl_output (mon);
+	g_return_if_fail (wloutput != NULL && s_pOutputMap != NULL);
+	
+	if (g_hash_table_lookup (s_pOutputMap, mon)) return; // already added
+	XdgOutputInfo *info = g_new0 (XdgOutputInfo, 1);
+	g_hash_table_insert (s_pOutputMap, mon, info);
+	info->output = zxdg_output_manager_v1_get_xdg_output (s_pXdgOutput, wloutput);
+	zxdg_output_v1_add_listener (info->output, &s_output_listener, info);
+}
+
+static void _remove_monitor (G_GNUC_UNUSED GdkDisplay *dsp, GdkMonitor *mon, G_GNUC_UNUSED gpointer data)
+{
+	g_return_if_fail (s_pOutputMap != NULL);
+	g_hash_table_remove (s_pOutputMap, mon);
+}
+
+static gboolean _check_output_done (G_GNUC_UNUSED gpointer key, gpointer value, G_GNUC_UNUSED gpointer data)
+{
+	XdgOutputInfo *info = (XdgOutputInfo*)value;
+	return !!(info->output); // if the xdg-output object has been freed, we have received the done event already
+}
+
+
+////////////////////////////////////////////////////////////////////////
 // Registry
 struct wl_registry *s_pRegistry = NULL;
 static GHashTable *s_pProtocolMap = NULL; // key: name (owned), value: GldiWaylandProtocolInfo (owned)
@@ -490,6 +589,13 @@ static void _registry_global_cb ( G_GNUC_UNUSED void *data, struct wl_registry *
 	g_hash_table_insert (s_pProtocolMap, key, info);
 	g_hash_table_insert (s_pProtocolMapRev, GUINT_TO_POINTER (id), key);
 	/// TODO: send out a notification?
+	
+	if (!strcmp (interface, zxdg_output_manager_v1_interface.name) && version >= 2)
+	{
+		// we need version == 2 which already includes name and description, but
+		// still sends out a done event separately
+		s_pXdgOutput = wl_registry_bind (registry, id, &zxdg_output_manager_v1_interface, 2);
+	}
 #else
 	(void)version; // avoid warning
 #endif
@@ -540,6 +646,36 @@ static void init (void)
 		wl_display_roundtrip (s_pDisplay);
 	}
 	while (s_bInitializing);
+	
+	// init monitor tracking
+#ifdef HAVE_WAYLAND_PROTOCOLS
+	if (s_pXdgOutput)
+	{
+		s_pOutputMap = g_hash_table_new_full (NULL, NULL, NULL, _xdg_output_info_free);
+		
+		GdkDisplay *dsp = gdk_display_get_default();
+		int i, N = gdk_display_get_n_monitors (dsp);
+		for (i = 0; i < N; i++) _add_monitor (NULL, gdk_display_get_monitor (dsp, i), NULL);
+		
+		g_signal_connect (G_OBJECT (dsp), "monitor-added", G_CALLBACK (_add_monitor), NULL);
+		g_signal_connect (G_OBJECT (dsp), "monitor-removed", G_CALLBACK (_remove_monitor), NULL);
+		
+		// do roundtrips while all info is received -- this is a bit crude, but we want this to
+		// be available before docks are created
+		while (1)
+		{
+			wl_display_roundtrip (s_pDisplay);
+			gpointer tmp = g_hash_table_find (s_pOutputMap, _check_output_done, NULL);
+			if (!tmp) break; // all are initialized
+		}
+		
+		GldiDesktopManagerBackend dmb;
+		memset (&dmb, 0, sizeof (GldiDesktopManagerBackend));
+		dmb.get_monitor_description = _get_output_description;
+		dmb.get_monitor_name = _get_output_name;
+		gldi_desktop_manager_register_backend (&dmb, "xdg-output");
+	}
+#endif
 	
 	GldiContainerManagerBackend cmb;
 	memset (&cmb, 0, sizeof (GldiContainerManagerBackend));	

--- a/src/implementations/proto/xdg-output-unstable-v1.xml
+++ b/src/implementations/proto/xdg-output-unstable-v1.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_output_unstable_v1">
+
+  <copyright>
+    Copyright © 2017 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol to describe output regions">
+    This protocol aims at describing outputs in a way which is more in line
+    with the concept of an output on desktop oriented systems.
+
+    Some information are more specific to the concept of an output for
+    a desktop oriented system and may not make sense in other applications,
+    such as IVI systems for example.
+
+    Typically, the global compositor space on a desktop system is made of
+    a contiguous or overlapping set of rectangular regions.
+
+    The logical_position and logical_size events defined in this protocol
+    might provide information identical to their counterparts already
+    available from wl_output, in which case the information provided by this
+    protocol should be preferred to their equivalent in wl_output. The goal is
+    to move the desktop specific concepts (such as output location within the
+    global compositor space, etc.) out of the core wl_output protocol.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible
+    changes may be added together with the corresponding interface
+    version bump.
+    Backward incompatible changes are done by bumping the version
+    number in the protocol and interface names and resetting the
+    interface version. Once the protocol is to be declared stable,
+    the 'z' prefix and the version number in the protocol and
+    interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zxdg_output_manager_v1" version="3">
+    <description summary="manage xdg_output objects">
+      A global factory interface for xdg_output objects.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_output_manager object">
+	Using this request a client can tell the server that it is not
+	going to use the xdg_output_manager object anymore.
+
+	Any objects already created through this instance are not affected.
+      </description>
+    </request>
+
+    <request name="get_xdg_output">
+      <description summary="create an xdg output from a wl_output">
+	This creates a new xdg_output object for the given wl_output.
+      </description>
+      <arg name="id" type="new_id" interface="zxdg_output_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+  </interface>
+
+  <interface name="zxdg_output_v1" version="3">
+    <description summary="compositor logical output region">
+      An xdg_output describes part of the compositor geometry.
+
+      This typically corresponds to a monitor that displays part of the
+      compositor space.
+
+      For objects version 3 onwards, after all xdg_output properties have been
+      sent (when the object is created and when properties are updated), a
+      wl_output.done event is sent. This allows changes to the output
+      properties to be seen as atomic, even if they happen via multiple events.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_output object">
+	Using this request a client can tell the server that it is not
+	going to use the xdg_output object anymore.
+      </description>
+    </request>
+
+    <event name="logical_position">
+      <description summary="position of the output within the global compositor space">
+	The position event describes the location of the wl_output within
+	the global compositor space.
+
+	The logical_position event is sent after creating an xdg_output
+	(see xdg_output_manager.get_xdg_output) and whenever the location
+	of the output changes within the global compositor space.
+      </description>
+      <arg name="x" type="int"
+	   summary="x position within the global compositor space"/>
+      <arg name="y" type="int"
+	   summary="y position within the global compositor space"/>
+    </event>
+
+    <event name="logical_size">
+      <description summary="size of the output in the global compositor space">
+	The logical_size event describes the size of the output in the
+	global compositor space.
+
+	Most regular Wayland clients should not pay attention to the
+	logical size and would rather rely on xdg_shell interfaces.
+
+	Some clients such as Xwayland, however, need this to configure
+	their surfaces in the global compositor space as the compositor
+	may apply a different scale from what is advertised by the output
+	scaling property (to achieve fractional scaling, for example).
+
+	For example, for a wl_output mode 3840×2160 and a scale factor 2:
+
+	- A compositor not scaling the monitor viewport in its compositing space
+	  will advertise a logical size of 3840×2160,
+
+	- A compositor scaling the monitor viewport with scale factor 2 will
+	  advertise a logical size of 1920×1080,
+
+	- A compositor scaling the monitor viewport using a fractional scale of
+	  1.5 will advertise a logical size of 2560×1440.
+
+	For example, for a wl_output mode 1920×1080 and a 90 degree rotation,
+	the compositor will advertise a logical size of 1080x1920.
+
+	The logical_size event is sent after creating an xdg_output
+	(see xdg_output_manager.get_xdg_output) and whenever the logical
+	size of the output changes, either as a result of a change in the
+	applied scale or because of a change in the corresponding output
+	mode(see wl_output.mode) or transform (see wl_output.transform).
+      </description>
+      <arg name="width" type="int"
+	   summary="width in global compositor space"/>
+      <arg name="height" type="int"
+	   summary="height in global compositor space"/>
+    </event>
+
+    <event name="done" deprecated-since="3">
+      <description summary="all information about the output have been sent">
+	This event is sent after all other properties of an xdg_output
+	have been sent.
+
+	This allows changes to the xdg_output properties to be seen as
+	atomic, even if they happen via multiple events.
+
+	For objects version 3 onwards, this event is deprecated. Compositors
+	are not required to send it anymore and must send wl_output.done
+	instead.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="name" since="2">
+      <description summary="name of this output">
+	Many compositors will assign names to their outputs, show them to the
+	user, allow them to be configured by name, etc. The client may wish to
+	know this name as well to offer the user similar behaviors.
+
+	The naming convention is compositor defined, but limited to
+	alphanumeric characters and dashes (-). Each name is unique among all
+	wl_output globals, but if a wl_output global is destroyed the same name
+	may be reused later. The names will also remain consistent across
+	sessions with the same hardware and software configuration.
+
+	Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+	not assume that the name is a reflection of an underlying DRM
+	connector, X11 connection, etc.
+
+	The name event is sent after creating an xdg_output (see
+	xdg_output_manager.get_xdg_output). This event is only sent once per
+	xdg_output, and the name does not change over the lifetime of the
+	wl_output global.
+
+        This event is deprecated, instead clients should use wl_output.name.
+        Compositors must still support this event.
+      </description>
+      <arg name="name" type="string" summary="output name"/>
+    </event>
+
+    <event name="description" since="2">
+      <description summary="human-readable description of this output">
+	Many compositors can produce human-readable descriptions of their
+	outputs.  The client may wish to know this description as well, to
+	communicate the user for various purposes.
+
+	The description is a UTF-8 string with no convention defined for its
+	contents. Examples might include 'Foocorp 11" Display' or 'Virtual X11
+	output via :1'.
+
+	The description event is sent after creating an xdg_output (see
+	xdg_output_manager.get_xdg_output) and whenever the description
+	changes. The description is optional, and may not be sent at all.
+
+	For objects of version 2 and lower, this event is only sent once per
+	xdg_output, and the description does not change over the lifetime of
+	the wl_output global.
+
+	This event is deprecated, instead clients should use
+	wl_output.description. Compositors must still support this event.
+      </description>
+      <arg name="description" type="string" summary="output description"/>
+    </event>
+
+  </interface>
+</protocol>


### PR DESCRIPTION
Fixes #255 and #245 under most situations.

Try to present more information about monitors to the user in the screen selection GUI and more reliably match it to the connected monitors. This is surprisingly tricky, as the same physical display shows up under different names on different DEs; specifically with KDE Plasma, names differ between X11 and Wayland. So beyond "names", we also try to identify screens by their location; this of course will be off if the layout changes.

TODO:
 - [x] Always show the current configuration (so it can be kept even if the monitor in it is not connected, e.g. a preference for an external monitor)
 - [ ] Review under what circumstances should the dock reposition itself when monitors or the settings change; typically, it should only happen if there is a good quality match
 - [x] Handle the case when multiple monitors have the same name / description

